### PR TITLE
fix(justfile): build the UI before go build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ tmp/
 .claude/
 .playwright-mcp/
 .worktrees/
+
+# Brainstorming companion
+.superpowers/

--- a/justfile
+++ b/justfile
@@ -2,6 +2,9 @@
 
 # Build the binary
 build:
+    #!/usr/bin/env bash
+    test -d ui/node_modules || npm install --prefix ui
+    test -d ui/dist || npm run build --prefix ui
     exec go build -o houston .
 
 # Build and run the server


### PR DESCRIPTION
`just build` failed on a fresh checkout with `embed.go:5:12: pattern ui/dist: no matching files found` — the recipe went straight to `go build` while `ui/dist` is gitignored and only produced by the Vite build.

Adds the same guard `dev`, `run-dev`, and `dev-local` already use, and gitignores `.superpowers/`.

Verified from a clean worktree with no `ui/node_modules` and no `ui/dist`: `just build` installs deps, builds the UI, then builds the binary.

https://claude.ai/code/session_012NV8HxUyhB1h29q8f7bcia