### PR TITLE
fix(tmux): survive dropped chunks, tmux pauses and connection loss

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ tmp/
 .claude/
 .playwright-mcp/
 .worktrees/
+
+# Brainstorming companion
+.superpowers/

--- a/docs/superpowers/plans/2026-09-07-control-mode-transport-correctness.md
+++ b/docs/superpowers/plans/2026-09-07-control-mode-transport-correctness.md
@@ -1,0 +1,1083 @@
+# Control-mode transport correctness — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make houston's tmux control-mode feed survive dropped chunks, tmux-initiated pauses, and connection loss without silently rendering a corrupted terminal.
+
+**Architecture:** A pane subscription becomes a typed stream of `PaneEvent`s rather than raw `[]byte`. Any gap in that stream — a drop caused by a slow consumer, a `%pause` from tmux, or a reconnect — is signalled in-band as a `Dirty` event, so a consumer re-seeds from `capture-pane` at exactly the right point in the sequence rather than applying bytes on top of a corrupted screen. Reconnection moves inside `ControlClient`, so existing subscriptions survive a re-dial instead of every socket dying with the transport.
+
+**Tech Stack:** Go 1.x stdlib, `tmux -CC` control mode, `github.com/gorilla/websocket`. No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-09-07-houston-overhaul-design.md` — section "Control-mode transport".
+
+## Global Constraints
+
+- **Houston never resizes a pane.** `refresh-client -f ignore-size` at
+  `tmux/control_client.go:81` stays. A human is attached to that pane in kitty.
+- **`Done()` means closed, not disconnected.** After Task 4, `Done()` fires only
+  on explicit `Close()`. A transport drop must leave consumers attached.
+- **Single producer.** `dispatch` and all dirty-marking run on the `readLoop`
+  goroutine while holding `cc.mu`. Do not introduce a second producer.
+- **Go tests run with:** `go test ./tmux/... -v` from the repo root.
+- **No new dependencies.** The repo has exactly one non-stdlib dep
+  (`gorilla/websocket`); keep it that way.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `tmux/control_client.go` | The `-CC` connection: dial, read, demux, send, reconnect | Modify |
+| `tmux/control_client_test.go` | Unit tests for demux, dirty-marking, reconnect | **Create** |
+| `tmux/control_manager.go` | Ref-counted clients per session | Modify (small) |
+| `server/pane_ws.go` | WebSocket bridge; owns the seed handshake | Modify |
+| `tmux/control_test.go` | Existing `ParseControlLine` table test | Untouched |
+
+`control_client_test.go` is new because `control_test.go` covers the pure parser and should stay that way — parser tests need no fixtures or goroutines, and these do.
+
+---
+
+### Task 1: Typed pane subscriptions
+
+Replaces `chan []byte` with a handle carrying a typed channel. No behaviour
+change yet — this is the shape the next three tasks need. It also removes the
+pointer-comparison-by-`fmt.Sprintf("%p")` hack in `Unsubscribe`.
+
+**Files:**
+- Modify: `tmux/control_client.go:25-26` (struct field), `:145-180` (dispatch/Subscribe/Unsubscribe)
+- Modify: `server/pane_ws.go:105` (subscribe), `:118` (unsubscribe), `:169-196` (write loop)
+- Test: `tmux/control_client_test.go` (create)
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces:
+  - `type PaneEvent struct { Data []byte; Dirty bool }`
+  - `type PaneSub struct { ... }` with `func (s *PaneSub) C() <-chan PaneEvent`
+  - `func (cc *ControlClient) Subscribe(paneID string) *PaneSub`
+  - `func (cc *ControlClient) Unsubscribe(paneID string, s *PaneSub)`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tmux/control_client_test.go`:
+
+```go
+package tmux
+
+import "testing"
+
+func TestSubscribeDeliversOutput(t *testing.T) {
+	cc := NewControlClient("test")
+	sub := cc.Subscribe("%1")
+
+	cc.dispatch("%1", []byte("hello"))
+
+	select {
+	case ev := <-sub.C():
+		if ev.Dirty {
+			t.Fatalf("got dirty event, want data")
+		}
+		if string(ev.Data) != "hello" {
+			t.Fatalf("got %q, want %q", ev.Data, "hello")
+		}
+	default:
+		t.Fatal("no event delivered")
+	}
+}
+
+func TestUnsubscribeStopsDelivery(t *testing.T) {
+	cc := NewControlClient("test")
+	sub := cc.Subscribe("%1")
+	cc.Unsubscribe("%1", sub)
+
+	cc.dispatch("%1", []byte("hello"))
+
+	select {
+	case ev := <-sub.C():
+		t.Fatalf("got event %+v after unsubscribe", ev)
+	default:
+	}
+}
+
+func TestUnsubscribeRemovesOnlyThatSubscriber(t *testing.T) {
+	cc := NewControlClient("test")
+	a := cc.Subscribe("%1")
+	b := cc.Subscribe("%1")
+	cc.Unsubscribe("%1", a)
+
+	cc.dispatch("%1", []byte("hello"))
+
+	if len(a.C()) != 0 {
+		t.Fatal("unsubscribed handle still received output")
+	}
+	if len(b.C()) != 1 {
+		t.Fatalf("remaining subscriber got %d events, want 1", len(b.C()))
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./tmux/ -run TestSubscribe -v`
+Expected: FAIL to compile — `sub.C undefined (type <-chan []byte has no field or method C)`.
+
+- [ ] **Step 3: Write the implementation**
+
+In `tmux/control_client.go`, replace the `subs` field declaration (currently
+line 26) and the `dispatch`/`Subscribe`/`Unsubscribe` block (currently lines
+145-180):
+
+```go
+// PaneEvent is one item in a pane subscription. A Dirty event marks a gap in
+// the stream: everything buffered before it was discarded, and the subscriber
+// must re-seed from capture-pane before applying any later Data. Data and
+// Dirty are never both set.
+type PaneEvent struct {
+	Data  []byte
+	Dirty bool
+}
+
+// PaneSub is one subscriber's handle on a pane's output.
+type PaneSub struct {
+	ch    chan PaneEvent
+	dirty bool // guarded by ControlClient.mu
+}
+
+// C returns the event stream. Read it until the subscription is released.
+func (s *PaneSub) C() <-chan PaneEvent { return s.ch }
+```
+
+Change the struct field:
+
+```go
+	mu   sync.RWMutex
+	subs map[string][]*PaneSub // paneID → subscribers
+```
+
+Replace `dispatch`, `Subscribe` and `Unsubscribe`:
+
+```go
+func (cc *ControlClient) dispatch(paneID string, data []byte) {
+	cc.mu.Lock()
+	defer cc.mu.Unlock()
+	for _, s := range cc.subs[paneID] {
+		select {
+		case s.ch <- PaneEvent{Data: data}:
+		default:
+		}
+	}
+}
+
+// Subscribe returns a handle receiving output for the given pane.
+func (cc *ControlClient) Subscribe(paneID string) *PaneSub {
+	s := &PaneSub{ch: make(chan PaneEvent, 4096)}
+	cc.mu.Lock()
+	cc.subs[paneID] = append(cc.subs[paneID], s)
+	cc.mu.Unlock()
+	return s
+}
+
+// Unsubscribe releases a subscription handle.
+func (cc *ControlClient) Unsubscribe(paneID string, s *PaneSub) {
+	cc.mu.Lock()
+	defer cc.mu.Unlock()
+	subs := cc.subs[paneID]
+	for i, existing := range subs {
+		if existing == s {
+			cc.subs[paneID] = append(subs[:i], subs[i+1:]...)
+			break
+		}
+	}
+	if len(cc.subs[paneID]) == 0 {
+		delete(cc.subs, paneID)
+	}
+}
+```
+
+Note `dispatch` now takes the write lock rather than `RLock`, because Task 2
+mutates `s.dirty` inside it. Update `NewControlClient` (line 45):
+
+```go
+		subs:    make(map[string][]*PaneSub),
+```
+
+- [ ] **Step 4: Update the caller in `server/pane_ws.go`**
+
+At line 105, change:
+
+```go
+	sub := cc.Subscribe(paneID)
+```
+
+In the `defer` block at line 118, change `cc.Unsubscribe(paneID, outputCh)` to:
+
+```go
+		cc.Unsubscribe(paneID, sub)
+```
+
+At line 166, change the call to pass the handle:
+
+```go
+	s.paneWSWriteLoop(conn, cc, pane, sub)
+```
+
+Change the write loop signature (line 169) and its output case (lines 182-196):
+
+```go
+func (s *Server) paneWSWriteLoop(conn *websocket.Conn, cc *tmux.ControlClient, pane tmux.Pane, sub *tmux.PaneSub) {
+```
+
+```go
+		case ev := <-sub.C():
+			// Coalesce: drain all buffered chunks into one write
+			// to keep the channel drained and reduce WS round-trips.
+			buf := append([]byte(nil), ev.Data...)
+			for {
+				select {
+				case more := <-sub.C():
+					buf = append(buf, more.Data...)
+				default:
+					goto send
+				}
+			}
+		send:
+			outputJSON, _ := json.Marshal(WSOutput{Data: string(buf)})
+			msg, _ := json.Marshal(WSMessage{Type: "output", Data: outputJSON})
+			if err := conn.WriteMessage(websocket.TextMessage, msg); err != nil {
+				return
+			}
+```
+
+Dirty events are ignored for now — Task 5 handles them. Coalescing a `Dirty`
+event's empty `Data` is harmless.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `go test ./tmux/... ./server/... -v`
+Expected: PASS, including the pre-existing `TestParseControlLine`.
+
+- [ ] **Step 6: Verify it builds end to end**
+
+Run: `go build ./...`
+Expected: no output.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tmux/control_client.go tmux/control_client_test.go server/pane_ws.go
+git commit -m "refactor(tmux): typed pane subscriptions via PaneSub handle"
+```
+
+---
+
+### Task 2: A dropped chunk marks the stream dirty
+
+A full subscriber channel currently drops silently. A drop can cut an escape
+sequence in half, which corrupts every glyph rendered afterwards, and the pane
+stays wrong until the socket is reopened. The subscriber most likely to be slow
+is a phone on bad LTE — houston's whole premise.
+
+**Files:**
+- Modify: `tmux/control_client.go` (`dispatch`, plus new `markDirtyLocked`, `AckReseed`)
+- Test: `tmux/control_client_test.go`
+
+**Interfaces:**
+- Consumes: `PaneEvent`, `PaneSub` from Task 1.
+- Produces: `func (cc *ControlClient) AckReseed(s *PaneSub)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tmux/control_client_test.go`:
+
+```go
+// fillSub saturates a subscriber's buffer so the next dispatch must drop.
+func fillSub(cc *ControlClient, paneID string, s *PaneSub) {
+	for i := 0; i < cap(s.ch); i++ {
+		cc.dispatch(paneID, []byte("x"))
+	}
+}
+
+func TestDropMarksDirtyAndDiscardsStaleBuffer(t *testing.T) {
+	cc := NewControlClient("test")
+	sub := cc.Subscribe("%1")
+
+	fillSub(cc, "%1", sub)
+	cc.dispatch("%1", []byte("this one cannot fit"))
+
+	ev := <-sub.C()
+	if !ev.Dirty {
+		t.Fatalf("first event after a drop = %+v, want Dirty", ev)
+	}
+	if len(sub.C()) != 0 {
+		t.Fatalf("%d stale events survived the drop, want 0", len(sub.C()))
+	}
+}
+
+func TestDirtySuppressesDeliveryUntilAcked(t *testing.T) {
+	cc := NewControlClient("test")
+	sub := cc.Subscribe("%1")
+
+	fillSub(cc, "%1", sub)
+	cc.dispatch("%1", []byte("overflow"))
+	<-sub.C() // consume the Dirty marker
+
+	cc.dispatch("%1", []byte("still suppressed"))
+	if len(sub.C()) != 0 {
+		t.Fatal("delivered output while dirty; subscriber has not re-seeded yet")
+	}
+
+	cc.AckReseed(sub)
+	cc.dispatch("%1", []byte("after reseed"))
+
+	ev := <-sub.C()
+	if string(ev.Data) != "after reseed" {
+		t.Fatalf("got %q, want %q", ev.Data, "after reseed")
+	}
+}
+
+func TestDropOnOneSubscriberDoesNotAffectAnother(t *testing.T) {
+	cc := NewControlClient("test")
+	slow := cc.Subscribe("%1")
+	fast := cc.Subscribe("%1")
+
+	fillSub(cc, "%1", slow) // also fills fast; drain fast so it has room
+	for len(fast.C()) > 0 {
+		<-fast.C()
+	}
+
+	cc.dispatch("%1", []byte("live"))
+
+	if ev := <-slow.C(); !ev.Dirty {
+		t.Fatalf("slow subscriber = %+v, want Dirty", ev)
+	}
+	if ev := <-fast.C(); ev.Dirty {
+		t.Fatal("fast subscriber was marked dirty by its neighbour's drop")
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./tmux/ -run 'TestDrop|TestDirty' -v`
+Expected: FAIL — `cc.AckReseed undefined`, and once that compiles,
+`first event after a drop = {Data:[120] Dirty:false}, want Dirty`.
+
+- [ ] **Step 3: Write the implementation**
+
+In `tmux/control_client.go`, replace `dispatch` and add the two helpers below it:
+
+```go
+func (cc *ControlClient) dispatch(paneID string, data []byte) {
+	cc.mu.Lock()
+	defer cc.mu.Unlock()
+	for _, s := range cc.subs[paneID] {
+		// A dirty subscriber has a hole in its stream; nothing may be
+		// delivered until it re-seeds and acks.
+		if s.dirty {
+			continue
+		}
+		select {
+		case s.ch <- PaneEvent{Data: data}:
+		default:
+			// A drop can cut an escape sequence, so everything already
+			// buffered is unusable too. Discard it and signal a re-seed.
+			cc.markDirtyLocked(s)
+		}
+	}
+}
+
+// markDirtyLocked discards a subscriber's buffered output and leaves a single
+// Dirty event in its place. Caller must hold cc.mu.
+func (cc *ControlClient) markDirtyLocked(s *PaneSub) {
+	if s.dirty {
+		return
+	}
+	for {
+		select {
+		case <-s.ch:
+		default:
+			// Drained, and we are the only producer while holding cc.mu,
+			// so this send cannot block.
+			s.ch <- PaneEvent{Dirty: true}
+			s.dirty = true
+			return
+		}
+	}
+}
+
+// AckReseed resumes delivery after the subscriber has re-seeded from
+// capture-pane in response to a Dirty event.
+func (cc *ControlClient) AckReseed(s *PaneSub) {
+	cc.mu.Lock()
+	defer cc.mu.Unlock()
+	s.dirty = false
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `go test ./tmux/... -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tmux/control_client.go tmux/control_client_test.go
+git commit -m "fix(tmux): a dropped output chunk marks the pane dirty for re-seed"
+```
+
+---
+
+### Task 3: `%pause` marks the stream dirty
+
+tmux discards output while a pane is paused, so resuming without a re-seed
+leaves a corrupted screen. `tmux/control_client.go:110` currently logs
+`%pause`/`%continue` and does nothing.
+
+**Mark on `%pause` only, never on `%continue`.** This is load-bearing, not an
+oversight: houston's own seed handshake in `server/pane_ws.go` issues
+`refresh-client -A %pane:pause` *before* it subscribes, so its deliberate pause
+reaches no subscriber and marks nothing. Marking on `%continue` would instead
+fire a spurious re-seed immediately after every deliberate seed.
+
+**Files:**
+- Modify: `tmux/control_client.go:110-111` (the `EventPause, EventContinue` case)
+- Test: `tmux/control_client_test.go`
+
+**Interfaces:**
+- Consumes: `markDirtyLocked` from Task 2.
+- Produces: `func (cc *ControlClient) markPaneDirty(paneID string)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tmux/control_client_test.go`:
+
+```go
+import (
+	"bufio"
+	"strings"
+	"testing"
+)
+
+// feed runs the read loop over a canned control-mode transcript.
+func feed(cc *ControlClient, transcript string) {
+	cc.readLoop(bufio.NewReader(strings.NewReader(transcript)))
+}
+
+func TestPauseMarksDirty(t *testing.T) {
+	cc := NewControlClient("test")
+	sub := cc.Subscribe("%1")
+
+	feed(cc, "%output %1 before\\015\\012\n%pause %1\n")
+
+	if ev := <-sub.C(); ev.Dirty {
+		t.Fatal("marked dirty before the pause arrived")
+	}
+	ev := <-sub.C()
+	if !ev.Dirty {
+		t.Fatalf("event after %%pause = %+v, want Dirty", ev)
+	}
+}
+
+func TestContinueDoesNotMarkDirty(t *testing.T) {
+	cc := NewControlClient("test")
+	sub := cc.Subscribe("%1")
+
+	feed(cc, "%continue %1\n")
+
+	if len(sub.C()) != 0 {
+		t.Fatal("%continue marked the pane dirty; only %pause may")
+	}
+}
+
+func TestPauseOnAnotherPaneIsIgnored(t *testing.T) {
+	cc := NewControlClient("test")
+	sub := cc.Subscribe("%1")
+
+	feed(cc, "%pause %2\n")
+
+	if len(sub.C()) != 0 {
+		t.Fatal("a pause on %2 marked %1 dirty")
+	}
+}
+```
+
+Note: `readLoop` calls `close(cc.done)` on return until Task 4 moves it. Each
+test above uses a fresh client, so the double-close hazard does not arise.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./tmux/ -run TestPause -v`
+Expected: FAIL — `event after %pause = {Data:[] Dirty:false}, want Dirty`
+(the channel is empty, so the receive blocks and the test panics on timeout).
+
+- [ ] **Step 3: Write the implementation**
+
+In `tmux/control_client.go`, replace the `EventPause, EventContinue` case
+(lines 110-111):
+
+```go
+		case EventPause:
+			// tmux discards output while paused, so resuming without a
+			// re-seed would paint on top of a hole. Only %pause marks:
+			// houston's own seed handshake pauses BEFORE it subscribes,
+			// so its deliberate pause reaches nobody. Marking on
+			// %continue instead would re-seed straight after every seed.
+			cc.markPaneDirty(event.PaneID)
+
+		case EventContinue:
+			slog.Debug("control mode continue", "session", cc.session, "paneID", event.PaneID)
+```
+
+Add below `markDirtyLocked`:
+
+```go
+// markPaneDirty signals every subscriber of a pane that its stream has a gap.
+func (cc *ControlClient) markPaneDirty(paneID string) {
+	cc.mu.Lock()
+	defer cc.mu.Unlock()
+	for _, s := range cc.subs[paneID] {
+		cc.markDirtyLocked(s)
+	}
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `go test ./tmux/... -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tmux/control_client.go tmux/control_client_test.go
+git commit -m "fix(tmux): %pause marks subscribers dirty so %continue re-seeds"
+```
+
+---
+
+### Task 4: Reconnect inside the client
+
+`tmux/control_manager.go:47` deletes the client on `Done()` and never re-dials,
+so a tmux server restart kills every attached WebSocket. Reconnection belongs in
+`ControlClient` rather than the manager: the subscription map then survives the
+re-dial, existing `*PaneSub` handles stay valid, and every subscriber is simply
+marked dirty on re-attach. Per lazytmux `#482` — a transport drop must not
+destroy state that is trivially re-derivable.
+
+This also changes `Done()`: it now closes only on explicit `Close()`.
+
+**Files:**
+- Modify: `tmux/control_client.go:51-88` (`Start`), `:90-91` (`readLoop` prologue), `:353-362` (`Close`), struct fields
+- Test: `tmux/control_client_test.go`
+
+**Interfaces:**
+- Consumes: `markPaneDirty` from Task 3.
+- Produces:
+  - `func (cc *ControlClient) Connected() bool`
+  - unexported `dial func() (io.ReadCloser, io.Writer, func() error, error)` field, injectable by tests
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tmux/control_client_test.go` (add `"io"`, `"sync"`, `"time"` to the
+import block):
+
+```go
+// scriptedDialer hands out one canned transcript per dial, so a test can drive
+// the client through a disconnect and a re-attach without running tmux.
+type scriptedDialer struct {
+	mu         sync.Mutex
+	transcripts []string
+	dials      int
+}
+
+func (d *scriptedDialer) dial() (io.ReadCloser, io.Writer, func() error, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	i := d.dials
+	d.dials++
+	if i >= len(d.transcripts) {
+		// Keep the connection open but silent so the client stops re-dialling.
+		pr, pw := io.Pipe()
+		return pr, io.Discard, func() error { return pw.Close() }, nil
+	}
+	return io.NopCloser(strings.NewReader(d.transcripts[i])), io.Discard,
+		func() error { return nil }, nil
+}
+
+func (d *scriptedDialer) count() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.dials
+}
+
+func TestReconnectMarksSubscribersDirty(t *testing.T) {
+	d := &scriptedDialer{transcripts: []string{
+		"%output %1 first\\015\\012\n", // EOF here == connection dropped
+	}}
+	cc := NewControlClient("test")
+	cc.dial = d.dial
+	cc.backoff = time.Millisecond
+	if err := cc.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = cc.Close() }()
+
+	sub := cc.Subscribe("%1")
+	// The first transcript is consumed before Subscribe may run, so drain
+	// whatever arrived and assert on the reconnect signal instead.
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case ev := <-sub.C():
+			if ev.Dirty {
+				return // re-attach signalled a re-seed: what we want
+			}
+		case <-deadline:
+			t.Fatalf("no Dirty event after reconnect; dials=%d", d.count())
+		}
+	}
+}
+
+func TestDoneDoesNotFireOnDisconnect(t *testing.T) {
+	d := &scriptedDialer{transcripts: []string{""}}
+	cc := NewControlClient("test")
+	cc.dial = d.dial
+	cc.backoff = time.Millisecond
+	if err := cc.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = cc.Close() }()
+
+	select {
+	case <-cc.Done():
+		t.Fatal("Done() fired on a transport drop; it must mean closed")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	if d.count() < 2 {
+		t.Fatalf("dials=%d, want at least 2 (the client never re-dialled)", d.count())
+	}
+}
+
+func TestCloseFiresDone(t *testing.T) {
+	d := &scriptedDialer{}
+	cc := NewControlClient("test")
+	cc.dial = d.dial
+	cc.backoff = time.Millisecond
+	if err := cc.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	_ = cc.Close()
+
+	select {
+	case <-cc.Done():
+	case <-time.After(time.Second):
+		t.Fatal("Done() did not fire after Close()")
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./tmux/ -run 'TestReconnect|TestDone|TestClose' -v`
+Expected: FAIL to compile — `cc.dial undefined`, `cc.backoff undefined`.
+
+- [ ] **Step 3: Write the implementation**
+
+In `tmux/control_client.go`, add to the struct (after the `done` field):
+
+```go
+	// dial opens one control-mode connection. Overridable in tests.
+	dial    func() (io.ReadCloser, io.Writer, func() error, error)
+	backoff time.Duration // initial reconnect delay; doubles to backoffMax
+
+	closeMu  sync.Mutex
+	closed   bool
+	connMu   sync.RWMutex
+	connOK   bool
+	closeCur func() error
+```
+
+Add `"time"` to the imports. Add the constant above `NewControlClient`:
+
+```go
+const backoffMax = 10 * time.Second
+```
+
+Set the defaults in `NewControlClient`:
+
+```go
+func NewControlClient(session string) *ControlClient {
+	cc := &ControlClient{
+		session: session,
+		subs:    make(map[string][]*PaneSub),
+		pending: make(chan commandResponse, 1),
+		done:    make(chan struct{}),
+		backoff: 250 * time.Millisecond,
+	}
+	cc.dial = cc.dialTmux
+	return cc
+}
+```
+
+Replace `Start` (lines 51-88) with the split below:
+
+```go
+// dialTmux opens the real control-mode connection over a PTY. tmux -CC needs a
+// terminal for tcgetattr, so a plain pipe will not do.
+func (cc *ControlClient) dialTmux() (io.ReadCloser, io.Writer, func() error, error) {
+	master, slave, err := openPTY()
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("open pty: %w", err)
+	}
+
+	cmd := exec.Command("tmux", "-CC", "attach-session", "-t", cc.session)
+	cmd.Stdin = slave
+	cmd.Stdout = slave
+	cmd.Stderr = slave
+
+	if err := cmd.Start(); err != nil {
+		_ = master.Close()
+		_ = slave.Close()
+		return nil, nil, nil, fmt.Errorf("start tmux -CC: %w", err)
+	}
+	_ = slave.Close() // child inherited it
+
+	closeFn := func() error {
+		_ = master.Close()
+		return cmd.Wait()
+	}
+	return master, master, closeFn, nil
+}
+
+func (cc *ControlClient) Start() error {
+	r, w, closeFn, err := cc.dial()
+	if err != nil {
+		return err
+	}
+	cc.attach(w, closeFn)
+	go cc.supervise(r)
+	return nil
+}
+
+// attach installs a freshly dialled connection and re-asserts client options.
+func (cc *ControlClient) attach(w io.Writer, closeFn func() error) {
+	cc.connMu.Lock()
+	cc.stdin = w
+	cc.closeCur = closeFn
+	cc.connOK = true
+	cc.connMu.Unlock()
+
+	// Exclude this CC client from window size calculations so it never
+	// overrides kitty's dimensions (window-size=latest).
+	cc.stdinMu.Lock()
+	_, err := io.WriteString(w, "refresh-client -f ignore-size\n")
+	cc.stdinMu.Unlock()
+	if err != nil {
+		slog.Warn("failed to set ignore-size on CC client", "error", err)
+	}
+}
+
+// supervise runs the read loop, re-dialling until Close. Every successful
+// re-attach marks all subscribers dirty: the pane painted on while we were
+// away, so their screens are stale by definition.
+func (cc *ControlClient) supervise(r io.ReadCloser) {
+	defer close(cc.done)
+
+	delay := cc.backoff
+	for {
+		cc.readLoop(bufio.NewReader(r))
+		_ = r.Close()
+
+		cc.connMu.Lock()
+		cc.connOK = false
+		cc.connMu.Unlock()
+
+		if cc.isClosed() {
+			return
+		}
+		slog.Info("control client disconnected, reconnecting", "session", cc.session)
+
+		next, w, closeFn, err := cc.dial()
+		if err != nil {
+			if cc.isClosed() {
+				return
+			}
+			time.Sleep(delay)
+			if delay = delay * 2; delay > backoffMax {
+				delay = backoffMax
+			}
+			continue
+		}
+
+		delay = cc.backoff
+		r = next
+		cc.attach(w, closeFn)
+		cc.markAllDirty()
+		slog.Info("control client reattached", "session", cc.session)
+	}
+}
+
+func (cc *ControlClient) markAllDirty() {
+	cc.mu.Lock()
+	defer cc.mu.Unlock()
+	for _, subs := range cc.subs {
+		for _, s := range subs {
+			cc.markDirtyLocked(s)
+		}
+	}
+}
+
+func (cc *ControlClient) isClosed() bool {
+	cc.closeMu.Lock()
+	defer cc.closeMu.Unlock()
+	return cc.closed
+}
+
+// Connected reports whether a control connection is currently established.
+// Consumers use it to mark their view stale rather than to tear it down.
+func (cc *ControlClient) Connected() bool {
+	cc.connMu.RLock()
+	defer cc.connMu.RUnlock()
+	return cc.connOK
+}
+```
+
+Remove `defer close(cc.done)` from `readLoop` (line 91) — `supervise` owns it
+now. Remove the now-unused `cmd`, `ptyMaster` and `ptySlave` struct fields.
+
+Replace `Close` (lines 353-362):
+
+```go
+func (cc *ControlClient) Close() error {
+	cc.closeMu.Lock()
+	if cc.closed {
+		cc.closeMu.Unlock()
+		return nil
+	}
+	cc.closed = true
+	cc.closeMu.Unlock()
+
+	cc.connMu.RLock()
+	closeFn := cc.closeCur
+	cc.connMu.RUnlock()
+
+	if closeFn != nil {
+		return closeFn()
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `go test ./tmux/... -race -v`
+Expected: PASS with no data races.
+
+- [ ] **Step 5: Simplify the manager**
+
+In `tmux/control_manager.go`, replace the exit-monitor goroutine (lines 45-52).
+The client no longer exits on a drop, so the monitor should only clean up after
+a real close:
+
+```go
+	m.clients[session] = &managedClient{client: cc, refCount: 1}
+	slog.Info("started control client", "session", session)
+
+	// The client reconnects on its own; Done() now fires only on Close.
+	go func() {
+		<-cc.Done()
+		m.mu.Lock()
+		delete(m.clients, session)
+		m.mu.Unlock()
+		slog.Info("control client closed", "session", session)
+	}()
+```
+
+- [ ] **Step 6: Run the full suite and build**
+
+Run: `go test ./... -race` then `go build ./...`
+Expected: PASS, then no output.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tmux/control_client.go tmux/control_client_test.go tmux/control_manager.go
+git commit -m "fix(tmux): reconnect inside the control client, keeping subscriptions"
+```
+
+---
+
+### Task 5: Re-seed the WebSocket on a dirty event, and remove dead code
+
+Wires the signal to the consumer that needs it, and clears the two artefacts the
+spec flags: `SetClientSize` has no callers, and the comment at
+`server/pane_ws.go:317` describes a `400x200` fixed size that the code does not
+set.
+
+**Files:**
+- Modify: `server/pane_ws.go` (write loop, `resize` case comment)
+- Modify: `tmux/control_client.go` (delete `SetClientSize`)
+- Test: manual verification (the re-seed path needs a live tmux server)
+
+**Interfaces:**
+- Consumes: `PaneEvent.Dirty`, `AckReseed` from Tasks 1-2.
+- Produces: nothing consumed by later tasks in this plan. Plan 2 consumes
+  `ControlClient.Connected()` to mark runs stale.
+
+- [ ] **Step 1: Extract the seed send so the re-seed path reuses it**
+
+In `server/pane_ws.go`, add above `paneWSWriteLoop`:
+
+```go
+// sendSeed pushes a capture-pane snapshot as the authoritative screen state.
+// Used on connect and again after any gap in the control stream.
+func (s *Server) sendSeed(conn *websocket.Conn, pane tmux.Pane) error {
+	seed, err := s.tmux.CapturePane(pane, 500)
+	if err != nil || seed == "" {
+		return err
+	}
+	outputJSON, _ := json.Marshal(WSOutput{Data: seed})
+	msg, _ := json.Marshal(WSMessage{Type: "seed", Data: outputJSON})
+	return conn.WriteMessage(websocket.TextMessage, msg)
+}
+```
+
+Replace the inline seed block (currently lines 141-148) with:
+
+```go
+	// Seed: capture-pane provides scrollback history and initial visible
+	// content. Pane is paused so no %output races with this seed.
+	if err := s.sendSeed(conn, pane); err != nil {
+		return
+	}
+```
+
+- [ ] **Step 2: Handle the dirty event in the write loop**
+
+Replace the output case added in Task 1 with:
+
+```go
+		case ev := <-sub.C():
+			if ev.Dirty {
+				// The stream has a hole. Everything buffered was discarded,
+				// so capture-pane is the only trustworthy screen state.
+				slog.Debug("pane stream dirty, re-seeding", "target", pane.Target())
+				if err := s.sendSeed(conn, pane); err != nil {
+					return
+				}
+				cc.AckReseed(sub)
+				continue
+			}
+			// Coalesce: drain all buffered chunks into one write
+			// to keep the channel drained and reduce WS round-trips.
+			buf := append([]byte(nil), ev.Data...)
+			for {
+				select {
+				case more := <-sub.C():
+					if more.Dirty {
+						// Rare: a drop while coalescing. Flush what we have,
+						// then let the next iteration re-seed over it.
+						cc.markPendingReseed(sub)
+						goto send
+					}
+					buf = append(buf, more.Data...)
+				default:
+					goto send
+				}
+			}
+		send:
+```
+
+Add to `tmux/control_client.go`, below `AckReseed`:
+
+```go
+// markPendingReseed re-arms a Dirty event that a consumer drained while
+// coalescing, so it is not lost.
+func (cc *ControlClient) markPendingReseed(s *PaneSub) {
+	cc.mu.Lock()
+	defer cc.mu.Unlock()
+	s.dirty = false // markDirtyLocked is a no-op while already dirty
+	cc.markDirtyLocked(s)
+}
+```
+
+- [ ] **Step 3: Delete the dead code and fix the stale comment**
+
+Delete `SetClientSize` from `tmux/control_client.go` (currently lines 301-308).
+
+In `server/pane_ws.go`, replace the `resize` case comment (lines 316-318):
+
+```go
+		case "resize":
+			// No-op by design: the CC client is created with
+			// `refresh-client -f ignore-size`, so houston never resizes a
+			// pane a human is attached to. The browser absorbs the mismatch.
+```
+
+- [ ] **Step 4: Verify nothing references the deleted symbol**
+
+Run: `rg -n 'SetClientSize' --type go`
+Expected: no matches.
+
+Run: `go build ./... && go vet ./...`
+Expected: no output from either.
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `go test ./... -race`
+Expected: PASS.
+
+- [ ] **Step 6: Verify against a live tmux server**
+
+```bash
+go build -o /tmp/houston . && /tmp/houston -addr 127.0.0.1:9099 -debug
+```
+
+In another shell, open a pane in the browser at `http://127.0.0.1:9099`, then
+force a reconnect:
+
+```bash
+tmux kill-server
+```
+
+Expected: the log prints `control client disconnected, reconnecting`, then
+`control client reattached`; the browser pane does **not** close, and repaints
+with current content once tmux is back. Before this plan the socket died.
+
+To exercise the drop path, run something that floods a pane
+(`yes | head -c 10000000`) while the browser tab is throttled (DevTools →
+Network → offline for a second). Expected: `pane stream dirty, re-seeding` in
+the log and a clean screen afterwards, not garbage.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/pane_ws.go tmux/control_client.go
+git commit -m "fix(server): re-seed the pane socket after a stream gap"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage** — against "Control-mode transport" in the spec:
+
+| Spec requirement | Task |
+|---|---|
+| `%pause`/`%continue` handled, re-seed on resume | 3, 5 |
+| Drop marks dirty and triggers re-seed | 2, 5 |
+| Reconnect with backoff; state kept, not destroyed | 4 |
+| Keep `refresh-client -f ignore-size` | Global constraint; asserted in Task 5 Step 3 |
+| Delete dead `SetClientSize` | 5 |
+| Fix stale `400x200` comment | 5 |
+| Runs go `Stale` while disconnected | **Deferred to Plan 2** — `Run` does not exist yet. Task 4 exposes `Connected()` as the seam. |
+
+**Placeholder scan:** none — every step carries the code it needs.
+
+**Type consistency:** `PaneEvent`, `PaneSub`, `PaneSub.C()`, `Subscribe`,
+`Unsubscribe`, `AckReseed`, `markDirtyLocked`, `markPaneDirty`,
+`markPendingReseed`, `Connected`, `dial`, `backoff` are spelled identically in
+every task that names them. `dispatch` takes `cc.mu.Lock` from Task 1 onward
+because Task 2 mutates `s.dirty` under it.

--- a/docs/superpowers/specs/2026-09-07-houston-overhaul-design.md
+++ b/docs/superpowers/specs/2026-09-07-houston-overhaul-design.md
@@ -1,0 +1,372 @@
+# Houston overhaul — agent-run spine, Mocha shell, federation seam
+
+**Issue:** #2
+**Status:** accepted
+**Milestone:** M1 (local-complete). M2 federation and M3 pi/notifications have
+seams defined here but no code.
+
+## Problem
+
+Houston is two applications sharing one binary.
+
+`#/agents` renders hook-driven Claude Code cards from `hub/` over one SSE stream.
+`#/panes` renders a tmux tree and xterm panes from `server/` over a different SSE
+stream. They share no types, no status vocabulary and no visual language, and are
+joined by a floating toggle drawn with inline styles in `ui/src/App.tsx`. Adding
+a fifth agent, a second host, or a dispatcher crew to that structure means adding
+it twice.
+
+Three forces make the split untenable rather than merely untidy:
+
+1. **Not every agent is a tmux pane.** OpenCode is an HTTP API. `pi` on halo is a
+   local-model agent with its own JSONL sessions. A dispatcher crew is a set of
+   workers that happen to live in panes. The pane cannot be the spine.
+2. **Not every agent is on this machine.** halo, tp-g6 and mbp all run agents and
+   are all on the tailnet.
+3. **Enrichment already exists and houston ignores it.** lazytmux computes PR
+   state, issue identity, crew membership, worktree and branch for every window,
+   keeps them fresh, and parks them in tmux user-options. Houston screen-scrapes
+   `capture-pane` once a second instead.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Spine | The **agent run** | The only model all of tmux, OpenCode, pi and crew workers fit |
+| Terminal | A **view of a run**, tab 2 | Keeps it one tap away without making it the app |
+| Remote | **Federated houstons** over Tailscale | Each peer reads its own filesystem; no cross-host state problem |
+| Dispatcher | **Full control**, including dispatching | The composer needs a real screen, which decided the shell |
+| Visual | **Instrument Mocha** | Card structure with Catppuccin; coherent with lazytmux |
+| Mobile shell | 4 tabs — Fleet · Crews · Workspace · Dispatch | Dispatch earns a destination |
+| Desktop shell | Its own console layout | A sibling shell, not a breakpoint |
+| Enrichment | Read lazytmux's tmux user-options | Do not rebuild what is already computed and fresh |
+
+### Why federation rather than an SSH control-mode bridge
+
+lazytmux dials `ssh -CC attach-session` because tmux is the only thing it may
+assume on the remote. Houston has no such constraint: it can install itself, and
+every host is already on the tailnet. A peer houston reads its own hook state
+files, its own tmux options and its own pi sessions — none of which survive an
+SSH control-mode stream, which carries terminal bytes and structural
+notifications and nothing else. lazytmux works around this by stamping status
+into tmux pane options; houston does not need the workaround.
+
+What transfers from the bridge is not its transport but its **failure
+semantics** — see "Control-mode transport" below.
+
+## The `Run` model
+
+One struct replaces `hub.SessionView`, `server.SessionWithWindows`,
+`server.AgentStripItem` and `server.OpenCodeSession`.
+
+```go
+// Run is one agent run, anywhere. It is the only object the UI lists.
+type Run struct {
+    ID    string // stable: host/agent/native-session-id
+    Host  string // "" means local; stamped by the hub for peers
+    Agent string // claude | codex | cursor | amp | opencode | pi
+    State State
+
+    Repo, Branch, Worktree string
+
+    Tmux  *TmuxRef  // nil for agents with no pane
+    Issue *IssueRef // nil when the window has no @issue_id
+    PR    *PRRef    // nil when the window has no @pr_number
+    Crew  *CrewRef  // nil when not dispatcher-managed
+
+    Activity Activity  // tool, hint, trail, preview
+    Question *Question // the thing you answer; non-nil implies State == Blocked
+    Tokens   Tokens
+
+    Since, UpdatedAt int64
+    Stale bool // source went quiet; last-known values retained
+    Caps  Caps // what this run supports right now
+}
+
+type Caps struct {
+    Terminal bool // a live pane feed is available
+    Reply    bool // text can be delivered (pane keys or `crew reply`)
+    Kill     bool
+}
+```
+
+`Caps` is load-bearing. An OpenCode run has no pane; a peer that is offline has no
+terminal; a run outside a crew cannot take a `crew reply`. The UI renders
+affordances from capabilities rather than branching on agent type, so adding an
+agent does not mean touching the UI.
+
+`Stale` is a flag, never a state. A stale run keeps its last-known `State` and
+says it is stale. This is the lazytmux reconnect lesson (`#482`): a transport
+drop must not destroy state that is trivially re-derivable.
+
+### One state vocabulary
+
+Three vocabularies exist today and they disagree. This is the single mapping.
+
+| `Run.State` | Claude hooks (`hook.State`) | crew bus | `@claude_status` |
+|---|---|---|---|
+| `thinking` | `thinking`, `starting` | — | `processing` |
+| `running` | `tool-running` | `working` | `processing` |
+| `blocked` | `waiting`, `waiting:permission` | `blocked` | `waiting`, `denied` |
+| `compacting` | `compacting` | — | `compacting` |
+| `review` | — | `pr_open` | — |
+| `done` | `ended` | `done` | `done` |
+| `failed` | — | `failed`, `exited` | `error` |
+| `idle` | — | — | `idle`, `interrupted` |
+
+`blocked` is the only state meaning *a human is required*. It drives the badge,
+the sort order, and in M3 the push notification. Nothing else may claim it.
+
+## Sources, correlation and merge
+
+```go
+type Source interface {
+    Name() string
+    Run(ctx context.Context, out chan<- Delta) error
+}
+```
+
+A source emits partial `Delta`s; a registry merges them into `Run`s and
+broadcasts changes. Sources never see each other.
+
+| Source | Reads | Authoritative for |
+|---|---|---|
+| `hooksource` | `<state>/claude/*.json` (today's `hub/`) | `State`, `Activity`, `Tokens` |
+| `tmuxsource` | `list-windows -a -F`, `show-options -p` | `Repo`, `Branch`, `Worktree`, `Issue`, `PR`, `Crew` |
+| `crewsource` | `.git/crew/*.jsonl` in known repos | `Question`, crew messages |
+| `opencodesource` | OpenCode HTTP/WS (today's client) | everything, for its own runs |
+
+`tmuxsource` harvests, per window: `@branch @git_root @worktree @issue_id
+@issue_title @issue_url @issue_provider @pr_number @pr_state @pr_check_state
+@pr_mergeable @pr_draft @pr_url @crew_name @crew_color @window_task`, and per
+pane `@claude_status`. All are written and kept fresh by lazytmux. Houston
+neither computes nor refreshes any of them.
+
+### Correlation
+
+**The join key is the tmux pane id.** Claude Code hooks already capture
+`TmuxPane` (`hook.SessionState.TmuxPane`, e.g. `%307`), and lazytmux writes
+`@claude_status` onto that same pane. Crew bus records key by branch, which
+resolves to a window through `@branch`/`@crew_name`. A run with no pane
+(OpenCode, and pi in M3) keys on its native session id and carries `Tmux == nil`.
+
+### Merge precedence
+
+Per field, highest first: **hooks → crew bus → tmux options → screen-scrape.**
+
+Hooks win because they fire synchronously with the event they describe. Screen
+scraping is last because it infers state from rendered text. Concretely this
+demotes `parser/` and `agents/*/detect.go` to the fallback for agents with no
+better source — **amp and generic only** — and retires
+`server/pane_ws.go:metaPollLoop`, which currently runs a `capture-pane` every
+second per open pane in parallel with the control stream.
+
+To be explicit, because "demote screen-scraping" is easy to over-read:
+identifying *which* pane runs Claude Code does not need detection at all. The
+hook state file carries `TmuxPane`, so a Claude pane identifies itself. What is
+retired is inferring Claude's *state* from rendered text —
+`agents/claude/detect.go` and `agents/claude/state.go` lose their role in the
+status path. The Workspace view labels plain panes from
+`#{pane_current_command}`, not from the parser.
+
+## Control-mode transport
+
+Houston already has a working control-mode client. Three of the four transport
+lessons from lazytmux's bridge are already implemented; the design keeps them and
+fixes the rest.
+
+**Already correct, keep:**
+
+- `tmux/control_client.go:81` — `refresh-client -f ignore-size`
+- `server/pane_ws.go:95-160` — a genuine seed handshake:
+  `refresh-client -A %pane:pause` → subscribe → `capture-pane` seed → SIGWINCH
+  redraw → `continue`. This solves the seed race with tmux's own per-pane pause
+  rather than a stream mark.
+- `tmux/control_client.go:144-154` — non-blocking fanout; a slow subscriber
+  cannot stall the control stream.
+
+**Fix:**
+
+1. **`%pause`/`%continue` are parsed and then ignored**
+   (`tmux/control_client.go:110`). That is safe only while houston drives the
+   pause itself. A tmux-initiated pause discards output, so resuming without a
+   re-seed leaves a corrupted screen. Mark the pane dirty on `%pause`; force a
+   `capture-pane` re-seed on `%continue`.
+2. **A dropped chunk is silent** (`tmux/control_client.go:151`). Dropping mid
+   escape sequence corrupts everything rendered after it, and the pane stays
+   wrong until the socket is reopened. Every drop must mark the pane dirty and
+   trigger the same re-seed. The subscriber most likely to be slow is a phone on
+   bad LTE, which is houston's premise.
+3. **No reconnect** (`tmux/control_manager.go:47`): the client is deleted on
+   `Done()` and never re-dialled, so a tmux server restart kills every attached
+   socket. Re-dial with backoff; mark that session's runs `Stale` meanwhile;
+   reconcile with one `capture-pane` per attached pane on success.
+
+**Deliberately not adopted from the bridge:**
+
+- **Size authority.** lazytmux takes it (`local → remote`) because it mirrors
+  into real local panes that must match. Houston renounces it, because a human is
+  attached to the same pane in kitty and must not be resized, and because N
+  browser viewers at different widths cannot all own one size. `ignore-size`
+  stays; the mismatch is absorbed client-side.
+- **Structural mirroring.** `%window-add` → local `new-window` has no meaning
+  here; houston has no local tmux to mirror into and renders structure as a list.
+
+**Cleanup:** `ControlClient.SetClientSize` (`tmux/control_client.go:302`) has no
+callers — delete it. The comment at `server/pane_ws.go:317` claims the client
+size is "fixed at 400x200"; it is `ignore-size`. Correct it.
+
+## Mobile terminal
+
+Because houston renounces size authority, the pane is whatever width kitty made
+it — commonly ~190 columns — and the phone absorbs the entire mismatch.
+
+Today zoom is a CSS `transform: scale()` over a terminal pinned to 13px
+(`ui/src/components/TerminalPane.tsx:206`, `:460`). At scale 1.0 text is crisp
+but roughly 45 of 190 columns are visible; zooming out to see more makes text
+both smaller and blurry, because rasterised glyphs are being resampled. No zoom
+level is simultaneously readable and crisp except exactly 1.0.
+
+**Zoom selects a font size, not a scale.** During a pinch, keep the CSS transform
+— it tracks fingers at 60fps. On gesture end, snap to the nearest real font size,
+set `term.options.fontSize`, and reset the transform to 1.0. At rest the
+transform is always 1.0, so glyphs are never resampled, and the zoom range is a
+bounded **9–24px** rather than an unbounded scale factor. The 9px floor is what
+makes "text can't be too small" enforceable.
+
+Navigation:
+
+- **Pan is primary.** Default is a readable font, panned to column 0, with
+  magnetism toward column 0 so a flick returns home.
+- **Column scrubber** below the viewport showing which slice of the width is
+  visible, draggable for fast travel across a wide diff or table.
+- **Follow the cursor.** When output arrives and no touch is active, ease the
+  horizontal pan to bring the cursor column into view. Suppressed while touching.
+- **Double-tap toggles readable ⇄ fit-width**, restoring the removed WIDE/FIT
+  affordance as a gesture. Fit-width is a glance mode and is honest about being
+  unreadable.
+- **Font size is a persisted per-device preference** in `useLayout`, not derived
+  from the viewport.
+
+**Bug this surfaces:** `ui/src/hooks/useTouchGestures.ts:43` hardcodes
+`const lineHeight = 13 * 1.2`. Correct only while the font is pinned at 13px;
+scrollback maths drifts the moment font size varies. It must read the terminal's
+actual cell metrics.
+
+## API surface
+
+```
+GET  /api/runs                 snapshot
+GET  /api/runs/stream          SSE; one event per delta
+GET  /api/runs/{id}            detail incl. transcript tail
+POST /api/runs/{id}/reply      text → pane keys, or `crew reply` when crew-backed
+POST /api/runs/{id}/key        special key
+POST /api/runs/{id}/kill
+WS   /api/runs/{id}/terminal   control-mode pipe, re-addressed
+GET  /api/workspace            tmux tree — agent runs and plain panes alike
+GET  /api/crews                crews with members and open questions
+POST /api/dispatch             shells out to `dispatch`
+GET  /api/hosts                peers and health (returns only local in M1)
+```
+
+`/api/sessions`, `/api/agents` and `/api/pane/*` are **deleted, not aliased**.
+Nothing but this UI consumes them, and keeping two vocabularies alive is the
+problem being fixed.
+
+`POST /api/dispatch` takes `{repo, task, tier, engine}` and execs the `dispatch`
+CLI in that repo. It does not reimplement any dispatcher logic.
+
+## Auth
+
+Currently `server/api.go:233` sets `Access-Control-Allow-Origin: *` on all of
+`/api/` unconditionally, and `server/pane_ws.go:19` returns `true` from
+`CheckOrigin`. Any page in any browser that can route to houston can read every
+session and POST arbitrary keystrokes into any tmux pane — command execution
+triggered by visiting a page, gated only by reaching the port. On a
+tailnet-bound houston that includes every tailnet device and any page open on the
+local machine hitting `localhost:9090`.
+
+M1 fixes it:
+
+- `Access-Control-Allow-Origin` becomes an explicit allowlist; the Vite dev
+  origin is permitted only when the server is started with `-debug`.
+- `CheckOrigin` validates against that same allowlist.
+- A bearer token is generated on first run into the state dir (0600), delivered
+  to the SPA as an httpOnly, SameSite=Strict cookie, and required by every `/api/`
+  route. The same token becomes the peer credential in M2.
+
+This is not a hardening nicety. Dispatch-from-phone must not be built on top of
+an unauthenticated keystroke endpoint.
+
+## UI architecture
+
+One `useRuns()` store subscribing to `/api/runs/stream`, consumed by two shells.
+
+- **Mobile** — 4 tabs. Fleet (grouped by host, or crew via a toggle), Crews,
+  Workspace (the tmux tree, including panes that are not agents), Dispatch. A run
+  opens a detail view with `Activity / Terminal / Diff` tabs; `Diff` is M3 and is
+  hidden until then.
+- **Desktop** — console: rail (hosts, crews, saved filters), fleet list, detail
+  pane. Keeps `allotment`.
+
+`ui/src/theme/tokens.css` is rewritten as the Mocha system: raw `--ctp-*` values
+plus semantic aliases (`--state-blocked`, `--state-running`, `--surface-card`).
+The `--ag-*` block scoped inside `ui/src/components/agents/agents.css` is
+removed — it exists only to avoid leaking into the other view, and there is no
+other view.
+
+## What is deleted
+
+- `ui/src/App.tsx`'s hash router and inline-styled `ViewSwitch`
+- `ui/src/components/Sidebar.tsx`, `SessionTree.tsx`, `TerminalArea.tsx`,
+  `PaneHeader.tsx` — replaced by the shells
+- `server/types.go`: `SessionsData`, `SessionWithWindows`, `WindowWithStatus`,
+  `AgentStripItem`, `PaneData`, `OpenCodeData`, `OpenCodeSession`
+- `hub.SessionView` (becomes `Run`)
+- `ControlClient.SetClientSize`
+- `server/pane_ws.go:metaPollLoop`
+- `CLAUDE.md`'s "Legacy templ templates" and "Legacy static assets" entries —
+  `views/` and `static/` are already gone; the doc is stale
+
+## Testing
+
+- **Table test for the state vocabulary** — every row of the mapping table, all
+  three input vocabularies. This is where correctness lives.
+- **Table test for merge precedence** — a `Run` assembled from conflicting
+  deltas across all four sources resolves per the documented order.
+- **`tmuxsource` against recorded fixtures** — real `list-windows -F` and
+  `show-options -p` output captured from halo, including a window with a PR, a
+  window with an issue and no PR, a crew window, and a bare window with none.
+- **`crewsource` against a fixture JSONL** — a `dispatch` record, a `blocked`
+  status with a question, and a terminal `done`.
+- **Control-mode re-seed** — a drop and a `%pause`/`%continue` cycle each produce
+  exactly one re-seed; extends `tmux/control_test.go`.
+- **Reconnect** — killing the control client marks runs stale, re-dial clears it.
+
+Existing `hook/`, `tmux/control_*_test.go` and `agents/` tests stay.
+
+## Seams for later milestones
+
+- **M2 federation.** `Run.Host` exists from day one, `""` meaning local. M2 adds
+  a `peersource` dialling `https://<peer>/api/runs/stream`, stamping `Host`, and
+  proxying terminal WebSockets. A peer disconnect sets `Stale` on that host's
+  runs and **keeps them listed**. `GET /api/hosts` already exists and returns
+  only the local host in M1.
+- **M3 pi.** A `pisource` fed by a pi extension writing houston state files,
+  mirroring `contrib/opencode-plugin/houston.ts`, with session-JSONL tailing at
+  `~/.pi/agent/sessions/<slug>/*.jsonl` as the fallback. Needs no model change:
+  `Agent: "pi"`, `Tmux: nil` when headless.
+- **M3 notifications.** `State == Blocked` is already the single trigger.
+
+## Risks
+
+- **`tmuxsource` couples houston to lazytmux's option names.** Accepted: they are
+  stable, documented in lazytmux's `CLAUDE.md`, and the fields degrade to absent
+  rather than wrong when missing. A houston on a host without lazytmux loses PR
+  and issue chips and nothing else.
+- **Deleting the old routes is irreversible for any out-of-tree consumer.** No
+  such consumer is known; the only client is this SPA.
+- **Font-size zoom re-renders the whole terminal on gesture end.** Measured cost
+  is one xterm re-layout per pinch, not per frame, because the transform carries
+  the live gesture. If it proves visible on an old phone, the fallback is to
+  debounce the commit rather than to return to scale-zoom.

--- a/server/pane_ws.go
+++ b/server/pane_ws.go
@@ -135,15 +135,10 @@ func (s *Server) handlePaneWS(w http.ResponseWriter, r *http.Request, pane tmux.
 		}
 	}
 
-	// Seed: capture-pane provides scrollback history and initial visible content.
-	// This is a visual-only snapshot (no terminal state like modes/scroll regions).
-	// Pane is paused so no %output races with this seed.
-	if seedOutput, err := s.tmux.CapturePane(pane, 500); err == nil && seedOutput != "" {
-		outputJSON, _ := json.Marshal(WSOutput{Data: seedOutput})
-		msg, _ := json.Marshal(WSMessage{Type: "seed", Data: outputJSON})
-		if err := conn.WriteMessage(websocket.TextMessage, msg); err != nil {
-			return
-		}
+	// Seed: capture-pane provides scrollback history and initial visible
+	// content. Pane is paused so no %output races with this seed.
+	if err := s.sendSeed(conn, pane); err != nil {
+		return
 	}
 
 	// Force the TUI to redraw via SIGWINCH (resize pane to same dimensions).
@@ -166,6 +161,18 @@ func (s *Server) handlePaneWS(w http.ResponseWriter, r *http.Request, pane tmux.
 	s.paneWSWriteLoop(conn, cc, pane, sub)
 }
 
+// sendSeed pushes a capture-pane snapshot as the authoritative screen state.
+// Used on connect and again after any gap in the control stream.
+func (s *Server) sendSeed(conn *websocket.Conn, pane tmux.Pane) error {
+	seed, err := s.tmux.CapturePane(pane, 500)
+	if err != nil || seed == "" {
+		return err
+	}
+	outputJSON, _ := json.Marshal(WSOutput{Data: seed})
+	msg, _ := json.Marshal(WSMessage{Type: "seed", Data: outputJSON})
+	return conn.WriteMessage(websocket.TextMessage, msg)
+}
+
 func (s *Server) paneWSWriteLoop(conn *websocket.Conn, cc *tmux.ControlClient, pane tmux.Pane, sub *tmux.PaneSub) {
 	pingTicker := time.NewTicker(30 * time.Second)
 	defer pingTicker.Stop()
@@ -180,12 +187,28 @@ func (s *Server) paneWSWriteLoop(conn *websocket.Conn, cc *tmux.ControlClient, p
 	for {
 		select {
 		case ev := <-sub.C():
+			if ev.Dirty {
+				// The stream has a hole. Everything buffered was discarded,
+				// so capture-pane is the only trustworthy screen state.
+				slog.Debug("pane stream dirty, re-seeding", "target", pane.Target())
+				if err := s.sendSeed(conn, pane); err != nil {
+					return
+				}
+				cc.AckReseed(sub)
+				continue
+			}
 			// Coalesce: drain all buffered chunks into one write
 			// to keep the channel drained and reduce WS round-trips.
 			buf := append([]byte(nil), ev.Data...)
 			for {
 				select {
 				case more := <-sub.C():
+					if more.Dirty {
+						// Rare: a drop while coalescing. Flush what we have,
+						// then let the next iteration re-seed over it.
+						cc.MarkPendingReseed(sub)
+						goto send
+					}
 					buf = append(buf, more.Data...)
 				default:
 					goto send
@@ -314,8 +337,9 @@ func (s *Server) paneWSReadLoop(conn *websocket.Conn, cc *tmux.ControlClient, pa
 			}
 
 		case "resize":
-			// No-op: CC client size is fixed at 400x200 (set on connect).
-			// kitty controls actual pane dimensions via window-size=latest.
+			// No-op by design: the CC client is created with
+			// `refresh-client -f ignore-size`, so houston never resizes a
+			// pane a human is attached to. The browser absorbs the mismatch.
 		}
 	}
 }

--- a/server/pane_ws.go
+++ b/server/pane_ws.go
@@ -102,7 +102,7 @@ func (s *Server) handlePaneWS(w http.ResponseWriter, r *http.Request, pane tmux.
 		slog.Debug("pause pane failed, proceeding without", "paneID", paneID, "error", err)
 	}
 
-	outputCh := cc.Subscribe(paneID)
+	sub := cc.Subscribe(paneID)
 
 	defer func() {
 		// Ensure pane is resumed if we exit before the explicit continue
@@ -115,7 +115,7 @@ func (s *Server) handlePaneWS(w http.ResponseWriter, r *http.Request, pane tmux.
 			_ = s.tmux.ZoomPane(pane) // toggle off
 		}
 		_ = conn.Close()
-		cc.Unsubscribe(paneID, outputCh)
+		cc.Unsubscribe(paneID, sub)
 		s.controlMgr.ReleaseClient(pane.Session)
 	}()
 
@@ -163,10 +163,10 @@ func (s *Server) handlePaneWS(w http.ResponseWriter, r *http.Request, pane tmux.
 	}
 
 	go s.paneWSReadLoop(conn, cc, paneID)
-	s.paneWSWriteLoop(conn, cc, pane, outputCh)
+	s.paneWSWriteLoop(conn, cc, pane, sub)
 }
 
-func (s *Server) paneWSWriteLoop(conn *websocket.Conn, cc *tmux.ControlClient, pane tmux.Pane, outputCh <-chan []byte) {
+func (s *Server) paneWSWriteLoop(conn *websocket.Conn, cc *tmux.ControlClient, pane tmux.Pane, sub *tmux.PaneSub) {
 	pingTicker := time.NewTicker(30 * time.Second)
 	defer pingTicker.Stop()
 
@@ -179,14 +179,14 @@ func (s *Server) paneWSWriteLoop(conn *websocket.Conn, cc *tmux.ControlClient, p
 
 	for {
 		select {
-		case data := <-outputCh:
+		case ev := <-sub.C():
 			// Coalesce: drain all buffered chunks into one write
 			// to keep the channel drained and reduce WS round-trips.
-			buf := append([]byte(nil), data...)
+			buf := append([]byte(nil), ev.Data...)
 			for {
 				select {
-				case more := <-outputCh:
-					buf = append(buf, more...)
+				case more := <-sub.C():
+					buf = append(buf, more.Data...)
 				default:
 					goto send
 				}

--- a/server/pane_ws.go
+++ b/server/pane_ws.go
@@ -142,14 +142,15 @@ func (s *Server) handlePaneWS(w http.ResponseWriter, r *http.Request, pane tmux.
 		return
 	}
 
-	// Force the TUI to redraw via SIGWINCH (resize pane to same dimensions).
-	// While paused, the redraw output is buffered by tmux and will be
-	// delivered when we continue — giving the client a clean seed+redraw sequence.
+	// Force the TUI to redraw via SIGWINCH (resize pane to same dimensions),
+	// prompting it to repaint any garbled state. tmux discards %output while
+	// paused, so the redraw's own output is not queued for later delivery —
+	// this just nudges the TUI before we resume normal streaming below.
 	if err := s.tmux.ForceRedraw(pane); err != nil {
 		slog.Debug("force redraw failed", "target", pane.Target(), "error", err)
 	}
 
-	// Resume %output delivery — buffered events (including any SIGWINCH redraw) flow
+	// Resume %output delivery — normal streaming resumes from here.
 	if paused {
 		continueCmd := fmt.Sprintf("refresh-client -A %s:continue", paneID)
 		if _, err := cc.RunCommand(continueCmd); err != nil {
@@ -171,20 +172,36 @@ func (s *Server) handlePaneWS(w http.ResponseWriter, r *http.Request, pane tmux.
 // returns (false, nil) — the caller decides whether it can proceed without a
 // seed, and on connect it can.
 func (s *Server) sendSeed(conn *websocket.Conn, pane tmux.Pane) (ok bool, err error) {
-	seed, capErr := s.tmux.CapturePane(pane, 500)
-	if capErr != nil {
-		slog.Debug("capture-pane failed", "target", pane.Target(), "error", capErr)
+	seed, ok := s.captureSeed(pane)
+	if !ok {
 		return false, nil
 	}
-	if seed == "" {
-		return false, nil
-	}
-	outputJSON, _ := json.Marshal(WSOutput{Data: seed})
-	msg, _ := json.Marshal(WSMessage{Type: "seed", Data: outputJSON})
-	if err := conn.WriteMessage(websocket.TextMessage, msg); err != nil {
+	if err := writeSeed(conn, seed); err != nil {
 		return false, err
 	}
 	return true, nil
+}
+
+// captureSeed takes a capture-pane snapshot. The bool reports whether a
+// non-empty seed was captured; a capture failure or empty pane both return
+// false with no error, matching sendSeed's "costs scrollback, not the
+// connection" contract.
+func (s *Server) captureSeed(pane tmux.Pane) (string, bool) {
+	seed, capErr := s.tmux.CapturePane(pane, 500)
+	if capErr != nil {
+		slog.Debug("capture-pane failed", "target", pane.Target(), "error", capErr)
+		return "", false
+	}
+	if seed == "" {
+		return "", false
+	}
+	return seed, true
+}
+
+func writeSeed(conn *websocket.Conn, seed string) error {
+	outputJSON, _ := json.Marshal(WSOutput{Data: seed})
+	msg, _ := json.Marshal(WSMessage{Type: "seed", Data: outputJSON})
+	return conn.WriteMessage(websocket.TextMessage, msg)
 }
 
 func (s *Server) paneWSWriteLoop(conn *websocket.Conn, cc *tmux.ControlClient, pane tmux.Pane, sub *tmux.PaneSub) {
@@ -205,10 +222,7 @@ func (s *Server) paneWSWriteLoop(conn *websocket.Conn, cc *tmux.ControlClient, p
 				// The stream has a hole. Everything buffered was discarded,
 				// so capture-pane is the only trustworthy screen state.
 				slog.Debug("pane stream dirty, re-seeding", "target", pane.Target())
-				ok, err := s.sendSeed(conn, pane)
-				if err != nil {
-					return
-				}
+				seed, ok := s.captureSeed(pane)
 				if !ok {
 					// Cannot re-seed, so the screen is unrecoverable on this
 					// socket. Close it and let the client reconnect for a
@@ -216,7 +230,14 @@ func (s *Server) paneWSWriteLoop(conn *websocket.Conn, cc *tmux.ControlClient, p
 					slog.Warn("re-seed failed, closing pane socket", "target", pane.Target())
 					return
 				}
+				// Ack before the write: this write loop is the sole WebSocket
+				// writer and the subscription channel preserves order, so any
+				// output produced after the capture is queued behind this
+				// seed rather than dropped while we wait on the write.
 				cc.AckReseed(sub)
+				if err := writeSeed(conn, seed); err != nil {
+					return
+				}
 				continue
 			}
 			// Coalesce: drain all buffered chunks into one write

--- a/server/pane_ws.go
+++ b/server/pane_ws.go
@@ -136,8 +136,9 @@ func (s *Server) handlePaneWS(w http.ResponseWriter, r *http.Request, pane tmux.
 	}
 
 	// Seed: capture-pane provides scrollback history and initial visible
-	// content. Pane is paused so no %output races with this seed.
-	if err := s.sendSeed(conn, pane); err != nil {
+	// content. Pane is paused so no %output races with this seed. A capture
+	// failure costs scrollback, not the connection.
+	if _, err := s.sendSeed(conn, pane); err != nil {
 		return
 	}
 
@@ -163,14 +164,27 @@ func (s *Server) handlePaneWS(w http.ResponseWriter, r *http.Request, pane tmux.
 
 // sendSeed pushes a capture-pane snapshot as the authoritative screen state.
 // Used on connect and again after any gap in the control stream.
-func (s *Server) sendSeed(conn *websocket.Conn, pane tmux.Pane) error {
-	seed, err := s.tmux.CapturePane(pane, 500)
-	if err != nil || seed == "" {
-		return err
+//
+// The two failure kinds are deliberately distinct: ok reports whether a seed
+// was actually delivered, while err is non-nil ONLY when the WebSocket write
+// failed, which is always fatal to the connection. A capture-pane failure
+// returns (false, nil) — the caller decides whether it can proceed without a
+// seed, and on connect it can.
+func (s *Server) sendSeed(conn *websocket.Conn, pane tmux.Pane) (ok bool, err error) {
+	seed, capErr := s.tmux.CapturePane(pane, 500)
+	if capErr != nil {
+		slog.Debug("capture-pane failed", "target", pane.Target(), "error", capErr)
+		return false, nil
+	}
+	if seed == "" {
+		return false, nil
 	}
 	outputJSON, _ := json.Marshal(WSOutput{Data: seed})
 	msg, _ := json.Marshal(WSMessage{Type: "seed", Data: outputJSON})
-	return conn.WriteMessage(websocket.TextMessage, msg)
+	if err := conn.WriteMessage(websocket.TextMessage, msg); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func (s *Server) paneWSWriteLoop(conn *websocket.Conn, cc *tmux.ControlClient, pane tmux.Pane, sub *tmux.PaneSub) {
@@ -191,7 +205,15 @@ func (s *Server) paneWSWriteLoop(conn *websocket.Conn, cc *tmux.ControlClient, p
 				// The stream has a hole. Everything buffered was discarded,
 				// so capture-pane is the only trustworthy screen state.
 				slog.Debug("pane stream dirty, re-seeding", "target", pane.Target())
-				if err := s.sendSeed(conn, pane); err != nil {
+				ok, err := s.sendSeed(conn, pane)
+				if err != nil {
+					return
+				}
+				if !ok {
+					// Cannot re-seed, so the screen is unrecoverable on this
+					// socket. Close it and let the client reconnect for a
+					// coherent seed rather than ack and resume over a hole.
+					slog.Warn("re-seed failed, closing pane socket", "target", pane.Target())
 					return
 				}
 				cc.AckReseed(sub)

--- a/server/pane_ws.go
+++ b/server/pane_ws.go
@@ -166,11 +166,10 @@ func (s *Server) handlePaneWS(w http.ResponseWriter, r *http.Request, pane tmux.
 // sendSeed pushes a capture-pane snapshot as the authoritative screen state.
 // Used on connect and again after any gap in the control stream.
 //
-// The two failure kinds are deliberately distinct: ok reports whether a seed
-// was actually delivered, while err is non-nil ONLY when the WebSocket write
-// failed, which is always fatal to the connection. A capture-pane failure
-// returns (false, nil) — the caller decides whether it can proceed without a
-// seed, and on connect it can.
+// ok reports whether a seed was delivered; err is non-nil only when the
+// WebSocket write failed, which is always fatal. A capture-pane failure is
+// (false, nil), leaving the caller to decide whether it can proceed without
+// a seed.
 func (s *Server) sendSeed(conn *websocket.Conn, pane tmux.Pane) (ok bool, err error) {
 	seed, ok := s.captureSeed(pane)
 	if !ok {
@@ -183,9 +182,8 @@ func (s *Server) sendSeed(conn *websocket.Conn, pane tmux.Pane) (ok bool, err er
 }
 
 // captureSeed takes a capture-pane snapshot. The bool reports whether a
-// non-empty seed was captured; a capture failure or empty pane both return
-// false with no error, matching sendSeed's "costs scrollback, not the
-// connection" contract.
+// non-empty seed was captured; neither a capture failure nor an empty pane
+// is an error.
 func (s *Server) captureSeed(pane tmux.Pane) (string, bool) {
 	seed, capErr := s.tmux.CapturePane(pane, 500)
 	if capErr != nil {
@@ -230,10 +228,10 @@ func (s *Server) paneWSWriteLoop(conn *websocket.Conn, cc *tmux.ControlClient, p
 					slog.Warn("re-seed failed, closing pane socket", "target", pane.Target())
 					return
 				}
-				// Ack before the write: this write loop is the sole WebSocket
-				// writer and the subscription channel preserves order, so any
-				// output produced after the capture is queued behind this
-				// seed rather than dropped while we wait on the write.
+				// Ack before the write: this goroutine stays inside
+				// writeSeed until the seed reaches the socket, so output
+				// produced after the capture queues behind it instead of
+				// being dropped for the duration of the write.
 				cc.AckReseed(sub)
 				if err := writeSeed(conn, seed); err != nil {
 					return

--- a/tmux/control_client.go
+++ b/tmux/control_client.go
@@ -107,8 +107,16 @@ func (cc *ControlClient) readLoop(r *bufio.Reader) {
 		case EventOutput, EventExtendedOutput:
 			cc.dispatch(event.PaneID, []byte(event.Data))
 
-		case EventPause, EventContinue:
-			slog.Debug("control mode flow control", "session", cc.session, "event", event.Type, "paneID", event.PaneID)
+		case EventPause:
+			// tmux discards output while paused, so resuming without a
+			// re-seed would paint on top of a hole. Only %pause marks:
+			// houston's own seed handshake pauses BEFORE it subscribes,
+			// so its deliberate pause reaches nobody. Marking on
+			// %continue instead would re-seed straight after every seed.
+			cc.markPaneDirty(event.PaneID)
+
+		case EventContinue:
+			slog.Debug("control mode continue", "session", cc.session, "paneID", event.PaneID)
 
 		case EventBegin:
 			inBlock = true
@@ -195,6 +203,15 @@ func (cc *ControlClient) markDirtyLocked(s *PaneSub) {
 			s.dirty = true
 			return
 		}
+	}
+}
+
+// markPaneDirty signals every subscriber of a pane that its stream has a gap.
+func (cc *ControlClient) markPaneDirty(paneID string) {
+	cc.mu.Lock()
+	defer cc.mu.Unlock()
+	for _, s := range cc.subs[paneID] {
+		cc.markDirtyLocked(s)
 	}
 }
 

--- a/tmux/control_client.go
+++ b/tmux/control_client.go
@@ -242,12 +242,11 @@ func (cc *ControlClient) readLoop(r *bufio.Reader) {
 		case EventPause:
 			// tmux discards output while paused, so resuming without a
 			// re-seed would paint on top of a hole. Only %pause marks:
-			// houston's own seed handshake pauses before it subscribes, so
-			// its deliberate pause usually reaches nobody — but tmux does
-			// not guarantee the %pause notification precedes that command's
-			// %end, so on the rare reorder this connect does one spurious,
-			// harmless re-seed. Marking on %continue instead would re-seed
-			// straight after every seed.
+			// marking on %continue would re-seed straight after every
+			// deliberate seed. The handshake's own pause usually lands
+			// before its subscriber exists — usually, because tmux does not
+			// guarantee %pause precedes that command's %end; the rare
+			// reorder costs one harmless re-seed.
 			cc.markPaneDirty(event.PaneID)
 
 		case EventContinue:
@@ -332,10 +331,8 @@ func (cc *ControlClient) markDirtyLocked(s *PaneSub) {
 		select {
 		case <-s.ch:
 		default:
-			// Drained. Three goroutines write subscriber channels (readLoop,
-			// supervise, and the WebSocket write loop), but all are
-			// serialized by cc.mu and the reader only ever removes, so this
-			// send still cannot block.
+			// Drained, and every writer holds cc.mu while the reader only
+			// removes, so this send cannot block.
 			s.ch <- PaneEvent{Dirty: true}
 			s.dirty = true
 			return
@@ -525,12 +522,8 @@ func (cc *ControlClient) RunCommand(command string) (string, error) {
 	default:
 	}
 
-	// Capture the current connection's cancellation channel BEFORE writing, so
-	// a nil here means the connection was already dead and the command cannot
-	// have landed. Reading it after the write would let a reattach that swaps
-	// cc.stdin before publishing its gone channel report "lost" for a command
-	// that was in fact delivered — which strands the caller's state (a pane
-	// left paused with nothing to resume it).
+	// Captured before the write, so a nil here means the connection was
+	// already dead and the command cannot have landed.
 	cc.connMu.RLock()
 	gone := cc.gone
 	cc.connMu.RUnlock()

--- a/tmux/control_client.go
+++ b/tmux/control_client.go
@@ -23,7 +23,7 @@ type ControlClient struct {
 	ptySlave  *os.File
 
 	mu   sync.RWMutex
-	subs map[string][]chan<- []byte // paneID → output subscribers
+	subs map[string][]*PaneSub // paneID → subscribers
 
 	// Synchronous command support: one command at a time.
 	// tmux assigns command numbers server-side, so we serialize
@@ -42,7 +42,7 @@ type commandResponse struct {
 func NewControlClient(session string) *ControlClient {
 	return &ControlClient{
 		session: session,
-		subs:    make(map[string][]chan<- []byte),
+		subs:    make(map[string][]*PaneSub),
 		pending: make(chan commandResponse, 1),
 		done:    make(chan struct{}),
 	}
@@ -142,34 +142,51 @@ func (cc *ControlClient) readLoop(r *bufio.Reader) {
 	}
 }
 
+// PaneEvent is one item in a pane subscription. A Dirty event marks a gap in
+// the stream: everything buffered before it was discarded, and the subscriber
+// must re-seed from capture-pane before applying any later Data. Data and
+// Dirty are never both set.
+type PaneEvent struct {
+	Data  []byte
+	Dirty bool
+}
+
+// PaneSub is one subscriber's handle on a pane's output.
+type PaneSub struct {
+	ch    chan PaneEvent
+	dirty bool // guarded by ControlClient.mu
+}
+
+// C returns the event stream. Read it until the subscription is released.
+func (s *PaneSub) C() <-chan PaneEvent { return s.ch }
+
 func (cc *ControlClient) dispatch(paneID string, data []byte) {
-	cc.mu.RLock()
-	defer cc.mu.RUnlock()
-	for _, ch := range cc.subs[paneID] {
+	cc.mu.Lock()
+	defer cc.mu.Unlock()
+	for _, s := range cc.subs[paneID] {
 		select {
-		case ch <- data:
+		case s.ch <- PaneEvent{Data: data}:
 		default:
-			// Subscriber too slow — drop this chunk
 		}
 	}
 }
 
-// Subscribe returns a channel that receives raw output for the given pane.
-func (cc *ControlClient) Subscribe(paneID string) <-chan []byte {
-	ch := make(chan []byte, 4096)
+// Subscribe returns a handle receiving output for the given pane.
+func (cc *ControlClient) Subscribe(paneID string) *PaneSub {
+	s := &PaneSub{ch: make(chan PaneEvent, 4096)}
 	cc.mu.Lock()
-	cc.subs[paneID] = append(cc.subs[paneID], ch)
+	cc.subs[paneID] = append(cc.subs[paneID], s)
 	cc.mu.Unlock()
-	return ch
+	return s
 }
 
-// Unsubscribe removes a subscriber channel for a pane.
-func (cc *ControlClient) Unsubscribe(paneID string, ch <-chan []byte) {
+// Unsubscribe releases a subscription handle.
+func (cc *ControlClient) Unsubscribe(paneID string, s *PaneSub) {
 	cc.mu.Lock()
 	defer cc.mu.Unlock()
 	subs := cc.subs[paneID]
-	for i, s := range subs {
-		if fmt.Sprintf("%p", s) == fmt.Sprintf("%p", ch) {
+	for i, existing := range subs {
+		if existing == s {
 			cc.subs[paneID] = append(subs[:i], subs[i+1:]...)
 			break
 		}

--- a/tmux/control_client.go
+++ b/tmux/control_client.go
@@ -26,6 +26,11 @@ type ControlClient struct {
 	connMu   sync.RWMutex
 	connOK   bool
 	closeCur func() error
+	// gone is closed when the CURRENT connection ends, so a caller blocked in
+	// RunCommand is released at the end of that connection rather than waiting
+	// for Close(). Replaced on every attach; nil means no live connection.
+	// Guarded by connMu.
+	gone chan struct{}
 
 	mu   sync.RWMutex
 	subs map[string][]*PaneSub // paneID → subscribers
@@ -78,9 +83,21 @@ func (cc *ControlClient) dialTmux() (io.ReadCloser, io.Writer, func() error, err
 	}
 	_ = slave.Close() // child inherited it
 
+	var once sync.Once
 	closeFn := func() error {
-		_ = master.Close()
-		return cmd.Wait()
+		var err error
+		once.Do(func() {
+			_ = master.Close()
+			// Closing the PTY alone can leave the tmux client alive for ~10s
+			// before it notices, and Wait() would block that whole time —
+			// stalling both Close() and supervise. Killing the CLIENT is safe:
+			// the server and the session are untouched by it.
+			if cmd.Process != nil {
+				_ = cmd.Process.Kill()
+			}
+			err = cmd.Wait() // still reaps the child; no zombie
+		})
+		return err
 	}
 	return master, master, closeFn, nil
 }
@@ -91,7 +108,7 @@ func (cc *ControlClient) Start() error {
 		return err
 	}
 	cc.attach(w, closeFn)
-	go cc.supervise(r)
+	go cc.supervise(r, closeFn)
 	return nil
 }
 
@@ -112,6 +129,7 @@ func (cc *ControlClient) attach(w io.Writer, closeFn func() error) {
 	cc.connMu.Lock()
 	cc.closeCur = closeFn
 	cc.connOK = true
+	cc.gone = make(chan struct{})
 	cc.connMu.Unlock()
 }
 
@@ -124,17 +142,23 @@ const minHealthyConn = 5 * time.Second
 // supervise runs the read loop, re-dialling until Close. Every successful
 // re-attach marks all subscribers dirty: the pane painted on while we were
 // away, so their screens are stale by definition.
-func (cc *ControlClient) supervise(r io.ReadCloser) {
+func (cc *ControlClient) supervise(r io.ReadCloser, closeConn func() error) {
 	defer close(cc.done)
 
 	delay := cc.backoff
 	for {
 		start := time.Now()
 		cc.readLoop(bufio.NewReader(r))
-		_ = r.Close()
+		// closeConn, not r.Close(): it closes the PTY master AND waits on the
+		// tmux child. Closing only the reader leaves a zombie per reconnect.
+		_ = closeConn()
 
 		cc.connMu.Lock()
 		cc.connOK = false
+		if cc.gone != nil {
+			close(cc.gone)
+			cc.gone = nil // a dial-error lap must not close it twice
+		}
 		cc.connMu.Unlock()
 
 		if cc.isClosed() {
@@ -166,6 +190,7 @@ func (cc *ControlClient) supervise(r io.ReadCloser) {
 		}
 
 		r = next
+		closeConn = closeFn
 		cc.attach(w, closeFn)
 		cc.markAllDirty()
 		slog.Info("control client reattached", "session", cc.session)
@@ -217,9 +242,12 @@ func (cc *ControlClient) readLoop(r *bufio.Reader) {
 		case EventPause:
 			// tmux discards output while paused, so resuming without a
 			// re-seed would paint on top of a hole. Only %pause marks:
-			// houston's own seed handshake pauses BEFORE it subscribes,
-			// so its deliberate pause reaches nobody. Marking on
-			// %continue instead would re-seed straight after every seed.
+			// houston's own seed handshake pauses before it subscribes, so
+			// its deliberate pause usually reaches nobody — but tmux does
+			// not guarantee the %pause notification precedes that command's
+			// %end, so on the rare reorder this connect does one spurious,
+			// harmless re-seed. Marking on %continue instead would re-seed
+			// straight after every seed.
 			cc.markPaneDirty(event.PaneID)
 
 		case EventContinue:
@@ -304,8 +332,10 @@ func (cc *ControlClient) markDirtyLocked(s *PaneSub) {
 		select {
 		case <-s.ch:
 		default:
-			// Drained, and we are the only producer while holding cc.mu,
-			// so this send cannot block.
+			// Drained. Three goroutines write subscriber channels (readLoop,
+			// supervise, and the WebSocket write loop), but all are
+			// serialized by cc.mu and the reader only ever removes, so this
+			// send still cannot block.
 			s.ch <- PaneEvent{Dirty: true}
 			s.dirty = true
 			return
@@ -495,6 +525,19 @@ func (cc *ControlClient) RunCommand(command string) (string, error) {
 	default:
 	}
 
+	// Capture the current connection's cancellation channel BEFORE writing, so
+	// a nil here means the connection was already dead and the command cannot
+	// have landed. Reading it after the write would let a reattach that swaps
+	// cc.stdin before publishing its gone channel report "lost" for a command
+	// that was in fact delivered — which strands the caller's state (a pane
+	// left paused with nothing to resume it).
+	cc.connMu.RLock()
+	gone := cc.gone
+	cc.connMu.RUnlock()
+	if gone == nil {
+		return "", fmt.Errorf("control connection lost")
+	}
+
 	cc.stdinMu.Lock()
 	_, err := io.WriteString(cc.stdin, command+"\n")
 	cc.stdinMu.Unlock()
@@ -505,6 +548,8 @@ func (cc *ControlClient) RunCommand(command string) (string, error) {
 	select {
 	case resp := <-cc.pending:
 		return resp.output, resp.err
+	case <-gone:
+		return "", fmt.Errorf("control connection lost")
 	case <-cc.done:
 		return "", fmt.Errorf("control client closed")
 	}

--- a/tmux/control_client.go
+++ b/tmux/control_client.go
@@ -164,11 +164,46 @@ func (cc *ControlClient) dispatch(paneID string, data []byte) {
 	cc.mu.Lock()
 	defer cc.mu.Unlock()
 	for _, s := range cc.subs[paneID] {
+		// A dirty subscriber has a hole in its stream; nothing may be
+		// delivered until it re-seeds and acks.
+		if s.dirty {
+			continue
+		}
 		select {
 		case s.ch <- PaneEvent{Data: data}:
 		default:
+			// A drop can cut an escape sequence, so everything already
+			// buffered is unusable too. Discard it and signal a re-seed.
+			cc.markDirtyLocked(s)
 		}
 	}
+}
+
+// markDirtyLocked discards a subscriber's buffered output and leaves a single
+// Dirty event in its place. Caller must hold cc.mu.
+func (cc *ControlClient) markDirtyLocked(s *PaneSub) {
+	if s.dirty {
+		return
+	}
+	for {
+		select {
+		case <-s.ch:
+		default:
+			// Drained, and we are the only producer while holding cc.mu,
+			// so this send cannot block.
+			s.ch <- PaneEvent{Dirty: true}
+			s.dirty = true
+			return
+		}
+	}
+}
+
+// AckReseed resumes delivery after the subscriber has re-seeded from
+// capture-pane in response to a Dirty event.
+func (cc *ControlClient) AckReseed(s *PaneSub) {
+	cc.mu.Lock()
+	defer cc.mu.Unlock()
+	s.dirty = false
 }
 
 // Subscribe returns a handle receiving output for the given pane.

--- a/tmux/control_client.go
+++ b/tmux/control_client.go
@@ -115,6 +115,12 @@ func (cc *ControlClient) attach(w io.Writer, closeFn func() error) {
 	cc.connMu.Unlock()
 }
 
+// minHealthyConn is how long a connection must last to count as healthy. A
+// connection that dies sooner is treated as a failed attempt for backoff
+// purposes, even though dial() itself succeeded — a tmux server that is up
+// but has no such session accepts the dial and drops it instantly.
+const minHealthyConn = 5 * time.Second
+
 // supervise runs the read loop, re-dialling until Close. Every successful
 // re-attach marks all subscribers dirty: the pane painted on while we were
 // away, so their screens are stale by definition.
@@ -123,6 +129,7 @@ func (cc *ControlClient) supervise(r io.ReadCloser) {
 
 	delay := cc.backoff
 	for {
+		start := time.Now()
 		cc.readLoop(bufio.NewReader(r))
 		_ = r.Close()
 
@@ -133,21 +140,31 @@ func (cc *ControlClient) supervise(r io.ReadCloser) {
 		if cc.isClosed() {
 			return
 		}
-		slog.Info("control client disconnected, reconnecting", "session", cc.session)
+		if time.Since(start) >= minHealthyConn {
+			delay = cc.backoff
+		}
+
+		slog.Info("control client disconnected, reconnecting",
+			"session", cc.session, "in", delay)
+		time.Sleep(delay)
+		if delay *= 2; delay > backoffMax {
+			delay = backoffMax
+		}
+		if cc.isClosed() {
+			return
+		}
 
 		next, w, closeFn, err := cc.dial()
 		if err != nil {
-			if cc.isClosed() {
-				return
-			}
-			time.Sleep(delay)
-			if delay = delay * 2; delay > backoffMax {
-				delay = backoffMax
-			}
 			continue
 		}
+		// Close() may have run while dial() was in flight. It could only have
+		// closed the previous connection, so this one is ours to clean up.
+		if cc.isClosed() {
+			_ = closeFn()
+			return
+		}
 
-		delay = cc.backoff
 		r = next
 		cc.attach(w, closeFn)
 		cc.markAllDirty()

--- a/tmux/control_client.go
+++ b/tmux/control_client.go
@@ -330,6 +330,15 @@ func (cc *ControlClient) AckReseed(s *PaneSub) {
 	s.dirty = false
 }
 
+// MarkPendingReseed re-arms a Dirty event that a consumer drained while
+// coalescing, so it is not lost.
+func (cc *ControlClient) MarkPendingReseed(s *PaneSub) {
+	cc.mu.Lock()
+	defer cc.mu.Unlock()
+	s.dirty = false // markDirtyLocked is a no-op while already dirty
+	cc.markDirtyLocked(s)
+}
+
 // Subscribe returns a handle receiving output for the given pane.
 func (cc *ControlClient) Subscribe(paneID string) *PaneSub {
 	s := &PaneSub{ch: make(chan PaneEvent, 4096)}
@@ -468,15 +477,6 @@ func matchEscSeq(s string) (int, string) {
 // SendSpecialKey sends a named key (Enter, Escape, C-c, etc.) to a pane.
 func (cc *ControlClient) SendSpecialKey(paneID, key string) error {
 	cmd := fmt.Sprintf("send-keys -t %s %s\n", paneID, key)
-	cc.stdinMu.Lock()
-	_, err := io.WriteString(cc.stdin, cmd)
-	cc.stdinMu.Unlock()
-	return err
-}
-
-// SetClientSize sets the control client dimensions.
-func (cc *ControlClient) SetClientSize(cols, rows int) error {
-	cmd := fmt.Sprintf("refresh-client -C %d,%d\n", cols, rows)
 	cc.stdinMu.Lock()
 	_, err := io.WriteString(cc.stdin, cmd)
 	cc.stdinMu.Unlock()

--- a/tmux/control_client.go
+++ b/tmux/control_client.go
@@ -5,22 +5,27 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"os"
 	"os/exec"
 	"strings"
 	"sync"
+	"time"
 )
 
 // ControlClient manages a tmux -CC connection to a session.
 type ControlClient struct {
 	session string
-	cmd     *exec.Cmd
 	stdin   io.Writer
 	stdinMu sync.Mutex // serialize writes to stdin
 
-	// PTY master/slave for tmux -CC (requires a terminal)
-	ptyMaster *os.File
-	ptySlave  *os.File
+	// dial opens one control-mode connection. Overridable in tests.
+	dial    func() (io.ReadCloser, io.Writer, func() error, error)
+	backoff time.Duration // initial reconnect delay; doubles to backoffMax
+
+	closeMu  sync.Mutex
+	closed   bool
+	connMu   sync.RWMutex
+	connOK   bool
+	closeCur func() error
 
 	mu   sync.RWMutex
 	subs map[string][]*PaneSub // paneID → subscribers
@@ -39,57 +44,142 @@ type commandResponse struct {
 	err    error
 }
 
+const backoffMax = 10 * time.Second
+
 func NewControlClient(session string) *ControlClient {
-	return &ControlClient{
+	cc := &ControlClient{
 		session: session,
 		subs:    make(map[string][]*PaneSub),
 		pending: make(chan commandResponse, 1),
 		done:    make(chan struct{}),
+		backoff: 250 * time.Millisecond,
 	}
+	cc.dial = cc.dialTmux
+	return cc
+}
+
+// dialTmux opens the real control-mode connection over a PTY. tmux -CC needs a
+// terminal for tcgetattr, so a plain pipe will not do.
+func (cc *ControlClient) dialTmux() (io.ReadCloser, io.Writer, func() error, error) {
+	master, slave, err := openPTY()
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("open pty: %w", err)
+	}
+
+	cmd := exec.Command("tmux", "-CC", "attach-session", "-t", cc.session)
+	cmd.Stdin = slave
+	cmd.Stdout = slave
+	cmd.Stderr = slave
+
+	if err := cmd.Start(); err != nil {
+		_ = master.Close()
+		_ = slave.Close()
+		return nil, nil, nil, fmt.Errorf("start tmux -CC: %w", err)
+	}
+	_ = slave.Close() // child inherited it
+
+	closeFn := func() error {
+		_ = master.Close()
+		return cmd.Wait()
+	}
+	return master, master, closeFn, nil
 }
 
 func (cc *ControlClient) Start() error {
-	// tmux -CC requires a terminal for tcgetattr — use a PTY
-	master, slave, err := openPTY()
+	r, w, closeFn, err := cc.dial()
 	if err != nil {
-		return fmt.Errorf("open pty: %w", err)
+		return err
 	}
-	cc.ptyMaster = master
-	cc.ptySlave = slave
+	cc.attach(w, closeFn)
+	go cc.supervise(r)
+	return nil
+}
 
-	cc.cmd = exec.Command("tmux", "-CC", "attach-session", "-t", cc.session)
-	cc.cmd.Stdin = slave
-	cc.cmd.Stdout = slave
-	cc.cmd.Stderr = slave
-	cc.stdin = master // write commands to PTY master
-
-	if err := cc.cmd.Start(); err != nil {
-		_ = master.Close()
-		_ = slave.Close()
-		return fmt.Errorf("start tmux -CC: %w", err)
-	}
-
-	// Close slave in parent — child inherited it
-	_ = slave.Close()
-	cc.ptySlave = nil
-
-	go cc.readLoop(bufio.NewReader(master))
-
+// attach installs a freshly dialled connection and re-asserts client options.
+func (cc *ControlClient) attach(w io.Writer, closeFn func() error) {
+	// Every send path reads cc.stdin under stdinMu, so the assignment must be
+	// guarded by the same lock, not connMu.
+	cc.stdinMu.Lock()
+	cc.stdin = w
 	// Exclude this CC client from window size calculations so it never
 	// overrides kitty's dimensions (window-size=latest).
-	cc.stdinMu.Lock()
-	_, err = io.WriteString(cc.stdin, "refresh-client -f ignore-size\n")
+	_, err := io.WriteString(w, "refresh-client -f ignore-size\n")
 	cc.stdinMu.Unlock()
 	if err != nil {
 		slog.Warn("failed to set ignore-size on CC client", "error", err)
 	}
 
-	return nil
+	cc.connMu.Lock()
+	cc.closeCur = closeFn
+	cc.connOK = true
+	cc.connMu.Unlock()
+}
+
+// supervise runs the read loop, re-dialling until Close. Every successful
+// re-attach marks all subscribers dirty: the pane painted on while we were
+// away, so their screens are stale by definition.
+func (cc *ControlClient) supervise(r io.ReadCloser) {
+	defer close(cc.done)
+
+	delay := cc.backoff
+	for {
+		cc.readLoop(bufio.NewReader(r))
+		_ = r.Close()
+
+		cc.connMu.Lock()
+		cc.connOK = false
+		cc.connMu.Unlock()
+
+		if cc.isClosed() {
+			return
+		}
+		slog.Info("control client disconnected, reconnecting", "session", cc.session)
+
+		next, w, closeFn, err := cc.dial()
+		if err != nil {
+			if cc.isClosed() {
+				return
+			}
+			time.Sleep(delay)
+			if delay = delay * 2; delay > backoffMax {
+				delay = backoffMax
+			}
+			continue
+		}
+
+		delay = cc.backoff
+		r = next
+		cc.attach(w, closeFn)
+		cc.markAllDirty()
+		slog.Info("control client reattached", "session", cc.session)
+	}
+}
+
+func (cc *ControlClient) markAllDirty() {
+	cc.mu.Lock()
+	defer cc.mu.Unlock()
+	for _, subs := range cc.subs {
+		for _, s := range subs {
+			cc.markDirtyLocked(s)
+		}
+	}
+}
+
+func (cc *ControlClient) isClosed() bool {
+	cc.closeMu.Lock()
+	defer cc.closeMu.Unlock()
+	return cc.closed
+}
+
+// Connected reports whether a control connection is currently established.
+// Consumers use it to mark their view stale rather than to tear it down.
+func (cc *ControlClient) Connected() bool {
+	cc.connMu.RLock()
+	defer cc.connMu.RUnlock()
+	return cc.connOK
 }
 
 func (cc *ControlClient) readLoop(r *bufio.Reader) {
-	defer close(cc.done)
-
 	var cmdBuf strings.Builder
 	inBlock := false
 
@@ -420,12 +510,20 @@ func (cc *ControlClient) Done() <-chan struct{} {
 }
 
 func (cc *ControlClient) Close() error {
-	cc.stdinMu.Lock()
-	_, _ = io.WriteString(cc.stdin, "\n")
-	cc.stdinMu.Unlock()
-
-	if cc.ptyMaster != nil {
-		_ = cc.ptyMaster.Close()
+	cc.closeMu.Lock()
+	if cc.closed {
+		cc.closeMu.Unlock()
+		return nil
 	}
-	return cc.cmd.Wait()
+	cc.closed = true
+	cc.closeMu.Unlock()
+
+	cc.connMu.RLock()
+	closeFn := cc.closeCur
+	cc.connMu.RUnlock()
+
+	if closeFn != nil {
+		return closeFn()
+	}
+	return nil
 }

--- a/tmux/control_client_test.go
+++ b/tmux/control_client_test.go
@@ -2,8 +2,11 @@ package tmux
 
 import (
 	"bufio"
+	"io"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 )
 
 func TestSubscribeDeliversOutput(t *testing.T) {
@@ -159,5 +162,105 @@ func TestPauseOnAnotherPaneIsIgnored(t *testing.T) {
 
 	if len(sub.C()) != 0 {
 		t.Fatal("a pause on %2 marked %1 dirty")
+	}
+}
+
+// scriptedDialer hands out one canned transcript per dial, so a test can drive
+// the client through a disconnect and a re-attach without running tmux.
+type scriptedDialer struct {
+	mu          sync.Mutex
+	transcripts []string
+	dials       int
+}
+
+func (d *scriptedDialer) dial() (io.ReadCloser, io.Writer, func() error, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	i := d.dials
+	d.dials++
+	if i >= len(d.transcripts) {
+		// Keep the connection open but silent so the client stops re-dialling.
+		pr, pw := io.Pipe()
+		return pr, io.Discard, func() error { return pw.Close() }, nil
+	}
+	return io.NopCloser(strings.NewReader(d.transcripts[i])), io.Discard,
+		func() error { return nil }, nil
+}
+
+func (d *scriptedDialer) count() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.dials
+}
+
+func TestReconnectMarksSubscribersDirty(t *testing.T) {
+	d := &scriptedDialer{transcripts: []string{
+		"%output %1 first\\015\\012\n", // EOF here == connection dropped
+	}}
+	cc := NewControlClient("test")
+	cc.dial = d.dial
+	cc.backoff = time.Millisecond
+
+	// Subscribe before Start so the reconnect cannot fire with no
+	// subscriber present.
+	sub := cc.Subscribe("%1")
+
+	if err := cc.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = cc.Close() }()
+
+	// The pre-drop Data event may or may not be observed: markDirtyLocked
+	// drains the backlog on re-attach, so whether "first" survives depends
+	// on which side wins the race. Both interleavings are correct. What must
+	// happen is that Dirty arrives.
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case ev := <-sub.C():
+			if ev.Dirty {
+				return
+			}
+		case <-deadline:
+			t.Fatalf("no Dirty event after reconnect; dials=%d", d.count())
+		}
+	}
+}
+
+func TestDoneDoesNotFireOnDisconnect(t *testing.T) {
+	d := &scriptedDialer{transcripts: []string{""}}
+	cc := NewControlClient("test")
+	cc.dial = d.dial
+	cc.backoff = time.Millisecond
+	if err := cc.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = cc.Close() }()
+
+	select {
+	case <-cc.Done():
+		t.Fatal("Done() fired on a transport drop; it must mean closed")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	if d.count() < 2 {
+		t.Fatalf("dials=%d, want at least 2 (the client never re-dialled)", d.count())
+	}
+}
+
+func TestCloseFiresDone(t *testing.T) {
+	d := &scriptedDialer{}
+	cc := NewControlClient("test")
+	cc.dial = d.dial
+	cc.backoff = time.Millisecond
+	if err := cc.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	_ = cc.Close()
+
+	select {
+	case <-cc.Done():
+	case <-time.After(time.Second):
+		t.Fatal("Done() did not fire after Close()")
 	}
 }

--- a/tmux/control_client_test.go
+++ b/tmux/control_client_test.go
@@ -50,3 +50,68 @@ func TestUnsubscribeRemovesOnlyThatSubscriber(t *testing.T) {
 		t.Fatalf("remaining subscriber got %d events, want 1", len(b.C()))
 	}
 }
+
+// fillSub saturates a subscriber's buffer so the next dispatch must drop.
+func fillSub(cc *ControlClient, paneID string, s *PaneSub) {
+	for i := 0; i < cap(s.ch); i++ {
+		cc.dispatch(paneID, []byte("x"))
+	}
+}
+
+func TestDropMarksDirtyAndDiscardsStaleBuffer(t *testing.T) {
+	cc := NewControlClient("test")
+	sub := cc.Subscribe("%1")
+
+	fillSub(cc, "%1", sub)
+	cc.dispatch("%1", []byte("this one cannot fit"))
+
+	ev := <-sub.C()
+	if !ev.Dirty {
+		t.Fatalf("first event after a drop = %+v, want Dirty", ev)
+	}
+	if len(sub.C()) != 0 {
+		t.Fatalf("%d stale events survived the drop, want 0", len(sub.C()))
+	}
+}
+
+func TestDirtySuppressesDeliveryUntilAcked(t *testing.T) {
+	cc := NewControlClient("test")
+	sub := cc.Subscribe("%1")
+
+	fillSub(cc, "%1", sub)
+	cc.dispatch("%1", []byte("overflow"))
+	<-sub.C() // consume the Dirty marker
+
+	cc.dispatch("%1", []byte("still suppressed"))
+	if len(sub.C()) != 0 {
+		t.Fatal("delivered output while dirty; subscriber has not re-seeded yet")
+	}
+
+	cc.AckReseed(sub)
+	cc.dispatch("%1", []byte("after reseed"))
+
+	ev := <-sub.C()
+	if string(ev.Data) != "after reseed" {
+		t.Fatalf("got %q, want %q", ev.Data, "after reseed")
+	}
+}
+
+func TestDropOnOneSubscriberDoesNotAffectAnother(t *testing.T) {
+	cc := NewControlClient("test")
+	slow := cc.Subscribe("%1")
+	fast := cc.Subscribe("%1")
+
+	fillSub(cc, "%1", slow) // also fills fast; drain fast so it has room
+	for len(fast.C()) > 0 {
+		<-fast.C()
+	}
+
+	cc.dispatch("%1", []byte("live"))
+
+	if ev := <-slow.C(); !ev.Dirty {
+		t.Fatalf("slow subscriber = %+v, want Dirty", ev)
+	}
+	if ev := <-fast.C(); ev.Dirty {
+		t.Fatal("fast subscriber was marked dirty by its neighbour's drop")
+	}
+}

--- a/tmux/control_client_test.go
+++ b/tmux/control_client_test.go
@@ -104,6 +104,39 @@ func TestDirtySuppressesDeliveryUntilAcked(t *testing.T) {
 	}
 }
 
+func TestMarkPendingReseedReArmsExactlyOnce(t *testing.T) {
+	cc := NewControlClient("test")
+	sub := cc.Subscribe("%1")
+
+	// Drive the subscriber dirty, then consume the marker the way the
+	// WebSocket write loop's coalescing branch does.
+	fillSub(cc, "%1", sub)
+	cc.dispatch("%1", []byte("overflow"))
+	if ev := <-sub.C(); !ev.Dirty {
+		t.Fatalf("setup: expected Dirty, got %+v", ev)
+	}
+
+	cc.MarkPendingReseed(sub)
+
+	if got := len(sub.C()); got != 1 {
+		t.Fatalf("after re-arm, %d events queued, want exactly 1", got)
+	}
+	if ev := <-sub.C(); !ev.Dirty {
+		t.Fatalf("re-armed event = %+v, want Dirty", ev)
+	}
+
+	// Still suppressed until the consumer acks.
+	cc.dispatch("%1", []byte("suppressed"))
+	if len(sub.C()) != 0 {
+		t.Fatal("delivered output while still dirty")
+	}
+	cc.AckReseed(sub)
+	cc.dispatch("%1", []byte("after ack"))
+	if ev := <-sub.C(); string(ev.Data) != "after ack" {
+		t.Fatalf("got %q, want %q", ev.Data, "after ack")
+	}
+}
+
 func TestDropOnOneSubscriberDoesNotAffectAnother(t *testing.T) {
 	cc := NewControlClient("test")
 	slow := cc.Subscribe("%1")

--- a/tmux/control_client_test.go
+++ b/tmux/control_client_test.go
@@ -1,6 +1,10 @@
 package tmux
 
-import "testing"
+import (
+	"bufio"
+	"strings"
+	"testing"
+)
 
 func TestSubscribeDeliversOutput(t *testing.T) {
 	cc := NewControlClient("test")
@@ -113,5 +117,47 @@ func TestDropOnOneSubscriberDoesNotAffectAnother(t *testing.T) {
 	}
 	if ev := <-fast.C(); ev.Dirty {
 		t.Fatal("fast subscriber was marked dirty by its neighbour's drop")
+	}
+}
+
+// feed runs the read loop over a canned control-mode transcript.
+func feed(cc *ControlClient, transcript string) {
+	cc.readLoop(bufio.NewReader(strings.NewReader(transcript)))
+}
+
+func TestPauseMarksDirty(t *testing.T) {
+	cc := NewControlClient("test")
+	sub := cc.Subscribe("%1")
+
+	feed(cc, "%output %1 before\\015\\012\n%pause %1\n")
+
+	if ev := <-sub.C(); ev.Dirty {
+		t.Fatal("marked dirty before the pause arrived")
+	}
+	ev := <-sub.C()
+	if !ev.Dirty {
+		t.Fatalf("event after %%pause = %+v, want Dirty", ev)
+	}
+}
+
+func TestContinueDoesNotMarkDirty(t *testing.T) {
+	cc := NewControlClient("test")
+	sub := cc.Subscribe("%1")
+
+	feed(cc, "%continue %1\n")
+
+	if len(sub.C()) != 0 {
+		t.Fatal("continue marked the pane dirty; only pause may")
+	}
+}
+
+func TestPauseOnAnotherPaneIsIgnored(t *testing.T) {
+	cc := NewControlClient("test")
+	sub := cc.Subscribe("%1")
+
+	feed(cc, "%pause %2\n")
+
+	if len(sub.C()) != 0 {
+		t.Fatal("a pause on %2 marked %1 dirty")
 	}
 }

--- a/tmux/control_client_test.go
+++ b/tmux/control_client_test.go
@@ -190,12 +190,17 @@ func TestContinueDoesNotMarkDirty(t *testing.T) {
 
 func TestPauseOnAnotherPaneIsIgnored(t *testing.T) {
 	cc := NewControlClient("test")
-	sub := cc.Subscribe("%1")
+	other := cc.Subscribe("%2")
+	mine := cc.Subscribe("%1")
 
 	feed(cc, "%pause %2\n")
 
-	if len(sub.C()) != 0 {
-		t.Fatal("a pause on %2 marked %1 dirty")
+	ev := <-other.C()
+	if !ev.Dirty {
+		t.Fatalf("subscriber on the paused pane got %+v, want Dirty", ev)
+	}
+	if len(mine.C()) != 0 {
+		t.Fatalf("a pause on %%2 marked %%1 dirty (%d events)", len(mine.C()))
 	}
 }
 
@@ -310,7 +315,7 @@ func TestCloseDuringDialDoesNotLeak(t *testing.T) {
 	cc.backoff = time.Millisecond
 	cc.dial = func() (io.ReadCloser, io.Writer, func() error, error) {
 		if first {
-			first = false // dial() is only ever called from supervise, one goroutine
+			first = false // this first dial is Start()'s own call; every later one runs in supervise's goroutine, so the two never race
 			return io.NopCloser(strings.NewReader("")), io.Discard,
 				func() error { return nil }, nil
 		}

--- a/tmux/control_client_test.go
+++ b/tmux/control_client_test.go
@@ -131,12 +131,12 @@ func TestPauseMarksDirty(t *testing.T) {
 
 	feed(cc, "%output %1 before\\015\\012\n%pause %1\n")
 
-	if ev := <-sub.C(); ev.Dirty {
-		t.Fatal("marked dirty before the pause arrived")
-	}
 	ev := <-sub.C()
 	if !ev.Dirty {
-		t.Fatalf("event after %%pause = %+v, want Dirty", ev)
+		t.Fatalf("first event after %%pause = %+v, want Dirty", ev)
+	}
+	if len(sub.C()) != 0 {
+		t.Fatalf("%d events survived the pause, want 0 — the backlog is discarded", len(sub.C()))
 	}
 }
 

--- a/tmux/control_client_test.go
+++ b/tmux/control_client_test.go
@@ -1,0 +1,52 @@
+package tmux
+
+import "testing"
+
+func TestSubscribeDeliversOutput(t *testing.T) {
+	cc := NewControlClient("test")
+	sub := cc.Subscribe("%1")
+
+	cc.dispatch("%1", []byte("hello"))
+
+	select {
+	case ev := <-sub.C():
+		if ev.Dirty {
+			t.Fatalf("got dirty event, want data")
+		}
+		if string(ev.Data) != "hello" {
+			t.Fatalf("got %q, want %q", ev.Data, "hello")
+		}
+	default:
+		t.Fatal("no event delivered")
+	}
+}
+
+func TestUnsubscribeStopsDelivery(t *testing.T) {
+	cc := NewControlClient("test")
+	sub := cc.Subscribe("%1")
+	cc.Unsubscribe("%1", sub)
+
+	cc.dispatch("%1", []byte("hello"))
+
+	select {
+	case ev := <-sub.C():
+		t.Fatalf("got event %+v after unsubscribe", ev)
+	default:
+	}
+}
+
+func TestUnsubscribeRemovesOnlyThatSubscriber(t *testing.T) {
+	cc := NewControlClient("test")
+	a := cc.Subscribe("%1")
+	b := cc.Subscribe("%1")
+	cc.Unsubscribe("%1", a)
+
+	cc.dispatch("%1", []byte("hello"))
+
+	if len(a.C()) != 0 {
+		t.Fatal("unsubscribed handle still received output")
+	}
+	if len(b.C()) != 1 {
+		t.Fatalf("remaining subscriber got %d events, want 1", len(b.C()))
+	}
+}

--- a/tmux/control_client_test.go
+++ b/tmux/control_client_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -262,5 +263,76 @@ func TestCloseFiresDone(t *testing.T) {
 	case <-cc.Done():
 	case <-time.After(time.Second):
 		t.Fatal("Done() did not fire after Close()")
+	}
+}
+
+func TestCloseDuringDialDoesNotLeak(t *testing.T) {
+	dialStarted := make(chan struct{})
+	release := make(chan struct{})
+	closedConn := make(chan struct{}, 1)
+	var once sync.Once
+	first := true
+
+	cc := NewControlClient("test")
+	cc.backoff = time.Millisecond
+	cc.dial = func() (io.ReadCloser, io.Writer, func() error, error) {
+		if first {
+			first = false // dial() is only ever called from supervise, one goroutine
+			return io.NopCloser(strings.NewReader("")), io.Discard,
+				func() error { return nil }, nil
+		}
+		once.Do(func() { close(dialStarted) })
+		<-release // hold this dial in flight until the test has called Close()
+		return io.NopCloser(strings.NewReader("")), io.Discard,
+			func() error { closedConn <- struct{}{}; return nil }, nil
+	}
+
+	if err := cc.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	<-dialStarted
+	_ = cc.Close()
+	close(release)
+
+	select {
+	case <-closedConn:
+	case <-time.After(2 * time.Second):
+		t.Fatal("connection dialled during Close() was never closed — leaked")
+	}
+	select {
+	case <-cc.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("Done() never fired after Close()")
+	}
+}
+
+func TestReconnectBacksOffWhenConnectionsDieImmediately(t *testing.T) {
+	var dials int32
+
+	cc := NewControlClient("test")
+	cc.backoff = 20 * time.Millisecond
+	cc.dial = func() (io.ReadCloser, io.Writer, func() error, error) {
+		atomic.AddInt32(&dials, 1)
+		// dial succeeds, but the connection is dead on arrival
+		return io.NopCloser(strings.NewReader("")), io.Discard,
+			func() error { return nil }, nil
+	}
+
+	if err := cc.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = cc.Close() }()
+
+	time.Sleep(300 * time.Millisecond)
+
+	n := atomic.LoadInt32(&dials)
+	// 20ms doubling gives roughly 20+40+80+160 -> about 5 dials in 300ms.
+	// With no backoff on this path it would be thousands.
+	if n > 12 {
+		t.Fatalf("dialled %d times in 300ms — reconnect is hot-spinning", n)
+	}
+	if n < 2 {
+		t.Fatalf("dialled %d times — never retried at all", n)
 	}
 }

--- a/tmux/control_integration_test.go
+++ b/tmux/control_integration_test.go
@@ -36,8 +36,8 @@ func TestControlClientIntegration(t *testing.T) {
 	defer func() { _ = cc.Close() }()
 
 	// Subscribe to pane output
-	ch := cc.Subscribe(paneID)
-	defer cc.Unsubscribe(paneID, ch)
+	sub := cc.Subscribe(paneID)
+	defer cc.Unsubscribe(paneID, sub)
 
 	// Send keys via control client
 	if err := cc.SendKeys(paneID, "echo hello-control-mode"); err != nil {
@@ -53,8 +53,8 @@ func TestControlClientIntegration(t *testing.T) {
 	var received string
 	for {
 		select {
-		case data := <-ch:
-			received += string(data)
+		case ev := <-sub.C():
+			received += string(ev.Data)
 			if strings.Contains(received, "hello-control-mode") {
 				return // success
 			}

--- a/tmux/control_manager.go
+++ b/tmux/control_manager.go
@@ -42,13 +42,13 @@ func (m *ControlManager) GetClient(session string) (*ControlClient, error) {
 	m.clients[session] = &managedClient{client: cc, refCount: 1}
 	slog.Info("started control client", "session", session)
 
-	// Monitor for unexpected exit
+	// The client reconnects on its own; Done() now fires only on Close.
 	go func() {
 		<-cc.Done()
 		m.mu.Lock()
 		delete(m.clients, session)
 		m.mu.Unlock()
-		slog.Info("control client exited", "session", session)
+		slog.Info("control client closed", "session", session)
 	}()
 
 	return cc, nil


### PR DESCRIPTION
Closes the transport-correctness half of #2. Design spec and implementation plan are
included as the first two commits; the agent-run model, Mocha shell, federation and
dispatch integration are follow-up milestones.

## What was broken

houston holds one `tmux -CC` control-mode connection per session and fans pane output
out to browser WebSockets. Three defects, all of which surface as a terminal that is
silently wrong rather than one that visibly fails:

1. **A dropped output chunk was discarded silently.** A drop can cut a terminal escape
   sequence in half, corrupting every glyph rendered afterwards, and the pane stayed
   wrong until the socket was reopened. The subscriber most likely to be slow is a
   phone on bad LTE — houston's entire premise.
2. **A tmux-initiated `%pause` was ignored.** tmux discards output while a pane is
   paused, so resuming painted on top of a hole.
3. **A dropped connection killed every attached socket.** `ControlManager` deleted the
   client on `Done()` and never re-dialled, so one `tmux kill-server` or server restart
   took out every open pane.

## The mechanism

A pane subscription now carries typed `PaneEvent`s instead of raw bytes. Any gap in the
stream — a drop, a `%pause`, or a reconnect — is signalled **in band** as a `Dirty`
event, so the consumer re-seeds from `capture-pane` at exactly the right point in the
sequence rather than painting over the hole. Delivery to a dirty subscriber is
suppressed until it acks, which is what makes the gap impossible to miss.

In-band matters: with a separate notification channel you race the re-seed against the
bytes that follow it and can paint stale output over a fresh seed.

Reconnection moved **inside** `ControlClient`, so the subscription map survives a
re-dial and existing handles stay valid. `Done()` now fires only on explicit `Close()`,
never on a transport drop — a browser socket has to survive a reconnect.

## What houston deliberately does *not* do

`refresh-client -f ignore-size` stays, and is re-asserted on every reconnect. A human is
attached to the same pane in a real terminal, and N browser viewers at different widths
cannot all own one size, so houston renounces size authority and the client absorbs the
mismatch. This is the opposite of what lazytmux's bridge does, and the difference is
intentional: it mirrors into real local panes that must match; houston does not.

## Found during review, beyond the spec

Seven defects that the spec did not anticipate, none of which the test suite would have
caught:

| Defect | Consequence |
|---|---|
| `Close()` racing an in-flight `dial()` | leaked a subprocess, a PTY and two goroutines |
| Backoff wired only to the `dial()`-error path | **99,015 reconnect attempts in 300ms** when a session was gone but the server was up — the exact case this branch targets |
| `RunCommand` selecting only on `cc.done` | blocked for a whole outage holding `cmdMu`; `handlePaneWS`'s deferred cleanup runs `RunCommand` *before* `ReleaseClient`, so the wedge prevented the `Close()` that would release it |
| `supervise` closing the reader, not the connection | `cmd.Wait()` never ran — one zombie `tmux -CC` per reconnect, unbounded |
| Killing the child politely | `cmd.Wait()` blocked ~10s while the client noticed its closed PTY, stalling shutdown per session |
| Ack after the WebSocket write | output produced during the seed write was dropped and never repainted |
| `gone` published after the stdin swap | a landed command could report "connection lost", leaving a pane paused with nothing to resume it — frozen session-wide while the status badge kept updating |

## Testing

`go build ./...` clean, `go test ./...` green across all 11 packages, and
`go test ./tmux/... -race -count=3` clean in 2.8s with zero zombies.

The two reconnect regression tests were **falsified against the pre-fix commit** in a
throwaway worktree to confirm they are real nets rather than decoration — the hot-spin
one reports `dialled 99015 times in 300ms`.

The 10s shutdown stall was caught by comparing wall-clock against a baseline, not by a
failing test: `TestControlManagerGetClient` went 0.03s → 10.04s while the suite stayed
green.

## Known follow-ups, deliberately not in this PR

- **Defect 2 is only partially closed.** `%pause` correctly gates delivery, but the
  re-seed lands at the *start* of the gap rather than the end, so output tmux discards
  during a pause is still missing. Dormant today: nothing sets `pause-after`, whose
  default is 0, and `refresh-client -A %N:pause` sets a per-pane flag rather than that
  option — so tmux never initiates a pause for houston's client. Closing it properly
  needs an expected-continue counter plus a resume path that cannot live in `readLoop`
  (calling `RunCommand` from there would deadlock). That is a spec decision.
- **`server/agents_test.go:90` has a genuine data race** under `-race`, over
  `httptest.ResponseRecorder`. It predates this branch — that test exercises the hub SSE
  path and never constructs a `ControlClient` — and it passes without `-race`, which is
  why it was invisible. Not fixed here because a follow-up milestone deletes
  `/api/agents` and its stream outright. Flagged so it is not re-reported as new.
- `Connected()` has no callers; it is a deliberate seam for the milestone that marks
  runs stale when a federated peer goes quiet.
- `SubscriberCount()` has no non-test callers, and `metaPollLoop` leaks a goroutine
  forking `capture-pane` once a second when a second socket holds the client reference.
  Both pre-existing, both untouched here.
- No `server/` test exists for `pane_ws` at all, which is why the ack-ordering defect
  survived five green reviews. Covering it needs a WebSocket + tmux harness.

## Not verified live

The plan's manual verification step called for `tmux kill-server` to force a reconnect.
That was **not run**: houston's development environment is the same tmux server running
these sessions, so it would have destroyed all of them. Reconnect behaviour is covered
by four unit tests instead, two of them falsified against the buggy code.

https://claude.ai/code/session_01S3QQF9tpsskteWqRJN3Hn6
