### PR TITLE
fix(server): require an API token, check origins, and pin Host

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,7 +224,18 @@ The pane WebSocket (`/api/pane/:target/ws`) is bidirectional:
 
 ## Security
 
-**No built-in auth** — rely on network-level security:
+**Token-gated API.** On first run houston generates a random token into
+`<status-dir>/token` (`0600`). Every `/api/` request must present it as the
+`houston_token` cookie, an `Authorization: Bearer` header, or a `?token=` query
+parameter (the last is for WebSockets, which can't set headers). Loading the
+SPA issues the cookie as an httpOnly response cookie, so a browser that has
+opened the UI once authenticates transparently on every subsequent call.
+Requests are also checked against an origin allowlist — same-origin plus the
+Vite dev server under `-debug` — covering both the HTTP API and the WebSocket
+handshake, so a page from another origin is refused even with a valid token.
+Pass `-no-auth` to disable the token check entirely (not recommended).
+
+This token model is the primary defense; the following are additional layers:
 1. Default bind: `127.0.0.1:9090` (localhost only)
 2. Access via Tailscale (recommended)
 3. Or SSH tunnel: `ssh -L 9090:localhost:9090 host`

--- a/docs/superpowers/plans/2026-09-08-api-auth-and-origin-hardening.md
+++ b/docs/superpowers/plans/2026-09-08-api-auth-and-origin-hardening.md
@@ -1,0 +1,881 @@
+# API auth and origin hardening — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the unauthenticated remote-execution surface on houston's API — any web page that can route to the server can currently read every agent session and send arbitrary keystrokes into any tmux pane.
+
+**Architecture:** A bearer token generated on first run into the state dir, delivered to the SPA as an httpOnly cookie when the server serves `index.html`, and required by every `/api/` route. Origin checking (CORS headers and the WebSocket `CheckOrigin`) becomes an explicit allowlist instead of `*`/`true`. The SPA needs no changes at all: every call it makes is a same-origin relative path, so the browser attaches the cookie automatically to `fetch`, `EventSource` and `WebSocket` alike.
+
+**Tech Stack:** Go stdlib only (`crypto/rand`, `crypto/subtle`, `encoding/hex`, `net/http`). `github.com/gorilla/websocket` is already present. No new dependencies, no frontend changes.
+
+**Spec:** `docs/superpowers/specs/2026-09-07-houston-overhaul-design.md` — section "Auth".
+
+## Global Constraints
+
+- **No new dependencies.** This repo has exactly one non-stdlib dependency
+  (`github.com/gorilla/websocket`). Add nothing.
+- **No frontend changes.** `ui/` is untouched by this plan. Every call site is
+  already a same-origin relative path (`ui/src/hooks/useSessionsStream.ts:10`,
+  `useAgentsStream.ts:25`, `usePaneSocket.ts:56`,
+  `components/MobileInputBar.tsx:45,54,180`).
+- **Auth defaults ON.** `-no-auth` exists as an explicit opt-out and must log a
+  warning when used.
+- **The token file is `0600`** and lives in the state dir. It is never logged at
+  info level and never included in an error returned to a client.
+- **Tests:** `go test ./server/... -race` from the repo root. NOTE: the server
+  package has a PRE-EXISTING data race at `server/agents_test.go:90` over
+  `httptest.ResponseRecorder`. It fails under `-race` and predates this work. Run
+  `go test ./server/...` WITHOUT `-race` as your gate, and `-race` only with
+  `-run` scoped to your own tests.
+- **`go build ./...` needs `ui/dist`**, which is gitignored. If it is absent in
+  your worktree, build `./server/...` instead — do not run `just ui-build`.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `server/auth.go` | Token load/generate, origin allowlist, auth middleware | **Create** |
+| `server/auth_test.go` | Unit tests for all three | **Create** |
+| `server/server.go` | Config fields, `New` wiring, `Handler` route mounting, cookie on `index.html` | Modify |
+| `server/api.go` | `corsMiddleware` → allowlist-aware | Modify |
+| `server/pane_ws.go` | package-level `upgrader` → per-server, real `CheckOrigin` | Modify |
+| `main.go` | `-no-auth` flag, allowlist construction, startup logging | Modify |
+| `CLAUDE.md` | Security section is now wrong; correct it | Modify |
+
+`auth.go` is a new file rather than additions to `api.go` because it is a
+self-contained concern with its own test surface, and `api.go` is already the
+grab-bag handler file.
+
+---
+
+### Task 1: Token store
+
+**Files:**
+- Create: `server/auth.go`
+- Test: `server/auth_test.go`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `func LoadOrCreateToken(stateDir string) (string, error)`
+  - `func tokenMatches(want, got string) bool`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server/auth_test.go`:
+
+```go
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadOrCreateTokenGeneratesAndPersists(t *testing.T) {
+	dir := t.TempDir()
+
+	first, err := LoadOrCreateToken(dir)
+	if err != nil {
+		t.Fatalf("LoadOrCreateToken: %v", err)
+	}
+	if len(first) != 64 {
+		t.Fatalf("token length %d, want 64 hex chars", len(first))
+	}
+	if strings.TrimSpace(first) != first {
+		t.Fatalf("token has surrounding whitespace: %q", first)
+	}
+
+	second, err := LoadOrCreateToken(dir)
+	if err != nil {
+		t.Fatalf("second LoadOrCreateToken: %v", err)
+	}
+	if second != first {
+		t.Fatalf("token not persisted: %q then %q", first, second)
+	}
+}
+
+func TestLoadOrCreateTokenFileIsPrivate(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := LoadOrCreateToken(dir); err != nil {
+		t.Fatalf("LoadOrCreateToken: %v", err)
+	}
+
+	info, err := os.Stat(filepath.Join(dir, "token"))
+	if err != nil {
+		t.Fatalf("stat token: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("token file mode %o, want 600", perm)
+	}
+}
+
+func TestLoadOrCreateTokenToleratesTrailingNewline(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "token"), []byte("deadbeef\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := LoadOrCreateToken(dir)
+	if err != nil {
+		t.Fatalf("LoadOrCreateToken: %v", err)
+	}
+	if got != "deadbeef" {
+		t.Fatalf("got %q, want %q — an editor-added newline must not change the token", got, "deadbeef")
+	}
+}
+
+func TestTokenMatches(t *testing.T) {
+	if !tokenMatches("abc123", "abc123") {
+		t.Error("identical tokens did not match")
+	}
+	if tokenMatches("abc123", "abc124") {
+		t.Error("different tokens matched")
+	}
+	if tokenMatches("abc123", "") {
+		t.Error("empty presented token matched")
+	}
+	if tokenMatches("", "abc123") {
+		t.Error("empty expected token matched — that would disable auth")
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./server/ -run 'TestLoadOrCreateToken|TestTokenMatches' -v`
+Expected: FAIL to compile — `undefined: LoadOrCreateToken`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `server/auth.go`:
+
+```go
+package server
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// tokenFile is the state-dir-relative path of the API token.
+const tokenFile = "token"
+
+// LoadOrCreateToken returns the API token for this state dir, generating one on
+// first run. The file is 0600: anyone who can read it can drive every tmux pane
+// this server can reach.
+func LoadOrCreateToken(stateDir string) (string, error) {
+	path := filepath.Join(stateDir, tokenFile)
+
+	b, err := os.ReadFile(path)
+	switch {
+	case err == nil:
+		tok := strings.TrimSpace(string(b))
+		if tok == "" {
+			return "", fmt.Errorf("token file %s is empty; delete it to regenerate", path)
+		}
+		return tok, nil
+	case !errors.Is(err, fs.ErrNotExist):
+		return "", fmt.Errorf("read token: %w", err)
+	}
+
+	raw := make([]byte, 32)
+	if _, err := rand.Read(raw); err != nil {
+		return "", fmt.Errorf("generate token: %w", err)
+	}
+	tok := hex.EncodeToString(raw)
+
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		return "", fmt.Errorf("create state dir: %w", err)
+	}
+	if err := os.WriteFile(path, []byte(tok+"\n"), 0o600); err != nil {
+		return "", fmt.Errorf("write token: %w", err)
+	}
+	return tok, nil
+}
+
+// tokenMatches compares in constant time. An empty expected token never
+// matches, so a misconfiguration fails closed rather than open.
+func tokenMatches(want, got string) bool {
+	if want == "" || got == "" {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(want), []byte(got)) == 1
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `go test ./server/ -run 'TestLoadOrCreateToken|TestTokenMatches' -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/auth.go server/auth_test.go
+git commit -m "feat(server): generate and persist an API token"
+```
+
+---
+
+### Task 2: Origin allowlist
+
+Replaces `Access-Control-Allow-Origin: *` (`server/api.go`) and the WebSocket
+`CheckOrigin` that returns `true` unconditionally (`server/pane_ws.go`).
+
+A browser always sends `Origin` on a WebSocket handshake and on cross-origin
+`fetch`. A request with no `Origin` is therefore not a browser being used as a
+confused deputy — it is `curl` or a native client, and the token is what gates
+it. So: absent `Origin` is allowed; a present one must be same-origin or
+allowlisted.
+
+**Files:**
+- Modify: `server/auth.go`
+- Test: `server/auth_test.go`
+
+**Interfaces:**
+- Consumes: nothing from Task 1.
+- Produces: `func originAllowed(r *http.Request, allowed []string) bool`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `server/auth_test.go` (merge `net/http` and `net/http/httptest` into the
+existing import block — do NOT add a second `import` block, it will not compile):
+
+```go
+func reqWithOrigin(host, origin string) *http.Request {
+	r := httptest.NewRequest("GET", "http://"+host+"/api/runs", nil)
+	r.Host = host
+	if origin != "" {
+		r.Header.Set("Origin", origin)
+	}
+	return r
+}
+
+func TestOriginAllowed(t *testing.T) {
+	allowed := []string{"http://localhost:5173"}
+
+	tests := []struct {
+		name   string
+		host   string
+		origin string
+		want   bool
+	}{
+		{"no origin is a non-browser client", "halo:9090", "", true},
+		{"same origin", "halo:9090", "http://halo:9090", true},
+		{"same origin over https", "halo:9090", "https://halo:9090", true},
+		{"explicitly allowlisted", "halo:9090", "http://localhost:5173", true},
+		{"different host", "halo:9090", "http://evil.example", false},
+		{"different port on same host", "halo:9090", "http://halo:9091", false},
+		{"port-less origin against ported host", "halo:9090", "http://halo", false},
+		{"null origin from a sandboxed frame", "halo:9090", "null", false},
+		{"prefix of an allowed origin", "halo:9090", "http://localhost:51739", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := originAllowed(reqWithOrigin(tc.host, tc.origin), allowed); got != tc.want {
+				t.Fatalf("originAllowed(host=%q, origin=%q) = %v, want %v",
+					tc.host, tc.origin, got, tc.want)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./server/ -run TestOriginAllowed -v`
+Expected: FAIL to compile — `undefined: originAllowed`.
+
+- [ ] **Step 3: Write the implementation**
+
+Add to `server/auth.go` (and add `"net/http"` and `"net/url"` to its imports):
+
+```go
+// originAllowed reports whether a request's Origin may talk to this server.
+//
+// A browser always sends Origin on a WebSocket handshake and on a cross-origin
+// fetch, so an absent Origin means a non-browser client (curl, a native app) —
+// those are gated by the token, not by this check. A present Origin must match
+// the request's own host or appear in allowed.
+func originAllowed(r *http.Request, allowed []string) bool {
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		return true
+	}
+
+	u, err := url.Parse(origin)
+	if err != nil || u.Host == "" {
+		return false // includes the literal "null" a sandboxed frame sends
+	}
+	if u.Host == r.Host {
+		return true
+	}
+	for _, a := range allowed {
+		if a == origin {
+			return true
+		}
+	}
+	return false
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `go test ./server/ -run TestOriginAllowed -v`
+Expected: PASS, all nine subtests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/auth.go server/auth_test.go
+git commit -m "feat(server): allowlist-based origin checking"
+```
+
+---
+
+### Task 3: Auth middleware and cookie issuance
+
+**Files:**
+- Modify: `server/auth.go`
+- Test: `server/auth_test.go`
+
+**Interfaces:**
+- Consumes: `tokenMatches` (Task 1), `originAllowed` (Task 2).
+- Produces:
+  - `const authCookie = "houston_token"`
+  - `func (a *authGate) middleware(next http.Handler) http.Handler`
+  - `func (a *authGate) setCookie(w http.ResponseWriter)`
+  - `type authGate struct { token string; allowedOrigins []string; enabled bool }`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `server/auth_test.go`:
+
+```go
+func okHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+}
+
+func TestMiddlewareRejectsWithoutToken(t *testing.T) {
+	a := &authGate{token: "secret", enabled: true}
+	rec := httptest.NewRecorder()
+
+	a.middleware(okHandler()).ServeHTTP(rec, reqWithOrigin("halo:9090", ""))
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status %d, want 401", rec.Code)
+	}
+	if strings.Contains(rec.Body.String(), "secret") {
+		t.Fatal("the response body leaked the token")
+	}
+}
+
+func TestMiddlewareAcceptsCookieBearerAndQuery(t *testing.T) {
+	a := &authGate{token: "secret", enabled: true}
+
+	cookieReq := reqWithOrigin("halo:9090", "")
+	cookieReq.AddCookie(&http.Cookie{Name: authCookie, Value: "secret"})
+
+	bearerReq := reqWithOrigin("halo:9090", "")
+	bearerReq.Header.Set("Authorization", "Bearer secret")
+
+	queryReq := httptest.NewRequest("GET", "http://halo:9090/api/runs?token=secret", nil)
+	queryReq.Host = "halo:9090"
+
+	for name, r := range map[string]*http.Request{
+		"cookie": cookieReq,
+		"bearer": bearerReq,
+		"query":  queryReq,
+	} {
+		t.Run(name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			a.middleware(okHandler()).ServeHTTP(rec, r)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status %d, want 200", rec.Code)
+			}
+		})
+	}
+}
+
+func TestMiddlewareRejectsBadOriginEvenWithValidToken(t *testing.T) {
+	a := &authGate{token: "secret", enabled: true}
+	r := reqWithOrigin("halo:9090", "http://evil.example")
+	r.AddCookie(&http.Cookie{Name: authCookie, Value: "secret"})
+
+	rec := httptest.NewRecorder()
+	a.middleware(okHandler()).ServeHTTP(rec, r)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status %d, want 403 — a valid token from a hostile page must still be refused", rec.Code)
+	}
+}
+
+func TestMiddlewareDisabledAllowsEverything(t *testing.T) {
+	a := &authGate{enabled: false}
+	rec := httptest.NewRecorder()
+
+	a.middleware(okHandler()).ServeHTTP(rec, reqWithOrigin("halo:9090", "http://evil.example"))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d, want 200 when auth is disabled", rec.Code)
+	}
+}
+
+func TestCORSHeadersOnlyForAllowedOrigin(t *testing.T) {
+	a := &authGate{token: "secret", enabled: true, allowedOrigins: []string{"http://localhost:5173"}}
+
+	good := reqWithOrigin("halo:9090", "http://localhost:5173")
+	good.AddCookie(&http.Cookie{Name: authCookie, Value: "secret"})
+	goodRec := httptest.NewRecorder()
+	a.middleware(okHandler()).ServeHTTP(goodRec, good)
+
+	if got := goodRec.Header().Get("Access-Control-Allow-Origin"); got != "http://localhost:5173" {
+		t.Fatalf("Allow-Origin = %q, want the echoed allowed origin", got)
+	}
+	if got := goodRec.Header().Get("Access-Control-Allow-Credentials"); got != "true" {
+		t.Fatalf("Allow-Credentials = %q, want true — the cookie must be sent cross-origin in dev", got)
+	}
+
+	bad := reqWithOrigin("halo:9090", "http://evil.example")
+	badRec := httptest.NewRecorder()
+	a.middleware(okHandler()).ServeHTTP(badRec, bad)
+
+	if got := badRec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Fatalf("Allow-Origin = %q for a rejected origin, want empty", got)
+	}
+}
+
+func TestSetCookieIsHttpOnly(t *testing.T) {
+	a := &authGate{token: "secret", enabled: true}
+	rec := httptest.NewRecorder()
+
+	a.setCookie(rec)
+
+	cookies := rec.Result().Cookies()
+	if len(cookies) != 1 {
+		t.Fatalf("%d cookies set, want 1", len(cookies))
+	}
+	c := cookies[0]
+	if c.Name != authCookie || c.Value != "secret" {
+		t.Fatalf("cookie = %s=%s, want %s=secret", c.Name, c.Value, authCookie)
+	}
+	if !c.HttpOnly {
+		t.Error("cookie is not HttpOnly — script on the page could read the token")
+	}
+	if c.SameSite != http.SameSiteStrictMode {
+		t.Error("cookie is not SameSite=Strict")
+	}
+	if c.Path != "/" {
+		t.Errorf("cookie path %q, want /", c.Path)
+	}
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `go test ./server/ -run 'TestMiddleware|TestCORS|TestSetCookie' -v`
+Expected: FAIL to compile — `undefined: authGate`.
+
+- [ ] **Step 3: Write the implementation**
+
+Add to `server/auth.go`:
+
+```go
+// authCookie is the httpOnly cookie the SPA is issued when it loads. Every UI
+// call is a same-origin relative path, so the browser attaches it to fetch,
+// EventSource and WebSocket alike without any frontend involvement.
+const authCookie = "houston_token"
+
+// authGate guards /api/. Disabled, it is a pass-through, which is what
+// -no-auth selects.
+type authGate struct {
+	token          string
+	allowedOrigins []string
+	enabled        bool
+}
+
+// presentedToken pulls the token from the three places a client can put it.
+// A browser WebSocket cannot set headers, which is why the query parameter
+// exists; same-origin sockets use the cookie and never need it.
+func presentedToken(r *http.Request) string {
+	if c, err := r.Cookie(authCookie); err == nil && c.Value != "" {
+		return c.Value
+	}
+	if h := r.Header.Get("Authorization"); strings.HasPrefix(h, "Bearer ") {
+		return strings.TrimPrefix(h, "Bearer ")
+	}
+	return r.URL.Query().Get("token")
+}
+
+func (a *authGate) middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !a.enabled {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		if !originAllowed(r, a.allowedOrigins) {
+			http.Error(w, "forbidden origin", http.StatusForbidden)
+			return
+		}
+
+		// Echo the origin only once it is known-good, and only when it is
+		// genuinely cross-origin; same-origin requests need no CORS headers.
+		if origin := r.Header.Get("Origin"); origin != "" && origin != "http://"+r.Host && origin != "https://"+r.Host {
+			w.Header().Set("Access-Control-Allow-Origin", origin)
+			w.Header().Set("Access-Control-Allow-Credentials", "true")
+			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+		}
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
+		if !tokenMatches(a.token, presentedToken(r)) {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// setCookie issues the token to a browser loading the SPA.
+func (a *authGate) setCookie(w http.ResponseWriter) {
+	if !a.enabled {
+		return
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     authCookie,
+		Value:    a.token,
+		Path:     "/",
+		HttpOnly: true,
+		SameSite: http.SameSiteStrictMode,
+	})
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `go test ./server/ -run 'TestMiddleware|TestCORS|TestSetCookie' -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run the whole auth suite**
+
+Run: `go test ./server/ -run 'TestLoadOrCreateToken|TestTokenMatches|TestOriginAllowed|TestMiddleware|TestCORS|TestSetCookie' -race -v`
+Expected: PASS. (`-race` is safe here because it is scoped away from the
+pre-existing `agents_test.go` race.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/auth.go server/auth_test.go
+git commit -m "feat(server): token auth middleware and SPA cookie issuance"
+```
+
+---
+
+### Task 4: Wire it in and correct the docs
+
+**Files:**
+- Modify: `server/server.go` (`Config`, `Server`, `New`, `Handler`, `SPAHandler`)
+- Modify: `server/api.go` (delete `corsMiddleware`)
+- Modify: `server/pane_ws.go` (package `upgrader` → per-server)
+- Modify: `main.go` (flag, allowlist, startup logging)
+- Modify: `CLAUDE.md` (the Security section is now wrong)
+- Test: `server/auth_test.go`
+
+**Interfaces:**
+- Consumes: `authGate`, `LoadOrCreateToken`, `originAllowed` from Tasks 1-3.
+- Produces: `Config.AuthEnabled`, `Config.AllowedOrigins`, `Server.auth`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `server/auth_test.go`:
+
+```go
+func TestSPAHandlerIssuesCookie(t *testing.T) {
+	a := &authGate{token: "secret", enabled: true}
+	rec := httptest.NewRecorder()
+
+	SPAHandler(nil, a).ServeHTTP(rec, httptest.NewRequest("GET", "/", nil))
+
+	found := false
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == authCookie {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("loading the SPA did not issue the auth cookie; the UI could never authenticate")
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./server/ -run TestSPAHandlerIssuesCookie -v`
+Expected: FAIL to compile — `too many arguments in call to SPAHandler`.
+
+- [ ] **Step 3: Wire the gate into the server**
+
+In `server/server.go`, add to `Config`:
+
+```go
+	// AuthEnabled gates /api/ behind the state-dir token. Disabled only by
+	// an explicit -no-auth.
+	AuthEnabled bool
+	// AllowedOrigins are extra origins permitted beyond same-origin, e.g. the
+	// Vite dev server.
+	AllowedOrigins []string
+```
+
+Add to the `Server` struct:
+
+```go
+	auth *authGate
+```
+
+In `New`, after the struct literal is built, load the token and build the gate:
+
+```go
+	gate := &authGate{enabled: cfg.AuthEnabled, allowedOrigins: cfg.AllowedOrigins}
+	if cfg.AuthEnabled {
+		tok, err := LoadOrCreateToken(cfg.StatusDir)
+		if err != nil {
+			return nil, fmt.Errorf("api token: %w", err)
+		}
+		gate.token = tok
+	}
+	s.auth = gate
+```
+
+(Add `"fmt"` to the imports if it is not already there.)
+
+Replace the body of `Handler` with the gate mounted on `/api/` and the SPA
+handler taking the gate:
+
+```go
+func (s *Server) Handler() http.Handler {
+	mux := http.NewServeMux()
+
+	if s.uiFS != nil {
+		mux.Handle("/", SPAHandler(s.uiFS, s.auth))
+	}
+
+	apiMux := http.NewServeMux()
+	apiMux.HandleFunc("/api/sessions", s.handleAPISessions)
+	apiMux.HandleFunc("/api/pane/", s.handleAPIPane)
+	apiMux.HandleFunc("/api/opencode/sessions", s.handleAPIOpenCodeSessions)
+	apiMux.HandleFunc("/api/opencode/session/", s.handleAPIOpenCodeSession)
+	apiMux.HandleFunc("/api/agents", s.handleAgentsSnapshot)
+	apiMux.HandleFunc("/api/agents/stream", s.handleAgentsStream)
+	mux.Handle("/api/", s.auth.middleware(apiMux))
+
+	return mux
+}
+```
+
+Change `SPAHandler` to take the gate and issue the cookie on every SPA response.
+It must tolerate a nil `uiFS` so the test above can call it:
+
+```go
+// SPAHandler serves the embedded SPA, falling back to index.html for
+// client-side routing. Every response issues the auth cookie, which is how the
+// browser comes to hold a token it can send on same-origin fetch, EventSource
+// and WebSocket calls.
+func SPAHandler(uiFS fs.FS, auth *authGate) http.Handler {
+	var fileServer http.Handler
+	if uiFS != nil {
+		fileServer = http.FileServer(http.FS(uiFS))
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth.setCookie(w)
+		if fileServer == nil {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		path := strings.TrimPrefix(r.URL.Path, "/")
+		if path == "" {
+			path = "index.html"
+		}
+		if _, err := fs.Stat(uiFS, path); err == nil {
+			fileServer.ServeHTTP(w, r)
+			return
+		}
+		r.URL.Path = "/"
+		fileServer.ServeHTTP(w, r)
+	})
+}
+```
+
+- [ ] **Step 4: Delete `corsMiddleware` and fix the WebSocket origin check**
+
+Delete `corsMiddleware` entirely from `server/api.go` — the gate now owns CORS.
+
+In `server/pane_ws.go`, delete the package-level `upgrader` var and give the
+server its own:
+
+```go
+// wsUpgrader validates Origin against the same allowlist as the HTTP API. A
+// browser always sends Origin on a WebSocket handshake, so this is a real
+// check, not a formality.
+func (s *Server) wsUpgrader() websocket.Upgrader {
+	return websocket.Upgrader{
+		CheckOrigin: func(r *http.Request) bool {
+			if !s.auth.enabled {
+				return true
+			}
+			return originAllowed(r, s.auth.allowedOrigins)
+		},
+	}
+}
+```
+
+Then replace the single `upgrader.Upgrade(...)` call site with
+`up := s.wsUpgrader()` followed by `up.Upgrade(...)`. Find it by symbol, not by
+line number.
+
+- [ ] **Step 5: Wire the flag in `main.go`**
+
+In `runServer`, add the flag beside the existing ones:
+
+```go
+	noAuth := flag.Bool("no-auth", false, "disable API authentication (NOT recommended)")
+```
+
+After `flag.Parse()` and after `*statusDir` is resolved, build the config
+additions and log the outcome:
+
+```go
+	allowedOrigins := []string{}
+	if *debug {
+		// The Vite dev server proxies /api here; its Origin is preserved
+		// through the proxy, so it has to be allowlisted explicitly.
+		allowedOrigins = append(allowedOrigins, "http://localhost:5173")
+	}
+	if *noAuth {
+		slog.Warn("API authentication is DISABLED; any page that can reach this port can drive your tmux panes")
+	}
+```
+
+Pass them into `server.New`:
+
+```go
+		AuthEnabled:    !*noAuth,
+		AllowedOrigins: allowedOrigins,
+```
+
+And after the server starts, tell the user where the token is — the path, never
+the value:
+
+```go
+	if !*noAuth {
+		fmt.Fprintf(os.Stderr, "api token: %s (open the UI once to authorize this browser)\n",
+			filepath.Join(*statusDir, "token"))
+	}
+```
+
+- [ ] **Step 6: Run the tests**
+
+Run: `go test ./server/...`
+Expected: PASS. If `TestAgentsStreamEmitsSnapshotAndUpdate` fails, check whether
+you ran with `-race` — that failure is pre-existing and `-race`-only.
+
+Run: `go vet ./server/... && go build ./server/...`
+Expected: no output.
+
+- [ ] **Step 7: Verify by hand that the UI still works**
+
+```bash
+go build -o /tmp/houston-auth . 2>/dev/null || go build -o /tmp/houston-auth ./...
+/tmp/houston-auth -addr 127.0.0.1:9099 &
+```
+
+Then, from another shell:
+
+```bash
+# No token: refused.
+curl -si http://127.0.0.1:9099/api/agents | head -1        # expect 401
+
+# Token from the file: accepted.
+curl -si -H "Authorization: Bearer $(cat ~/.local/state/houston/token)" \
+     http://127.0.0.1:9099/api/agents | head -1            # expect 200
+
+# A hostile page's origin is refused even with a good token.
+curl -si -H "Origin: http://evil.example" \
+     -H "Authorization: Bearer $(cat ~/.local/state/houston/token)" \
+     http://127.0.0.1:9099/api/agents | head -1            # expect 403
+
+# Loading the SPA issues the cookie.
+curl -si http://127.0.0.1:9099/ | grep -i set-cookie       # expect houston_token, HttpOnly
+```
+
+Kill the server when done (`kill %1`). Do NOT run `tmux kill-server` or any tmux
+command affecting a server or session you did not create.
+
+- [ ] **Step 8: Correct `CLAUDE.md`**
+
+Its Security section currently reads "**No built-in auth** — rely on
+network-level security". That is no longer true and was the source of the
+vulnerability. Replace that section with the token model: a token generated into
+the state dir on first run, issued to the browser as an httpOnly cookie when the
+SPA loads, accepted as a cookie, `Authorization: Bearer`, or `?token=` (for
+WebSockets, which cannot set headers), an origin allowlist covering both the API
+and the WebSocket handshake, and `-no-auth` as an explicit opt-out. Keep the
+existing Tailscale/SSH-tunnel advice as defence in depth rather than as the only
+defence.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add server/ main.go CLAUDE.md
+git commit -m "feat(server): require an API token and check origins"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage** — against the spec's "Auth" section:
+
+| Spec requirement | Task |
+|---|---|
+| `Allow-Origin` becomes an explicit allowlist | 2, 3 |
+| Vite dev origin permitted only under `-debug` | 4 |
+| `CheckOrigin` validates against the same allowlist | 4 |
+| Bearer token generated on first run into the state dir, 0600 | 1 |
+| Delivered to the SPA as an httpOnly cookie | 3, 4 |
+| Required by every `/api/` route | 3, 4 |
+| Reused as the M2 peer credential | out of scope; `LoadOrCreateToken` is the seam |
+
+**Placeholder scan:** none — every step carries the code it needs.
+
+**Type consistency:** `authGate`, its three fields, `middleware`, `setCookie`,
+`presentedToken`, `authCookie`, `originAllowed`, `tokenMatches`,
+`LoadOrCreateToken`, `Config.AuthEnabled`, `Config.AllowedOrigins` and
+`Server.auth` are spelled identically everywhere they appear. `SPAHandler` gains
+its second parameter in Task 4, which is the only signature change to an
+existing exported function.
+
+**One deliberate asymmetry worth not "fixing":** the middleware checks the origin
+*before* the token, so a hostile page with a stolen token gets 403 rather than
+401. That ordering is intentional — it means a cross-origin attacker learns
+nothing about token validity.

--- a/main.go
+++ b/main.go
@@ -166,6 +166,8 @@ func runServer() {
 	openCodeURL := flag.String("opencode-url", "", "OpenCode server URL (skip discovery)")
 	noOpenCode := flag.Bool("no-opencode", false, "Disable OpenCode integration")
 
+	noAuth := flag.Bool("no-auth", false, "disable API authentication (NOT recommended)")
+
 	flag.Parse()
 
 	// Configure slog
@@ -193,12 +195,24 @@ func runServer() {
 		log.Fatalf("failed to create UI sub-filesystem: %v", err)
 	}
 
+	allowedOrigins := []string{}
+	if *debug {
+		// The Vite dev server proxies /api here; its Origin is preserved
+		// through the proxy, so it has to be allowlisted explicitly.
+		allowedOrigins = append(allowedOrigins, "http://localhost:5173")
+	}
+	if *noAuth {
+		slog.Warn("API authentication is DISABLED; any page that can reach this port can drive your tmux panes")
+	}
+
 	srv, err := server.New(server.Config{
 		StatusDir:       *statusDir,
 		FontController:  fontCtrl,
 		OpenCodeEnabled: !*noOpenCode,
 		OpenCodeURL:     *openCodeURL,
 		UIFS:            uiSubFS,
+		AuthEnabled:     !*noAuth,
+		AllowedOrigins:  allowedOrigins,
 	})
 	if err != nil {
 		log.Fatalf("failed to create server: %v", err)
@@ -206,6 +220,10 @@ func runServer() {
 
 	fmt.Fprintf(os.Stderr, "houston starting on http://%s\n", *addr)
 	fmt.Fprintf(os.Stderr, "status directory: %s\n", *statusDir)
+	if !*noAuth {
+		fmt.Fprintf(os.Stderr, "api token: %s (open the UI once to authorize this browser)\n",
+			filepath.Join(*statusDir, "token"))
+	}
 
 	if err := http.ListenAndServe(*addr, srv.Handler()); err != nil {
 		log.Fatal(err)

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/noamsto/houston/hook"
 	"github.com/noamsto/houston/server"
@@ -168,6 +169,9 @@ func runServer() {
 
 	noAuth := flag.Bool("no-auth", false, "disable API authentication (NOT recommended)")
 
+	var hostnames stringList
+	flag.Var(&hostnames, "hostname", "additional Host value to accept (repeatable; for reverse proxies or custom DNS)")
+
 	flag.Parse()
 
 	// Configure slog
@@ -213,6 +217,7 @@ func runServer() {
 		UIFS:            uiSubFS,
 		AuthEnabled:     !*noAuth,
 		AllowedOrigins:  allowedOrigins,
+		AllowedHosts:    hostnames,
 	})
 	if err != nil {
 		log.Fatalf("failed to create server: %v", err)
@@ -228,4 +233,16 @@ func runServer() {
 	if err := http.ListenAndServe(*addr, srv.Handler()); err != nil {
 		log.Fatal(err)
 	}
+}
+
+// stringList collects repeated occurrences of a flag into a slice.
+type stringList []string
+
+func (l *stringList) String() string {
+	return strings.Join(*l, ",")
+}
+
+func (l *stringList) Set(v string) error {
+	*l = append(*l, v)
+	return nil
 }

--- a/server/api.go
+++ b/server/api.go
@@ -226,17 +226,3 @@ func (s *Server) handleAPIOpenCodeSession(w http.ResponseWriter, r *http.Request
 	r.URL.Path = strings.TrimPrefix(r.URL.Path, "/api")
 	s.handleOpenCodeSession(w, r)
 }
-
-// corsMiddleware adds CORS headers for development (Vite dev server on different port).
-func corsMiddleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
-		if r.Method == "OPTIONS" {
-			w.WriteHeader(http.StatusNoContent)
-			return
-		}
-		next.ServeHTTP(w, r)
-	})
-}

--- a/server/auth.go
+++ b/server/auth.go
@@ -60,24 +60,37 @@ func tokenMatches(want, got string) bool {
 	return subtle.ConstantTimeCompare([]byte(want), []byte(got)) == 1
 }
 
+// sameOrigin reports whether the request's Origin is this server's own.
+func sameOrigin(r *http.Request) bool {
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		return false
+	}
+	u, err := url.Parse(origin)
+	return err == nil && u.Host == r.Host
+}
+
 // originAllowed reports whether a request's Origin may talk to this server.
 //
-// A browser always sends Origin on a WebSocket handshake and on a cross-origin
-// fetch, so an absent Origin means a non-browser client (curl, a native app) —
-// those are gated by the token, not by this check. A present Origin must match
-// the request's own host or appear in allowed.
+// An absent Origin is allowed, but NOT because browsers always send one — they
+// do not: <img>, <script>, <link>, top-level navigation and <form method=GET>
+// all omit it. It is safe for two independent reasons: every state-changing
+// route is POST, and every Origin-less vector above is GET-only; and the auth
+// cookie is SameSite=Strict, so no cross-site request carries it at all.
+// Weakening either of those — a GET that mutates, or SameSite=Lax — reopens
+// this, whatever this comment says.
 func originAllowed(r *http.Request, allowed []string) bool {
 	origin := r.Header.Get("Origin")
 	if origin == "" {
+		return true
+	}
+	if sameOrigin(r) {
 		return true
 	}
 
 	u, err := url.Parse(origin)
 	if err != nil || u.Host == "" {
 		return false // includes the literal "null" a sandboxed frame sends
-	}
-	if u.Host == r.Host {
-		return true
 	}
 	for _, a := range allowed {
 		if a == origin {
@@ -93,27 +106,33 @@ func originAllowed(r *http.Request, allowed []string) bool {
 const authCookie = "houston_token"
 
 // authGate guards /api/. Disabled, it is a pass-through, which is what
-// -no-auth selects. A nil *authGate is a different case: agents_test.go
-// constructs bare &Server{} values that never set auth, but that is a
-// programming error, not a configuration choice — middleware fails closed
-// on it rather than treating it as auth-disabled.
+// -no-auth selects. A nil *authGate is a different case: a Server constructed
+// without wiring auth, which is a programming error, not a configuration
+// choice — middleware fails closed on it rather than treating it as
+// auth-disabled.
 type authGate struct {
 	token          string
 	allowedOrigins []string
 	enabled        bool
 }
 
-// presentedToken pulls the token from the three places a client can put it.
-// A browser WebSocket cannot set headers, which is why the query parameter
-// exists; same-origin sockets use the cookie and never need it.
+// presentedToken pulls the token from the places a client can put it. The
+// query parameter is accepted only on a WebSocket upgrade: a browser socket
+// cannot set headers, and the cookie already covers same-origin sockets, so
+// the parameter exists solely for the cross-site Vite dev proxy. Accepting it
+// on ordinary requests would leak the token into browser history, Referer,
+// and proxy logs for no benefit.
 func presentedToken(r *http.Request) string {
 	if c, err := r.Cookie(authCookie); err == nil && c.Value != "" {
 		return c.Value
 	}
-	if h := r.Header.Get("Authorization"); strings.HasPrefix(h, "Bearer ") {
-		return strings.TrimPrefix(h, "Bearer ")
+	if h := r.Header.Get("Authorization"); len(h) > 7 && strings.EqualFold(h[:7], "Bearer ") {
+		return h[7:]
 	}
-	return r.URL.Query().Get("token")
+	if strings.EqualFold(r.Header.Get("Upgrade"), "websocket") {
+		return r.URL.Query().Get("token")
+	}
+	return ""
 }
 
 func (a *authGate) middleware(next http.Handler) http.Handler {
@@ -125,19 +144,23 @@ func (a *authGate) middleware(next http.Handler) http.Handler {
 			http.Error(w, "server misconfigured", http.StatusInternalServerError)
 			return
 		}
-		if !a.enabled {
-			next.ServeHTTP(w, r)
-			return
-		}
 
+		// Origin checking runs even when auth is disabled: -no-auth removes
+		// the token requirement, not cross-origin drivability.
 		if !originAllowed(r, a.allowedOrigins) {
 			http.Error(w, "forbidden origin", http.StatusForbidden)
 			return
 		}
 
+		if !a.enabled {
+			next.ServeHTTP(w, r)
+			return
+		}
+
 		// Echo the origin only once it is known-good, and only when it is
 		// genuinely cross-origin; same-origin requests need no CORS headers.
-		if origin := r.Header.Get("Origin"); origin != "" && origin != "http://"+r.Host && origin != "https://"+r.Host {
+		if origin := r.Header.Get("Origin"); origin != "" && !sameOrigin(r) {
+			w.Header().Set("Vary", "Origin")
 			w.Header().Set("Access-Control-Allow-Origin", origin)
 			w.Header().Set("Access-Control-Allow-Credentials", "true")
 			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
@@ -156,7 +179,9 @@ func (a *authGate) middleware(next http.Handler) http.Handler {
 	})
 }
 
-// setCookie issues the token to a browser loading the SPA.
+// setCookie issues the token to a browser loading the SPA. It has no Secure
+// flag: houston serves plaintext over a tailnet or loopback, and Secure would
+// break the cookie on both.
 func (a *authGate) setCookie(w http.ResponseWriter) {
 	if a == nil || !a.enabled {
 		return

--- a/server/auth.go
+++ b/server/auth.go
@@ -85,3 +85,77 @@ func originAllowed(r *http.Request, allowed []string) bool {
 	}
 	return false
 }
+
+// authCookie is the httpOnly cookie the SPA is issued when it loads. Every UI
+// call is a same-origin relative path, so the browser attaches it to fetch,
+// EventSource and WebSocket alike without any frontend involvement.
+const authCookie = "houston_token"
+
+// authGate guards /api/. Disabled, it is a pass-through, which is what
+// -no-auth selects. A nil *authGate behaves the same way: agents_test.go
+// constructs bare &Server{} values that never set auth.
+type authGate struct {
+	token          string
+	allowedOrigins []string
+	enabled        bool
+}
+
+// presentedToken pulls the token from the three places a client can put it.
+// A browser WebSocket cannot set headers, which is why the query parameter
+// exists; same-origin sockets use the cookie and never need it.
+func presentedToken(r *http.Request) string {
+	if c, err := r.Cookie(authCookie); err == nil && c.Value != "" {
+		return c.Value
+	}
+	if h := r.Header.Get("Authorization"); strings.HasPrefix(h, "Bearer ") {
+		return strings.TrimPrefix(h, "Bearer ")
+	}
+	return r.URL.Query().Get("token")
+}
+
+func (a *authGate) middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if a == nil || !a.enabled {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		if !originAllowed(r, a.allowedOrigins) {
+			http.Error(w, "forbidden origin", http.StatusForbidden)
+			return
+		}
+
+		// Echo the origin only once it is known-good, and only when it is
+		// genuinely cross-origin; same-origin requests need no CORS headers.
+		if origin := r.Header.Get("Origin"); origin != "" && origin != "http://"+r.Host && origin != "https://"+r.Host {
+			w.Header().Set("Access-Control-Allow-Origin", origin)
+			w.Header().Set("Access-Control-Allow-Credentials", "true")
+			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+		}
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
+		if !tokenMatches(a.token, presentedToken(r)) {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// setCookie issues the token to a browser loading the SPA.
+func (a *authGate) setCookie(w http.ResponseWriter) {
+	if a == nil || !a.enabled {
+		return
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     authCookie,
+		Value:    a.token,
+		Path:     "/",
+		HttpOnly: true,
+		SameSite: http.SameSiteStrictMode,
+	})
+}

--- a/server/auth.go
+++ b/server/auth.go
@@ -7,6 +7,8 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -55,4 +57,31 @@ func tokenMatches(want, got string) bool {
 		return false
 	}
 	return subtle.ConstantTimeCompare([]byte(want), []byte(got)) == 1
+}
+
+// originAllowed reports whether a request's Origin may talk to this server.
+//
+// A browser always sends Origin on a WebSocket handshake and on a cross-origin
+// fetch, so an absent Origin means a non-browser client (curl, a native app) —
+// those are gated by the token, not by this check. A present Origin must match
+// the request's own host or appear in allowed.
+func originAllowed(r *http.Request, allowed []string) bool {
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		return true
+	}
+
+	u, err := url.Parse(origin)
+	if err != nil || u.Host == "" {
+		return false // includes the literal "null" a sandboxed frame sends
+	}
+	if u.Host == r.Host {
+		return true
+	}
+	for _, a := range allowed {
+		if a == origin {
+			return true
+		}
+	}
+	return false
 }

--- a/server/auth.go
+++ b/server/auth.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"os"
@@ -92,8 +93,10 @@ func originAllowed(r *http.Request, allowed []string) bool {
 const authCookie = "houston_token"
 
 // authGate guards /api/. Disabled, it is a pass-through, which is what
-// -no-auth selects. A nil *authGate behaves the same way: agents_test.go
-// constructs bare &Server{} values that never set auth.
+// -no-auth selects. A nil *authGate is a different case: agents_test.go
+// constructs bare &Server{} values that never set auth, but that is a
+// programming error, not a configuration choice — middleware fails closed
+// on it rather than treating it as auth-disabled.
 type authGate struct {
 	token          string
 	allowedOrigins []string
@@ -115,7 +118,14 @@ func presentedToken(r *http.Request) string {
 
 func (a *authGate) middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if a == nil || !a.enabled {
+		if a == nil {
+			// An unwired gate is a programming error, not a configuration
+			// choice. Refuse loudly rather than serving /api/ unauthenticated.
+			slog.Error("auth gate not configured; refusing request", "path", r.URL.Path)
+			http.Error(w, "server misconfigured", http.StatusInternalServerError)
+			return
+		}
+		if !a.enabled {
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/server/auth.go
+++ b/server/auth.go
@@ -1,0 +1,58 @@
+package server
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// tokenFile is the state-dir-relative path of the API token.
+const tokenFile = "token"
+
+// LoadOrCreateToken returns the API token for this state dir, generating one on
+// first run. The file is 0600: anyone who can read it can drive every tmux pane
+// this server can reach.
+func LoadOrCreateToken(stateDir string) (string, error) {
+	path := filepath.Join(stateDir, tokenFile)
+
+	b, err := os.ReadFile(path)
+	switch {
+	case err == nil:
+		tok := strings.TrimSpace(string(b))
+		if tok == "" {
+			return "", fmt.Errorf("token file %s is empty; delete it to regenerate", path)
+		}
+		return tok, nil
+	case !errors.Is(err, fs.ErrNotExist):
+		return "", fmt.Errorf("read token: %w", err)
+	}
+
+	raw := make([]byte, 32)
+	if _, err := rand.Read(raw); err != nil {
+		return "", fmt.Errorf("generate token: %w", err)
+	}
+	tok := hex.EncodeToString(raw)
+
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		return "", fmt.Errorf("create state dir: %w", err)
+	}
+	if err := os.WriteFile(path, []byte(tok+"\n"), 0o600); err != nil {
+		return "", fmt.Errorf("write token: %w", err)
+	}
+	return tok, nil
+}
+
+// tokenMatches compares in constant time. An empty expected token never
+// matches, so a misconfiguration fails closed rather than open.
+func tokenMatches(want, got string) bool {
+	if want == "" || got == "" {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(want), []byte(got)) == 1
+}

--- a/server/auth_test.go
+++ b/server/auth_test.go
@@ -115,3 +115,124 @@ func TestOriginAllowed(t *testing.T) {
 		})
 	}
 }
+
+func okHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+}
+
+func TestMiddlewareRejectsWithoutToken(t *testing.T) {
+	a := &authGate{token: "secret", enabled: true}
+	rec := httptest.NewRecorder()
+
+	a.middleware(okHandler()).ServeHTTP(rec, reqWithOrigin("halo:9090", ""))
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status %d, want 401", rec.Code)
+	}
+	if strings.Contains(rec.Body.String(), "secret") {
+		t.Fatal("the response body leaked the token")
+	}
+}
+
+func TestMiddlewareAcceptsCookieBearerAndQuery(t *testing.T) {
+	a := &authGate{token: "secret", enabled: true}
+
+	cookieReq := reqWithOrigin("halo:9090", "")
+	cookieReq.AddCookie(&http.Cookie{Name: authCookie, Value: "secret"})
+
+	bearerReq := reqWithOrigin("halo:9090", "")
+	bearerReq.Header.Set("Authorization", "Bearer secret")
+
+	queryReq := httptest.NewRequest("GET", "http://halo:9090/api/runs?token=secret", nil)
+	queryReq.Host = "halo:9090"
+
+	for name, r := range map[string]*http.Request{
+		"cookie": cookieReq,
+		"bearer": bearerReq,
+		"query":  queryReq,
+	} {
+		t.Run(name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			a.middleware(okHandler()).ServeHTTP(rec, r)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status %d, want 200", rec.Code)
+			}
+		})
+	}
+}
+
+func TestMiddlewareRejectsBadOriginEvenWithValidToken(t *testing.T) {
+	a := &authGate{token: "secret", enabled: true}
+	r := reqWithOrigin("halo:9090", "http://evil.example")
+	r.AddCookie(&http.Cookie{Name: authCookie, Value: "secret"})
+
+	rec := httptest.NewRecorder()
+	a.middleware(okHandler()).ServeHTTP(rec, r)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status %d, want 403 — a valid token from a hostile page must still be refused", rec.Code)
+	}
+}
+
+func TestMiddlewareDisabledAllowsEverything(t *testing.T) {
+	a := &authGate{enabled: false}
+	rec := httptest.NewRecorder()
+
+	a.middleware(okHandler()).ServeHTTP(rec, reqWithOrigin("halo:9090", "http://evil.example"))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d, want 200 when auth is disabled", rec.Code)
+	}
+}
+
+func TestCORSHeadersOnlyForAllowedOrigin(t *testing.T) {
+	a := &authGate{token: "secret", enabled: true, allowedOrigins: []string{"http://localhost:5173"}}
+
+	good := reqWithOrigin("halo:9090", "http://localhost:5173")
+	good.AddCookie(&http.Cookie{Name: authCookie, Value: "secret"})
+	goodRec := httptest.NewRecorder()
+	a.middleware(okHandler()).ServeHTTP(goodRec, good)
+
+	if got := goodRec.Header().Get("Access-Control-Allow-Origin"); got != "http://localhost:5173" {
+		t.Fatalf("Allow-Origin = %q, want the echoed allowed origin", got)
+	}
+	if got := goodRec.Header().Get("Access-Control-Allow-Credentials"); got != "true" {
+		t.Fatalf("Allow-Credentials = %q, want true — the cookie must be sent cross-origin in dev", got)
+	}
+
+	bad := reqWithOrigin("halo:9090", "http://evil.example")
+	badRec := httptest.NewRecorder()
+	a.middleware(okHandler()).ServeHTTP(badRec, bad)
+
+	if got := badRec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Fatalf("Allow-Origin = %q for a rejected origin, want empty", got)
+	}
+}
+
+func TestSetCookieIsHttpOnly(t *testing.T) {
+	a := &authGate{token: "secret", enabled: true}
+	rec := httptest.NewRecorder()
+
+	a.setCookie(rec)
+
+	cookies := rec.Result().Cookies()
+	if len(cookies) != 1 {
+		t.Fatalf("%d cookies set, want 1", len(cookies))
+	}
+	c := cookies[0]
+	if c.Name != authCookie || c.Value != "secret" {
+		t.Fatalf("cookie = %s=%s, want %s=secret", c.Name, c.Value, authCookie)
+	}
+	if !c.HttpOnly {
+		t.Error("cookie is not HttpOnly — script on the page could read the token")
+	}
+	if c.SameSite != http.SameSiteStrictMode {
+		t.Error("cookie is not SameSite=Strict")
+	}
+	if c.Path != "/" {
+		t.Errorf("cookie path %q, want /", c.Path)
+	}
+}

--- a/server/auth_test.go
+++ b/server/auth_test.go
@@ -261,3 +261,20 @@ func TestNilGateSetCookieIsSafeNoOp(t *testing.T) {
 		t.Fatal("an unwired gate issued a cookie")
 	}
 }
+
+func TestSPAHandlerIssuesCookie(t *testing.T) {
+	a := &authGate{token: "secret", enabled: true}
+	rec := httptest.NewRecorder()
+
+	SPAHandler(nil, a).ServeHTTP(rec, httptest.NewRequest("GET", "/", nil))
+
+	found := false
+	for _, c := range rec.Result().Cookies() {
+		if c.Name == authCookie {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("loading the SPA did not issue the auth cookie; the UI could never authenticate")
+	}
+}

--- a/server/auth_test.go
+++ b/server/auth_test.go
@@ -146,8 +146,11 @@ func TestMiddlewareAcceptsCookieBearerAndQuery(t *testing.T) {
 	bearerReq := reqWithOrigin("halo:9090", "")
 	bearerReq.Header.Set("Authorization", "Bearer secret")
 
+	// The query parameter is accepted only on a WebSocket upgrade — that is
+	// the one path a browser socket can't attach the cookie/header to.
 	queryReq := httptest.NewRequest("GET", "http://halo:9090/api/runs?token=secret", nil)
 	queryReq.Host = "halo:9090"
+	queryReq.Header.Set("Upgrade", "websocket")
 
 	for name, r := range map[string]*http.Request{
 		"cookie": cookieReq,
@@ -161,6 +164,20 @@ func TestMiddlewareAcceptsCookieBearerAndQuery(t *testing.T) {
 				t.Fatalf("status %d, want 200", rec.Code)
 			}
 		})
+	}
+}
+
+func TestMiddlewareRejectsQueryTokenOnNonUpgradeRequest(t *testing.T) {
+	a := &authGate{token: "secret", enabled: true}
+
+	r := httptest.NewRequest("GET", "http://halo:9090/api/runs?token=secret", nil)
+	r.Host = "halo:9090"
+
+	rec := httptest.NewRecorder()
+	a.middleware(okHandler()).ServeHTTP(rec, r)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status %d, want 401 — ?token= must only work on a WebSocket upgrade", rec.Code)
 	}
 }
 
@@ -181,10 +198,21 @@ func TestMiddlewareDisabledAllowsEverything(t *testing.T) {
 	a := &authGate{enabled: false}
 	rec := httptest.NewRecorder()
 
-	a.middleware(okHandler()).ServeHTTP(rec, reqWithOrigin("halo:9090", "http://evil.example"))
+	a.middleware(okHandler()).ServeHTTP(rec, reqWithOrigin("halo:9090", ""))
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status %d, want 200 when auth is disabled", rec.Code)
+	}
+}
+
+func TestMiddlewareDisabledStillEnforcesOrigin(t *testing.T) {
+	a := &authGate{enabled: false}
+	rec := httptest.NewRecorder()
+
+	a.middleware(okHandler()).ServeHTTP(rec, reqWithOrigin("halo:9090", "http://evil.example"))
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status %d, want 403 — -no-auth disables the token requirement, not cross-origin drivability", rec.Code)
 	}
 }
 
@@ -209,6 +237,41 @@ func TestCORSHeadersOnlyForAllowedOrigin(t *testing.T) {
 
 	if got := badRec.Header().Get("Access-Control-Allow-Origin"); got != "" {
 		t.Fatalf("Allow-Origin = %q for a rejected origin, want empty", got)
+	}
+
+	same := reqWithOrigin("halo:9090", "http://halo:9090")
+	same.AddCookie(&http.Cookie{Name: authCookie, Value: "secret"})
+	sameRec := httptest.NewRecorder()
+	a.middleware(okHandler()).ServeHTTP(sameRec, same)
+
+	if got := sameRec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Fatalf("Allow-Origin = %q for a same-origin request, want empty — a reintroduced Allow-Origin: * would show up here", got)
+	}
+}
+
+func TestOptionsFromDisallowedOriginIsForbidden(t *testing.T) {
+	a := &authGate{token: "secret", enabled: true, allowedOrigins: []string{"http://localhost:5173"}}
+	r := reqWithOrigin("halo:9090", "http://evil.example")
+	r.Method = http.MethodOptions
+
+	rec := httptest.NewRecorder()
+	a.middleware(okHandler()).ServeHTTP(rec, r)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status %d, want 403 — preflight must not bypass the origin check", rec.Code)
+	}
+}
+
+func TestMiddlewareRejectsWrongToken(t *testing.T) {
+	a := &authGate{token: "secret", enabled: true}
+	r := reqWithOrigin("halo:9090", "")
+	r.AddCookie(&http.Cookie{Name: authCookie, Value: "wrong"})
+
+	rec := httptest.NewRecorder()
+	a.middleware(okHandler()).ServeHTTP(rec, r)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status %d, want 401 for a wrong (not merely absent) token", rec.Code)
 	}
 }
 

--- a/server/auth_test.go
+++ b/server/auth_test.go
@@ -1,0 +1,76 @@
+package server
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadOrCreateTokenGeneratesAndPersists(t *testing.T) {
+	dir := t.TempDir()
+
+	first, err := LoadOrCreateToken(dir)
+	if err != nil {
+		t.Fatalf("LoadOrCreateToken: %v", err)
+	}
+	if len(first) != 64 {
+		t.Fatalf("token length %d, want 64 hex chars", len(first))
+	}
+	if strings.TrimSpace(first) != first {
+		t.Fatalf("token has surrounding whitespace: %q", first)
+	}
+
+	second, err := LoadOrCreateToken(dir)
+	if err != nil {
+		t.Fatalf("second LoadOrCreateToken: %v", err)
+	}
+	if second != first {
+		t.Fatalf("token not persisted: %q then %q", first, second)
+	}
+}
+
+func TestLoadOrCreateTokenFileIsPrivate(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := LoadOrCreateToken(dir); err != nil {
+		t.Fatalf("LoadOrCreateToken: %v", err)
+	}
+
+	info, err := os.Stat(filepath.Join(dir, "token"))
+	if err != nil {
+		t.Fatalf("stat token: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("token file mode %o, want 600", perm)
+	}
+}
+
+func TestLoadOrCreateTokenToleratesTrailingNewline(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "token"), []byte("deadbeef\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := LoadOrCreateToken(dir)
+	if err != nil {
+		t.Fatalf("LoadOrCreateToken: %v", err)
+	}
+	if got != "deadbeef" {
+		t.Fatalf("got %q, want %q — an editor-added newline must not change the token", got, "deadbeef")
+	}
+}
+
+func TestTokenMatches(t *testing.T) {
+	if !tokenMatches("abc123", "abc123") {
+		t.Error("identical tokens did not match")
+	}
+	if tokenMatches("abc123", "abc124") {
+		t.Error("different tokens matched")
+	}
+	if tokenMatches("abc123", "") {
+		t.Error("empty presented token matched")
+	}
+	if tokenMatches("", "abc123") {
+		t.Error("empty expected token matched — that would disable auth")
+	}
+}

--- a/server/auth_test.go
+++ b/server/auth_test.go
@@ -236,3 +236,28 @@ func TestSetCookieIsHttpOnly(t *testing.T) {
 		t.Errorf("cookie path %q, want /", c.Path)
 	}
 }
+
+func TestNilGateRefusesRatherThanPassesThrough(t *testing.T) {
+	var a *authGate // a Server built without wiring the gate
+
+	rec := httptest.NewRecorder()
+	a.middleware(okHandler()).ServeHTTP(rec, reqWithOrigin("halo:9090", ""))
+
+	if rec.Code == http.StatusOK {
+		t.Fatal("an unwired auth gate served the request — auth would silently vanish")
+	}
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status %d, want 500", rec.Code)
+	}
+}
+
+func TestNilGateSetCookieIsSafeNoOp(t *testing.T) {
+	var a *authGate
+
+	rec := httptest.NewRecorder()
+	a.setCookie(rec) // must not panic
+
+	if len(rec.Result().Cookies()) != 0 {
+		t.Fatal("an unwired gate issued a cookie")
+	}
+}

--- a/server/auth_test.go
+++ b/server/auth_test.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -72,5 +74,44 @@ func TestTokenMatches(t *testing.T) {
 	}
 	if tokenMatches("", "abc123") {
 		t.Error("empty expected token matched — that would disable auth")
+	}
+}
+
+func reqWithOrigin(host, origin string) *http.Request {
+	r := httptest.NewRequest("GET", "http://"+host+"/api/runs", nil)
+	r.Host = host
+	if origin != "" {
+		r.Header.Set("Origin", origin)
+	}
+	return r
+}
+
+func TestOriginAllowed(t *testing.T) {
+	allowed := []string{"http://localhost:5173"}
+
+	tests := []struct {
+		name   string
+		host   string
+		origin string
+		want   bool
+	}{
+		{"no origin is a non-browser client", "halo:9090", "", true},
+		{"same origin", "halo:9090", "http://halo:9090", true},
+		{"same origin over https", "halo:9090", "https://halo:9090", true},
+		{"explicitly allowlisted", "halo:9090", "http://localhost:5173", true},
+		{"different host", "halo:9090", "http://evil.example", false},
+		{"different port on same host", "halo:9090", "http://halo:9091", false},
+		{"port-less origin against ported host", "halo:9090", "http://halo", false},
+		{"null origin from a sandboxed frame", "halo:9090", "null", false},
+		{"prefix of an allowed origin", "halo:9090", "http://localhost:51739", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := originAllowed(reqWithOrigin(tc.host, tc.origin), allowed); got != tc.want {
+				t.Fatalf("originAllowed(host=%q, origin=%q) = %v, want %v",
+					tc.host, tc.origin, got, tc.want)
+			}
+		})
 	}
 }

--- a/server/hosts.go
+++ b/server/hosts.go
@@ -1,0 +1,122 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+// hostGate is the set of Host values this server answers to. It exists because
+// Origin checking cannot defend against DNS rebinding: a rebound attacker
+// controls both Host and Origin, so they always agree. Host is the only field
+// we can pin to something the machine knows about itself.
+type hostGate struct {
+	hosts map[string]struct{}
+}
+
+// deriveHosts builds the allowlist from what this machine knows about itself.
+// It never resolves a client-supplied name: under rebinding the attacker's
+// domain genuinely does resolve to our address, so a lookup would validate the
+// attacker's own claim.
+func deriveHosts(extra []string, allowedOrigins []string) *hostGate {
+	g := &hostGate{hosts: map[string]struct{}{}}
+
+	for _, h := range []string{"localhost", "127.0.0.1", "::1"} {
+		g.add(h)
+	}
+	if hn, err := os.Hostname(); err == nil {
+		g.add(hn)
+	}
+	for _, ip := range tailnetAddrs() {
+		g.add(ip)
+		// Reverse lookup is safe here: the input is our own bound address,
+		// not anything a client sent. Bounded so a dead resolver (e.g. a
+		// laptop waking on a flaky network) can't hang startup — a timeout
+		// only costs the MagicDNS name, which -hostname can cover instead.
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		var resolver net.Resolver
+		names, err := resolver.LookupAddr(ctx, ip)
+		cancel()
+		if err == nil {
+			for _, n := range names {
+				g.add(strings.TrimSuffix(n, "."))
+			}
+		}
+	}
+	for _, o := range allowedOrigins {
+		if u, err := url.Parse(o); err == nil && u.Hostname() != "" {
+			g.add(u.Hostname())
+		}
+	}
+	for _, h := range extra {
+		g.add(h)
+	}
+	return g
+}
+
+// tailnetAddrs returns this machine's Tailscale addresses (CGNAT 100.64.0.0/10).
+func tailnetAddrs() []string {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return nil
+	}
+	_, cgnat, err := net.ParseCIDR("100.64.0.0/10")
+	if err != nil {
+		return nil
+	}
+	var out []string
+	for _, a := range addrs {
+		ipnet, ok := a.(*net.IPNet)
+		if !ok {
+			continue
+		}
+		if v4 := ipnet.IP.To4(); v4 != nil && cgnat.Contains(v4) {
+			out = append(out, v4.String())
+		}
+	}
+	return out
+}
+
+func (g *hostGate) add(h string) {
+	h = strings.ToLower(strings.TrimSpace(h))
+	if h != "" {
+		g.hosts[h] = struct{}{}
+	}
+}
+
+// allows compares the hostname only. The port is already pinned by the request
+// having arrived on our listener, so comparing it just breeds "[::1]:9090"
+// mismatches.
+func (g *hostGate) allows(rawHost string) bool {
+	host := rawHost
+	if h, _, err := net.SplitHostPort(rawHost); err == nil {
+		host = h
+	}
+	host = strings.ToLower(strings.Trim(host, "[]"))
+	_, ok := g.hosts[host]
+	return ok
+}
+
+// middleware rejects an unrecognised Host before any handler runs — including
+// the SPA handler, so an unknown host is never issued a token.
+func (g *hostGate) middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if g == nil || !g.allows(r.Host) {
+			host := r.Host
+			if h, _, err := net.SplitHostPort(host); err == nil {
+				host = h
+			}
+			w.Header().Set("X-Content-Type-Options", "nosniff")
+			http.Error(w,
+				fmt.Sprintf("Host %q not recognized; if this address is legitimate, restart houston with -hostname %s", host, host),
+				http.StatusMisdirectedRequest)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/server/hosts_test.go
+++ b/server/hosts_test.go
@@ -1,0 +1,91 @@
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"testing/fstest"
+)
+
+// TestUnknownHostGetsNoCookieAndIsRefused is the A0 regression test. If it
+// fails, a rebound page can obtain the real token by fetching "/".
+func TestUnknownHostGetsNoCookieAndIsRefused(t *testing.T) {
+	g := deriveHosts(nil, nil)
+	a := &authGate{token: "secret", enabled: true}
+
+	handler := g.middleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		a.setCookie(w)
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	r := httptest.NewRequest("GET", "http://evil.example/", nil)
+	r.Host = "evil.example"
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, r)
+
+	if rec.Code != http.StatusMisdirectedRequest {
+		t.Fatalf("status %d, want %d", rec.Code, http.StatusMisdirectedRequest)
+	}
+	if cookies := rec.Result().Cookies(); len(cookies) != 0 {
+		t.Fatalf("%d cookies set for an unrecognized host, want 0 — the real token must never reach a rebound page", len(cookies))
+	}
+}
+
+// TestHandlerRefusesUnknownHostEndToEnd is the A0 regression test proper: it
+// exercises Server.Handler(), because A0 was a wiring defect — the SPA
+// handler sat outside the host gate and issued the real token to any Host. A
+// test that builds its own middleware chain (above) cannot catch that coming
+// back.
+func TestHandlerRefusesUnknownHostEndToEnd(t *testing.T) {
+	dir := t.TempDir()
+	s, err := New(Config{StatusDir: dir, AuthEnabled: true, UIFS: fstest.MapFS{}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "http://evil.example/", nil)
+	req.Host = "evil.example"
+	rec := httptest.NewRecorder()
+
+	s.Handler().ServeHTTP(rec, req)
+
+	if n := len(rec.Result().Cookies()); n != 0 {
+		t.Fatalf("%d cookies issued to an unrecognized Host — the token is being handed to a rebound attacker", n)
+	}
+	if rec.Code != http.StatusMisdirectedRequest {
+		t.Fatalf("status %d, want 421", rec.Code)
+	}
+}
+
+func TestDeriveHostsIncludesSelfKnowledge(t *testing.T) {
+	g := deriveHosts(nil, nil)
+
+	for _, want := range []string{"localhost", "127.0.0.1", "::1"} {
+		if !g.allows(want) {
+			t.Errorf("deriveHosts did not include loopback literal %q", want)
+		}
+	}
+
+	hn, err := os.Hostname()
+	if err != nil {
+		t.Fatalf("os.Hostname: %v", err)
+	}
+	if !g.allows(hn) {
+		t.Errorf("deriveHosts did not include os.Hostname() %q", hn)
+	}
+}
+
+func TestAllowsStripsPortAndIsCaseInsensitive(t *testing.T) {
+	g := deriveHosts(nil, nil)
+
+	if !g.allows("127.0.0.1:9090") {
+		t.Error("allows(\"127.0.0.1:9090\") = false, want true — the port must be stripped")
+	}
+	if !g.allows("LOCALHOST") {
+		t.Error("allows(\"LOCALHOST\") = false, want true — the comparison must be case-insensitive")
+	}
+	if !g.allows("[::1]:9090") {
+		t.Error("allows(\"[::1]:9090\") = false, want true — a bracketed IPv6 host:port must be recognized")
+	}
+}

--- a/server/hosts_test.go
+++ b/server/hosts_test.go
@@ -8,8 +8,7 @@ import (
 	"testing/fstest"
 )
 
-// TestUnknownHostGetsNoCookieAndIsRefused is the A0 regression test. If it
-// fails, a rebound page can obtain the real token by fetching "/".
+// If this fails, a rebound page can obtain the real token by fetching "/".
 func TestUnknownHostGetsNoCookieAndIsRefused(t *testing.T) {
 	g := deriveHosts(nil, nil)
 	a := &authGate{token: "secret", enabled: true}
@@ -32,11 +31,9 @@ func TestUnknownHostGetsNoCookieAndIsRefused(t *testing.T) {
 	}
 }
 
-// TestHandlerRefusesUnknownHostEndToEnd is the A0 regression test proper: it
-// exercises Server.Handler(), because A0 was a wiring defect — the SPA
-// handler sat outside the host gate and issued the real token to any Host. A
-// test that builds its own middleware chain (above) cannot catch that coming
-// back.
+// Exercises the real Handler() rather than a hand-built chain: the bug this
+// guards against was in the wiring, not the gate — the SPA handler sat outside
+// the host gate and issued the real token to any Host that asked.
 func TestHandlerRefusesUnknownHostEndToEnd(t *testing.T) {
 	dir := t.TempDir()
 	s, err := New(Config{StatusDir: dir, AuthEnabled: true, UIFS: fstest.MapFS{}})

--- a/server/pane_ws.go
+++ b/server/pane_ws.go
@@ -15,18 +15,16 @@ import (
 	"github.com/noamsto/houston/tmux"
 )
 
-// wsUpgrader validates Origin against the same allowlist as the HTTP API. A
-// browser always sends Origin on a WebSocket handshake, so this is a real
-// check, not a formality.
+// wsUpgrader validates Origin against the same allowlist as the HTTP API.
+// This runs regardless of whether auth is enabled: -no-auth disables the
+// token requirement, not cross-origin drivability — see originAllowed's
+// comment in auth.go for why an absent Origin is still safe to allow.
 func (s *Server) wsUpgrader() websocket.Upgrader {
 	return websocket.Upgrader{
 		CheckOrigin: func(r *http.Request) bool {
 			if s.auth == nil {
 				// Unwired gate — refuse rather than accept every origin.
 				return false
-			}
-			if !s.auth.enabled {
-				return true
 			}
 			return originAllowed(r, s.auth.allowedOrigins)
 		},

--- a/server/pane_ws.go
+++ b/server/pane_ws.go
@@ -15,8 +15,22 @@ import (
 	"github.com/noamsto/houston/tmux"
 )
 
-var upgrader = websocket.Upgrader{
-	CheckOrigin: func(r *http.Request) bool { return true },
+// wsUpgrader validates Origin against the same allowlist as the HTTP API. A
+// browser always sends Origin on a WebSocket handshake, so this is a real
+// check, not a formality.
+func (s *Server) wsUpgrader() websocket.Upgrader {
+	return websocket.Upgrader{
+		CheckOrigin: func(r *http.Request) bool {
+			if s.auth == nil {
+				// Unwired gate — refuse rather than accept every origin.
+				return false
+			}
+			if !s.auth.enabled {
+				return true
+			}
+			return originAllowed(r, s.auth.allowedOrigins)
+		},
+	}
 }
 
 // WebSocket message types
@@ -56,7 +70,8 @@ type WSDims struct {
 }
 
 func (s *Server) handlePaneWS(w http.ResponseWriter, r *http.Request, pane tmux.Pane) {
-	conn, err := upgrader.Upgrade(w, r, nil)
+	up := s.wsUpgrader()
+	conn, err := up.Upgrade(w, r, nil)
 	if err != nil {
 		slog.Error("websocket upgrade failed", "error", err)
 		return

--- a/server/server.go
+++ b/server/server.go
@@ -223,7 +223,8 @@ func (s *Server) Handler() http.Handler {
 // SPAHandler serves the embedded SPA, falling back to index.html for
 // client-side routing. Every response issues the auth cookie, which is how the
 // browser comes to hold a token it can send on same-origin fetch, EventSource
-// and WebSocket calls.
+// and WebSocket calls. It must therefore stay inside the host gate: served to
+// an unrecognised Host, it would hand the token to a rebound attacker.
 func SPAHandler(uiFS fs.FS, auth *authGate) http.Handler {
 	var fileServer http.Handler
 	if uiFS != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -88,6 +88,8 @@ type Server struct {
 
 	// Agent-card hub (new) — aggregates hook state + transcript tails.
 	hub *hub.Hub
+
+	auth *authGate
 }
 
 // FontController controls terminal font size.
@@ -109,6 +111,13 @@ type Config struct {
 
 	// UIFS is the embedded React SPA filesystem.
 	UIFS fs.FS
+
+	// AuthEnabled gates /api/ behind the state-dir token. Disabled only by
+	// an explicit -no-auth.
+	AuthEnabled bool
+	// AllowedOrigins are extra origins permitted beyond same-origin, e.g. the
+	// Vite dev server.
+	AllowedOrigins []string
 }
 
 func New(cfg Config) (*Server, error) {
@@ -170,6 +179,16 @@ func New(cfg Config) (*Server, error) {
 		s.ocManager.StartBackgroundRefresh(ctx, 10*time.Second)
 	}
 
+	gate := &authGate{enabled: cfg.AuthEnabled, allowedOrigins: cfg.AllowedOrigins}
+	if cfg.AuthEnabled {
+		tok, err := LoadOrCreateToken(cfg.StatusDir)
+		if err != nil {
+			return nil, fmt.Errorf("api token: %w", err)
+		}
+		gate.token = tok
+	}
+	s.auth = gate
+
 	return s, nil
 }
 
@@ -177,7 +196,7 @@ func (s *Server) Handler() http.Handler {
 	mux := http.NewServeMux()
 
 	if s.uiFS != nil {
-		mux.Handle("/", SPAHandler(s.uiFS))
+		mux.Handle("/", SPAHandler(s.uiFS, s.auth))
 	}
 
 	// JSON API routes (always available)
@@ -188,26 +207,35 @@ func (s *Server) Handler() http.Handler {
 	apiMux.HandleFunc("/api/opencode/session/", s.handleAPIOpenCodeSession)
 	apiMux.HandleFunc("/api/agents", s.handleAgentsSnapshot)
 	apiMux.HandleFunc("/api/agents/stream", s.handleAgentsStream)
-	mux.Handle("/api/", corsMiddleware(apiMux))
+	mux.Handle("/api/", s.auth.middleware(apiMux))
 
 	return mux
 }
 
-// SPAHandler serves an embedded filesystem with fallback to index.html for client-side routing.
-func SPAHandler(uiFS fs.FS) http.Handler {
-	fileServer := http.FileServer(http.FS(uiFS))
+// SPAHandler serves the embedded SPA, falling back to index.html for
+// client-side routing. Every response issues the auth cookie, which is how the
+// browser comes to hold a token it can send on same-origin fetch, EventSource
+// and WebSocket calls.
+func SPAHandler(uiFS fs.FS, auth *authGate) http.Handler {
+	var fileServer http.Handler
+	if uiFS != nil {
+		fileServer = http.FileServer(http.FS(uiFS))
+	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth.setCookie(w)
+		if fileServer == nil {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
 		path := strings.TrimPrefix(r.URL.Path, "/")
 		if path == "" {
 			path = "index.html"
 		}
-
-		// Serve the file if it exists; otherwise fallback to index.html (client-side routing).
 		if _, err := fs.Stat(uiFS, path); err == nil {
 			fileServer.ServeHTTP(w, r)
 			return
 		}
-
 		r.URL.Path = "/"
 		fileServer.ServeHTTP(w, r)
 	})

--- a/server/server.go
+++ b/server/server.go
@@ -89,7 +89,8 @@ type Server struct {
 	// Agent-card hub (new) — aggregates hook state + transcript tails.
 	hub *hub.Hub
 
-	auth *authGate
+	auth  *authGate
+	hosts *hostGate
 }
 
 // FontController controls terminal font size.
@@ -118,6 +119,10 @@ type Config struct {
 	// AllowedOrigins are extra origins permitted beyond same-origin, e.g. the
 	// Vite dev server.
 	AllowedOrigins []string
+	// AllowedHosts are extra Host values this server answers to, beyond what
+	// it can derive about itself (loopback, hostname, Tailscale addresses).
+	// For reverse proxies or custom DNS.
+	AllowedHosts []string
 }
 
 func New(cfg Config) (*Server, error) {
@@ -188,6 +193,7 @@ func New(cfg Config) (*Server, error) {
 		gate.token = tok
 	}
 	s.auth = gate
+	s.hosts = deriveHosts(cfg.AllowedHosts, cfg.AllowedOrigins)
 
 	return s, nil
 }
@@ -209,7 +215,9 @@ func (s *Server) Handler() http.Handler {
 	apiMux.HandleFunc("/api/agents/stream", s.handleAgentsStream)
 	mux.Handle("/api/", s.auth.middleware(apiMux))
 
-	return mux
+	// The host gate wraps everything, including "/", so a rebound domain is
+	// never handed the token via SPAHandler's setCookie.
+	return s.hosts.middleware(mux)
 }
 
 // SPAHandler serves the embedded SPA, falling back to index.html for


### PR DESCRIPTION
Closes the security half of #2. Independent of #3 — this branches from `main` so it
can merge on its own rather than queue behind the transport refactor.

## The hole

`server/api.go` set `Access-Control-Allow-Origin: *` on all of `/api/`, and
`server/pane_ws.go`'s upgrader returned `true` from `CheckOrigin` unconditionally.
Any page in any browser that could route to houston — including one open on your own
laptop hitting `localhost:9090`, or anything on your tailnet — could read every agent
session and `POST /api/pane/<target>/send` arbitrary keystrokes into any tmux pane.
That is command execution triggered by visiting a web page, gated only by reaching
the port.

## The fix

A bearer token generated on first run into the state dir (`0600`), issued to the SPA
as an httpOnly `SameSite=Strict` cookie when it loads, and required by every `/api/`
route. Origin checking becomes an explicit allowlist for both the HTTP API and the
WebSocket handshake.

**No frontend changes.** Every UI call is already a same-origin relative path, so the
browser attaches the cookie to `fetch`, `EventSource` and `WebSocket` alike.

`-no-auth` opts out with a startup warning. It disables the *token*, not origin
checking — turning off authentication needn't make the server cross-origin drivable.

## A second hole, introduced and then closed in this branch

The first version of this gate was **also vulnerable**, and worse than it looked. It
issued the cookie from `SPAHandler`, which is mounted outside the `/api/` gate, so it
would hand the real token to any `Host`. Demonstrated against the built binary:

```
curl -H "Host: evil.example" http://127.0.0.1:9098/
  → Set-Cookie: houston_token=<the real token>; HttpOnly; SameSite=Strict

curl -H "Host: evil.example" -H "Origin: http://evil.example" -H "Cookie: <that>" \
     http://127.0.0.1:9098/api/agents      → 200 OK

# control: same token, Origin not matching Host
                                           → 403 Forbidden
```

Under DNS rebinding the attacker controls both `Host` and `Origin`, so they always
agree and the origin check is worthless. The token gave no protection because the
server handed it over.

Fixed with a **`Host` allowlist wrapping the entire mux**, so `/` and `/api/` are both
covered and cookie issuance inherits it. One guard, not two half-measures — a refactor
either keeps it or visibly removes it.

The allowlist is derived from what the machine knows about *itself*, never by
resolving a client-supplied name. That distinction is the whole point: under rebinding
`evil.example` genuinely does resolve to `127.0.0.1`, so a lookup would validate the
attacker's own claim.

- `os.Hostname()` → `halo`
- `net.InterfaceAddrs()` filtered to CGNAT `100.64.0.0/10` → the tailnet IP
- reverse-DNS **of that own address** → the MagicDNS name
- loopback literals, plus the hosts of any configured allowed origins
- `-hostname` appends for reverse-proxy and custom-DNS setups; it never replaces

Verified working with zero configuration, bound to `0.0.0.0`:

| Host | Result |
|---|---|
| `localhost`, `127.0.0.1` | 200, cookie issued |
| `halo` | 200, cookie issued |
| `100.92.49.55` | 200, cookie issued |
| `halo.tail68e513.ts.net` | 200, cookie issued |
| `evil.example` | **421, no cookie** |

An unrecognised Host gets 421 naming the flag that fixes it, rather than the binary
refusing to start — a dead process on a headless tailnet box is a worse failure than a
legible error.

## Things worth knowing about the design

- **Origin is checked before the token**, so a cross-origin caller with a stolen token
  gets 403 and learns nothing about token validity.
- **OPTIONS is answered before the token check**, because a CORS preflight never
  carries credentials. The origin check still runs first.
- **`?token=` is accepted only on a WebSocket upgrade.** A browser socket cannot set
  headers, and the cookie already covers same-origin sockets, so the parameter exists
  solely for the cross-site Vite dev proxy. Accepting it elsewhere would leak the token
  into history, `Referer` and proxy logs for no benefit. `Upgrade` is a fetch-forbidden
  header, so a page cannot forge it.
- **An absent `Origin` is allowed** — but *not* because browsers always send one. They
  do not: `<img>`, `<script>`, `<link>`, top-level navigation and `<form method=GET>`
  all omit it. It is safe because every mutating route is POST while those vectors are
  GET-only, and because `SameSite=Strict` means no cross-site request carries the
  cookie at all. The code says this, because a later switch to `SameSite=Lax` to make
  deep links work would silently reopen it.
- **A nil gate fails closed.** `-no-auth` is a configuration choice and passes through;
  an unwired gate is a programming error and returns 500 rather than serving `/api/`
  unauthenticated.

## Testing

`go build ./...`, `go vet ./server/...` and `go test ./server/...` all clean.

The end-to-end regression test was **proven to bite**: moving `SPAHandler` outside the
host gate makes it fail with `1 cookies issued to an unrecognized Host — the token is
being handed to a rebound attacker`, and restoring the wiring makes it pass. A
regression test that has never failed is an assertion about hope.

## Known follow-ups, not in this PR

- No `server/` test exercises `pane_ws` at all. That gap is why the earlier ack-ordering
  defect in #3 survived five reviews, and it applies here too — the WebSocket origin
  path is covered by reasoning and unit tests, not an end-to-end one. Needs a
  WebSocket + tmux harness.
- `server/agents_test.go:90` has a genuine pre-existing data race over
  `httptest.ResponseRecorder`, `-race`-only, unrelated to this branch. Not fixed here
  because a later milestone deletes `/api/agents` outright. Flagged so it isn't
  re-reported as new.
- `deriveHosts` reverse-resolves this host's own CGNAT address, bounded to 2s so a dead
  resolver cannot stall startup. An attacker who controlled the PTR record for our own
  tailnet address could add one name to the allowlist; that requires control of your
  tailnet's reverse zone and widens the list by a name rather than defeating the gate.

https://claude.ai/code/session_01S3QQF9tpsskteWqRJN3Hn6
