### PR TITLE
feat(runs): make the agent run the primary object, served at /api/runs

### DIFF
--- a/docs/superpowers/plans/2026-09-08-run-model-and-runs-api.md
+++ b/docs/superpowers/plans/2026-09-08-run-model-and-runs-api.md
@@ -1,0 +1,1920 @@
+# Run model, source registry and /api/runs — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the agent run — not the tmux pane — the thing houston is a list of, and expose it at `/api/runs` **alongside** the existing routes so nothing breaks while the UI still uses them.
+
+**Architecture:** One `Run` struct with a single state vocabulary. Sources publish sparse per-source *layers*; a registry composes them by a fixed precedence, so "which source wins for this field" is one ordered list rather than logic scattered across writers. Three sources ship here: Claude Code hooks (via the existing hub), tmux user-options written by lazytmux, and the dispatcher crew bus. Runs correlate on tmux pane id, which every source can produce or resolve.
+
+**Tech Stack:** Go stdlib, plus the existing `fsnotify` and `gorilla/websocket`. No new dependencies. No frontend changes.
+
+**Spec:** `docs/superpowers/specs/2026-09-07-houston-overhaul-design.md` — sections "The `Run` model", "Sources, correlation and merge", "API surface".
+
+## Global Constraints
+
+- **Additive only.** `/api/sessions`, `/api/agents`, `/api/pane/*` keep working
+  exactly as they do. Deleting them is a separate plan, after the UI moves.
+- **No frontend changes.** `ui/` is untouched.
+- **No new dependencies.**
+- **Every new route sits behind the existing auth gate**, i.e. registered on the
+  same `apiMux` that `s.auth.middleware` wraps. A new route added outside it
+  would reopen the hole closed in #4.
+- **Tests:** `go test ./...` from the repo root. NOTE: `server/agents_test.go:90`
+  has a pre-existing data race — run the server package WITHOUT `-race`, and use
+  `-race` scoped with `-run` to your own tests. Tracked in issue #6.
+- `go build ./...` needs `ui/dist`; use `just build`, or build `./runs/...` and
+  `./server/...` directly.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `runs/run.go` | `Run` and its sub-structs; no logic | **Create** |
+| `runs/state.go` | The single state vocabulary + the three mappings into it | **Create** |
+| `runs/registry.go` | `Source`, `Delta`, layered `Registry`, precedence, correlation | **Create** |
+| `runs/hooksource.go` | Claude Code hook state, via the existing hub | **Create** |
+| `runs/tmuxsource.go` | lazytmux's tmux user-options | **Create** |
+| `runs/crewsource.go` | dispatcher crew bus | **Create** |
+| `tmux/options.go` | Two format-string queries for window/pane user-options | **Create** |
+| `server/runs_api.go` | `GET /api/runs`, `GET /api/runs/stream` | **Create** |
+| `server/server.go` | Build the registry, register the two routes | Modify |
+
+A new `runs/` package rather than growing `server/`: the registry has no HTTP
+concerns, and keeping it importable without `server` is what will let a future
+peer-federation source live beside it.
+
+---
+
+### Task 1: The Run model and one state vocabulary
+
+Three vocabularies exist today and disagree. This is the only place they are
+reconciled.
+
+**Files:**
+- Create: `runs/run.go`, `runs/state.go`
+- Test: `runs/state_test.go`
+
+**Interfaces:**
+- Produces: `Run`, `State` + its constants, `TmuxRef`, `IssueRef`, `PRRef`,
+  `CrewRef`, `Activity`, `Question`, `Tokens`, `Caps`,
+  `FromHookState(hook.State) State`, `FromCrewState(string) State`,
+  `FromClaudeStatus(string) State`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `runs/state_test.go`:
+
+```go
+package runs
+
+import (
+	"testing"
+
+	"github.com/noamsto/houston/hook"
+)
+
+func TestFromHookState(t *testing.T) {
+	tests := map[hook.State]State{
+		hook.StateThinking:    StateThinking,
+		hook.StateStarting:    StateThinking,
+		hook.StateToolRunning: StateRunning,
+		hook.StateWaiting:     StateBlocked,
+		hook.StatePermission:  StateBlocked,
+		hook.StateCompacting:  StateCompacting,
+		hook.StateEnded:       StateDone,
+	}
+	for in, want := range tests {
+		if got := FromHookState(in); got != want {
+			t.Errorf("FromHookState(%q) = %q, want %q", in, got, want)
+		}
+	}
+	if got := FromHookState(hook.State("nonsense")); got != StateIdle {
+		t.Errorf("unknown hook state = %q, want %q", got, StateIdle)
+	}
+}
+
+func TestFromCrewState(t *testing.T) {
+	tests := map[string]State{
+		"working": StateRunning,
+		"blocked": StateBlocked,
+		"pr_open": StateReview,
+		"done":    StateDone,
+		"failed":  StateFailed,
+		"exited":  StateFailed,
+	}
+	for in, want := range tests {
+		if got := FromCrewState(in); got != want {
+			t.Errorf("FromCrewState(%q) = %q, want %q", in, got, want)
+		}
+	}
+	if got := FromCrewState(""); got != StateIdle {
+		t.Errorf("empty crew state = %q, want %q", got, StateIdle)
+	}
+}
+
+func TestFromClaudeStatus(t *testing.T) {
+	// The value is lazytmux's "@claude_status", whose first field is the state.
+	tests := map[string]State{
+		"processing 1788848628 ":  StateRunning,
+		"waiting 1788848628 1":    StateBlocked,
+		"denied 1788848628 ":      StateBlocked,
+		"compacting 1788848628 ":  StateCompacting,
+		"error 1788848628 ":       StateFailed,
+		"done 1788848628 ":        StateDone,
+		"idle 1788846509 ":        StateIdle,
+		"interrupted 1788846509 ": StateIdle,
+		"":                        StateIdle,
+	}
+	for in, want := range tests {
+		if got := FromClaudeStatus(in); got != want {
+			t.Errorf("FromClaudeStatus(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestBlockedIsTheOnlyNeedsYouState(t *testing.T) {
+	// Exactly one state means "a human is required". The badge, the sort order
+	// and (later) push notifications all key off this, so nothing else may
+	// claim it.
+	needsYou := 0
+	for _, s := range AllStates() {
+		if s.NeedsAttention() {
+			needsYou++
+		}
+	}
+	if needsYou != 1 {
+		t.Fatalf("%d states report NeedsAttention, want exactly 1 (blocked)", needsYou)
+	}
+	if !StateBlocked.NeedsAttention() {
+		t.Fatal("blocked does not report NeedsAttention")
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./runs/ -v`
+Expected: FAIL to compile — the package does not exist.
+
+- [ ] **Step 3: Write `runs/run.go`**
+
+```go
+// Package runs models one agent run — a Claude Code, Codex, Cursor, amp,
+// OpenCode or pi session — independent of where it happens to be running.
+package runs
+
+// Run is one agent run, anywhere. It is the only object the UI lists.
+type Run struct {
+	ID    string `json:"id"`
+	Host  string `json:"host,omitempty"` // "" means local
+	Agent string `json:"agent"`
+	State State  `json:"state"`
+
+	Repo     string `json:"repo,omitempty"`
+	Branch   string `json:"branch,omitempty"`
+	Worktree string `json:"worktree,omitempty"`
+
+	Tmux  *TmuxRef  `json:"tmux,omitempty"`
+	Issue *IssueRef `json:"issue,omitempty"`
+	PR    *PRRef    `json:"pr,omitempty"`
+	Crew  *CrewRef  `json:"crew,omitempty"`
+
+	Activity Activity  `json:"activity"`
+	Question *Question `json:"question,omitempty"`
+	Tokens   Tokens    `json:"tokens"`
+
+	Since     int64 `json:"since,omitempty"`
+	UpdatedAt int64 `json:"updated_at"`
+
+	// Stale means a source stopped reporting. The Run keeps its last known
+	// values and says so; it is never a State, because a stale run still has
+	// one.
+	Stale bool `json:"stale,omitempty"`
+
+	Caps Caps `json:"caps"`
+}
+
+// TmuxRef locates a run's pane. Nil for agents with no pane.
+type TmuxRef struct {
+	Session string `json:"session"`
+	Window  int    `json:"window"`
+	PaneID  string `json:"pane_id"` // "%307"
+}
+
+type IssueRef struct {
+	ID       string `json:"id"` // "#320"
+	Title    string `json:"title,omitempty"`
+	URL      string `json:"url,omitempty"`
+	Provider string `json:"provider,omitempty"`
+}
+
+type PRRef struct {
+	Number     string `json:"number"`
+	State      string `json:"state,omitempty"`
+	CheckState string `json:"check_state,omitempty"`
+	Mergeable  string `json:"mergeable,omitempty"`
+	Draft      bool   `json:"draft,omitempty"`
+	URL        string `json:"url,omitempty"`
+}
+
+type CrewRef struct {
+	Name  string `json:"name"`
+	Color string `json:"color,omitempty"`
+	Tier  string `json:"tier,omitempty"`
+}
+
+// Activity is what the run is doing right now.
+type Activity struct {
+	Tool    string      `json:"tool,omitempty"`
+	Hint    string      `json:"hint,omitempty"`
+	Message string      `json:"message,omitempty"`
+	Task    string      `json:"task,omitempty"`
+	Trail   []TrailChip `json:"trail,omitempty"`
+	Preview string      `json:"preview,omitempty"`
+	Turn    int         `json:"turn,omitempty"`
+}
+
+type TrailChip struct {
+	Tool    string `json:"tool"`
+	Hint    string `json:"hint,omitempty"`
+	Done    bool   `json:"done"`
+	IsError bool   `json:"error,omitempty"`
+}
+
+// Question is the thing a human answers. Non-nil implies State == StateBlocked.
+type Question struct {
+	Text string `json:"text"`
+	// Via is how an answer is delivered: "pane" or "crew".
+	Via string `json:"via"`
+}
+
+type Tokens struct {
+	Input  int `json:"input"`
+	Output int `json:"output"`
+}
+
+// Caps is what this run supports right now. The UI renders affordances from
+// capabilities rather than branching on Agent, so a new agent needs no UI change.
+type Caps struct {
+	Terminal bool `json:"terminal"`
+	Reply    bool `json:"reply"`
+	Kill     bool `json:"kill"`
+}
+```
+
+- [ ] **Step 4: Write `runs/state.go`**
+
+```go
+package runs
+
+import (
+	"strings"
+
+	"github.com/noamsto/houston/hook"
+)
+
+// State is houston's single vocabulary for what a run is doing. Three upstream
+// vocabularies map into it — Claude Code hooks, the dispatcher crew bus, and
+// lazytmux's @claude_status — and they disagree with each other, so this is the
+// only place the reconciliation lives.
+type State string
+
+const (
+	StateThinking   State = "thinking"
+	StateRunning    State = "running"
+	StateBlocked    State = "blocked"
+	StateCompacting State = "compacting"
+	StateReview     State = "review"
+	StateDone       State = "done"
+	StateFailed     State = "failed"
+	StateIdle       State = "idle"
+)
+
+// AllStates lists every state, for exhaustiveness tests.
+func AllStates() []State {
+	return []State{
+		StateThinking, StateRunning, StateBlocked, StateCompacting,
+		StateReview, StateDone, StateFailed, StateIdle,
+	}
+}
+
+// NeedsAttention reports whether a human is required. Exactly one state says
+// yes: it drives the badge, the sort order and later the push notification, so
+// nothing else may claim it.
+func (s State) NeedsAttention() bool { return s == StateBlocked }
+
+func FromHookState(s hook.State) State {
+	switch s {
+	case hook.StateThinking, hook.StateStarting:
+		return StateThinking
+	case hook.StateToolRunning:
+		return StateRunning
+	case hook.StateWaiting, hook.StatePermission:
+		return StateBlocked
+	case hook.StateCompacting:
+		return StateCompacting
+	case hook.StateEnded:
+		return StateDone
+	default:
+		return StateIdle
+	}
+}
+
+func FromCrewState(s string) State {
+	switch s {
+	case "working":
+		return StateRunning
+	case "blocked":
+		return StateBlocked
+	case "pr_open":
+		return StateReview
+	case "done":
+		return StateDone
+	case "failed", "exited":
+		return StateFailed
+	default:
+		return StateIdle
+	}
+}
+
+// FromClaudeStatus reads lazytmux's @claude_status pane option, whose format is
+// "<state> <epoch> <unseen>". Only the first field is a state.
+func FromClaudeStatus(v string) State {
+	word, _, _ := strings.Cut(strings.TrimSpace(v), " ")
+	switch word {
+	case "processing":
+		return StateRunning
+	case "waiting", "denied":
+		return StateBlocked
+	case "compacting":
+		return StateCompacting
+	case "error":
+		return StateFailed
+	case "done":
+		return StateDone
+	default:
+		// Covers "idle", "interrupted" and the empty string. Interrupting is
+		// something the user did deliberately, so it must not raise a badge.
+		return StateIdle
+	}
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `go test ./runs/ -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add runs/
+git commit -m "feat(runs): Run model and one state vocabulary"
+```
+
+---
+
+### Task 2: Layered registry with fixed precedence
+
+Sources never see each other. Each publishes a sparse `Run` as its own layer;
+the registry composes layers in a fixed order. Precedence is therefore one
+ordered list rather than merge logic spread across writers.
+
+**Files:**
+- Create: `runs/registry.go`
+- Test: `runs/registry_test.go`
+
+**Interfaces:**
+- Consumes: `Run`, `State` from Task 1.
+- Produces:
+  - `type Delta struct { Source, Key string; Run Run; Gone bool }`
+  - `type Source interface { Name() string; Run(ctx context.Context, out chan<- Delta) error }`
+  - `func NewRegistry(order []string) *Registry`
+  - `func (r *Registry) Apply(d Delta)`
+  - `func (r *Registry) Snapshot() []Run`
+  - `func (r *Registry) Subscribe() chan Run` / `Unsubscribe(chan Run)`
+  - `var DefaultOrder = []string{"hooks", "crew", "tmux"}`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `runs/registry_test.go`:
+
+```go
+package runs
+
+import (
+	"testing"
+)
+
+func TestPrecedenceHooksBeatTmux(t *testing.T) {
+	r := NewRegistry(DefaultOrder)
+	r.Apply(Delta{Source: "tmux", Key: "%1", Run: Run{State: StateIdle, Branch: "main"}})
+	r.Apply(Delta{Source: "hooks", Key: "%1", Run: Run{State: StateRunning}})
+
+	got := r.Snapshot()
+	if len(got) != 1 {
+		t.Fatalf("%d runs, want 1 — both deltas key on the same pane", len(got))
+	}
+	if got[0].State != StateRunning {
+		t.Errorf("State = %q, want %q — hooks outrank tmux", got[0].State, StateRunning)
+	}
+	if got[0].Branch != "main" {
+		t.Errorf("Branch = %q, want %q — tmux still supplies fields hooks leaves empty",
+			got[0].Branch, "main")
+	}
+}
+
+func TestLowerPrecedenceCannotBlankAHigherField(t *testing.T) {
+	r := NewRegistry(DefaultOrder)
+	r.Apply(Delta{Source: "hooks", Key: "%1", Run: Run{State: StateRunning}})
+	r.Apply(Delta{Source: "tmux", Key: "%1", Run: Run{State: ""}})
+
+	if got := r.Snapshot()[0].State; got != StateRunning {
+		t.Fatalf("State = %q, want %q — an empty field must not overwrite a set one", got, StateRunning)
+	}
+}
+
+func TestCrewBeatsTmuxButNotHooks(t *testing.T) {
+	r := NewRegistry(DefaultOrder)
+	r.Apply(Delta{Source: "tmux", Key: "%1", Run: Run{State: StateIdle}})
+	r.Apply(Delta{Source: "crew", Key: "%1", Run: Run{State: StateBlocked}})
+	if got := r.Snapshot()[0].State; got != StateBlocked {
+		t.Fatalf("State = %q, want %q", got, StateBlocked)
+	}
+
+	r.Apply(Delta{Source: "hooks", Key: "%1", Run: Run{State: StateRunning}})
+	if got := r.Snapshot()[0].State; got != StateRunning {
+		t.Fatalf("State = %q, want %q", got, StateRunning)
+	}
+}
+
+func TestGoneRemovesOnlyThatSourcesLayer(t *testing.T) {
+	r := NewRegistry(DefaultOrder)
+	r.Apply(Delta{Source: "tmux", Key: "%1", Run: Run{Branch: "main"}})
+	r.Apply(Delta{Source: "hooks", Key: "%1", Run: Run{State: StateRunning}})
+
+	r.Apply(Delta{Source: "hooks", Key: "%1", Gone: true})
+
+	got := r.Snapshot()
+	if len(got) != 1 {
+		t.Fatalf("%d runs, want 1 — the tmux layer still describes this pane", len(got))
+	}
+	if got[0].Branch != "main" {
+		t.Errorf("Branch = %q, want main", got[0].Branch)
+	}
+
+	r.Apply(Delta{Source: "tmux", Key: "%1", Gone: true})
+	if n := len(r.Snapshot()); n != 0 {
+		t.Fatalf("%d runs after the last layer went away, want 0", n)
+	}
+}
+
+func TestSubscribeReceivesComposedRun(t *testing.T) {
+	r := NewRegistry(DefaultOrder)
+	sub := r.Subscribe()
+	defer r.Unsubscribe(sub)
+
+	r.Apply(Delta{Source: "tmux", Key: "%1", Run: Run{Branch: "main"}})
+	r.Apply(Delta{Source: "hooks", Key: "%1", Run: Run{State: StateRunning}})
+
+	var last Run
+	for i := 0; i < 2; i++ {
+		select {
+		case last = <-sub:
+		default:
+			t.Fatalf("only %d broadcasts received", i)
+		}
+	}
+	if last.State != StateRunning || last.Branch != "main" {
+		t.Fatalf("subscriber got %+v, want the composed run, not one layer", last)
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./runs/ -run 'TestPrecedence|TestLower|TestCrew|TestGone|TestSubscribe' -v`
+Expected: FAIL to compile — `undefined: NewRegistry`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `runs/registry.go`:
+
+```go
+package runs
+
+import (
+	"context"
+	"sort"
+	"sync"
+)
+
+// Delta is one source's view of one run. A source publishes only the fields it
+// owns; everything else stays zero and is filled by another layer.
+type Delta struct {
+	Source string
+	Key    string // correlation key — the tmux pane id where there is one
+	Run    Run
+	Gone   bool // this source no longer describes Key
+}
+
+// Source produces Deltas until ctx is cancelled.
+type Source interface {
+	Name() string
+	Run(ctx context.Context, out chan<- Delta) error
+}
+
+// DefaultOrder is the precedence, lowest first. Hooks win because they fire
+// synchronously with the event they describe; tmux options lose because they
+// are a periodic scrape.
+var DefaultOrder = []string{"tmux", "crew", "hooks"}
+
+// Registry composes per-source layers into one Run per key.
+type Registry struct {
+	order map[string]int
+
+	mu     sync.RWMutex
+	layers map[string]map[string]Run // key -> source -> layer
+	subs   map[chan Run]struct{}
+}
+
+func NewRegistry(order []string) *Registry {
+	idx := make(map[string]int, len(order))
+	for i, name := range order {
+		idx[name] = i
+	}
+	return &Registry{
+		order:  idx,
+		layers: map[string]map[string]Run{},
+		subs:   map[chan Run]struct{}{},
+	}
+}
+
+// Apply records a source's layer and broadcasts the recomposed run.
+func (r *Registry) Apply(d Delta) {
+	r.mu.Lock()
+	if d.Gone {
+		if bySource, ok := r.layers[d.Key]; ok {
+			delete(bySource, d.Source)
+			if len(bySource) == 0 {
+				delete(r.layers, d.Key)
+			}
+		}
+	} else {
+		if r.layers[d.Key] == nil {
+			r.layers[d.Key] = map[string]Run{}
+		}
+		r.layers[d.Key][d.Source] = d.Run
+	}
+	composed, live := r.composeLocked(d.Key)
+	subs := make([]chan Run, 0, len(r.subs))
+	for ch := range r.subs {
+		subs = append(subs, ch)
+	}
+	r.mu.Unlock()
+
+	if !live {
+		return
+	}
+	for _, ch := range subs {
+		select {
+		case ch <- composed:
+		default: // a slow subscriber drops updates, never blocks the source
+		}
+	}
+}
+
+// composeLocked merges one key's layers in precedence order. Caller holds mu.
+func (r *Registry) composeLocked(key string) (Run, bool) {
+	bySource, ok := r.layers[key]
+	if !ok || len(bySource) == 0 {
+		return Run{}, false
+	}
+
+	names := make([]string, 0, len(bySource))
+	for name := range bySource {
+		names = append(names, name)
+	}
+	sort.Slice(names, func(i, j int) bool { return r.order[names[i]] < r.order[names[j]] })
+
+	var out Run
+	for _, name := range names {
+		mergeInto(&out, bySource[name])
+	}
+	out.ID = key
+	return out, true
+}
+
+// mergeInto copies every set field of src over dst. A zero field means "this
+// source has no opinion", so it never blanks a value a lower layer supplied.
+func mergeInto(dst *Run, src Run) {
+	if src.Host != "" {
+		dst.Host = src.Host
+	}
+	if src.Agent != "" {
+		dst.Agent = src.Agent
+	}
+	if src.State != "" {
+		dst.State = src.State
+	}
+	if src.Repo != "" {
+		dst.Repo = src.Repo
+	}
+	if src.Branch != "" {
+		dst.Branch = src.Branch
+	}
+	if src.Worktree != "" {
+		dst.Worktree = src.Worktree
+	}
+	if src.Tmux != nil {
+		dst.Tmux = src.Tmux
+	}
+	if src.Issue != nil {
+		dst.Issue = src.Issue
+	}
+	if src.PR != nil {
+		dst.PR = src.PR
+	}
+	if src.Crew != nil {
+		dst.Crew = src.Crew
+	}
+	if src.Question != nil {
+		dst.Question = src.Question
+	}
+	if src.Activity.Tool != "" {
+		dst.Activity.Tool = src.Activity.Tool
+	}
+	if src.Activity.Hint != "" {
+		dst.Activity.Hint = src.Activity.Hint
+	}
+	if src.Activity.Message != "" {
+		dst.Activity.Message = src.Activity.Message
+	}
+	if src.Activity.Task != "" {
+		dst.Activity.Task = src.Activity.Task
+	}
+	if len(src.Activity.Trail) > 0 {
+		dst.Activity.Trail = src.Activity.Trail
+	}
+	if src.Activity.Preview != "" {
+		dst.Activity.Preview = src.Activity.Preview
+	}
+	if src.Activity.Turn != 0 {
+		dst.Activity.Turn = src.Activity.Turn
+	}
+	if src.Tokens.Input != 0 {
+		dst.Tokens.Input = src.Tokens.Input
+	}
+	if src.Tokens.Output != 0 {
+		dst.Tokens.Output = src.Tokens.Output
+	}
+	if src.Since != 0 {
+		dst.Since = src.Since
+	}
+	if src.UpdatedAt > dst.UpdatedAt {
+		dst.UpdatedAt = src.UpdatedAt
+	}
+	if src.Stale {
+		dst.Stale = true
+	}
+	if src.Caps.Terminal {
+		dst.Caps.Terminal = true
+	}
+	if src.Caps.Reply {
+		dst.Caps.Reply = true
+	}
+	if src.Caps.Kill {
+		dst.Caps.Kill = true
+	}
+}
+
+func (r *Registry) Snapshot() []Run {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	keys := make([]string, 0, len(r.layers))
+	for k := range r.layers {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	out := make([]Run, 0, len(keys))
+	for _, k := range keys {
+		if run, ok := r.composeLocked(k); ok {
+			out = append(out, run)
+		}
+	}
+	return out
+}
+
+func (r *Registry) Subscribe() chan Run {
+	ch := make(chan Run, 64)
+	r.mu.Lock()
+	r.subs[ch] = struct{}{}
+	r.mu.Unlock()
+	return ch
+}
+
+func (r *Registry) Unsubscribe(ch chan Run) {
+	r.mu.Lock()
+	if _, ok := r.subs[ch]; ok {
+		delete(r.subs, ch)
+		close(ch)
+	}
+	r.mu.Unlock()
+}
+```
+
+Note `composeLocked` is called from `Snapshot` under `RLock` and from `Apply`
+under `Lock`. It only reads, so both are safe.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `go test ./runs/ -race -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add runs/registry.go runs/registry_test.go
+git commit -m "feat(runs): layered registry with fixed source precedence"
+```
+
+---
+
+### Task 3: `hooksource` — Claude Code hooks via the existing hub
+
+The hub already watches `<state-dir>/claude/` and tails transcripts. Reuse it
+rather than duplicating that machinery: `hooksource` subscribes and converts.
+
+**Files:**
+- Create: `runs/hooksource.go`
+- Test: `runs/hooksource_test.go`
+
+**Interfaces:**
+- Consumes: `Delta`, `Source`, `FromHookState` from Tasks 1-2.
+- Produces: `func NewHookSource(h *hub.Hub) *HookSource`, and
+  `func runFromSessionView(v hub.SessionView) (key string, r Run)` — exported
+  within the package for the test.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `runs/hooksource_test.go`:
+
+```go
+package runs
+
+import (
+	"testing"
+
+	"github.com/noamsto/houston/hook"
+	"github.com/noamsto/houston/hub"
+)
+
+func TestRunFromSessionViewKeysOnPane(t *testing.T) {
+	key, r := runFromSessionView(hub.SessionView{
+		SessionID:   "abc-123",
+		TmuxSession: "houston",
+		TmuxWindow:  "1",
+		TmuxPane:    "%307",
+		State:       hook.StateToolRunning,
+		Tool:        "Bash",
+	})
+
+	if key != "%307" {
+		t.Fatalf("key = %q, want the tmux pane id — that is what every source correlates on", key)
+	}
+	if r.State != StateRunning {
+		t.Errorf("State = %q, want %q", r.State, StateRunning)
+	}
+	if r.Tmux == nil || r.Tmux.PaneID != "%307" || r.Tmux.Session != "houston" || r.Tmux.Window != 1 {
+		t.Errorf("TmuxRef = %+v, want session houston window 1 pane %%307", r.Tmux)
+	}
+	if r.Agent != "claude" {
+		t.Errorf("Agent = %q, want claude", r.Agent)
+	}
+	if !r.Caps.Terminal || !r.Caps.Reply {
+		t.Errorf("Caps = %+v, want terminal and reply for a pane-backed run", r.Caps)
+	}
+}
+
+func TestRunFromSessionViewFallsBackToSessionID(t *testing.T) {
+	key, r := runFromSessionView(hub.SessionView{SessionID: "abc-123"})
+
+	if key != "claude/abc-123" {
+		t.Fatalf("key = %q, want claude/abc-123 when there is no pane", key)
+	}
+	if r.Tmux != nil {
+		t.Errorf("TmuxRef = %+v, want nil without a pane", r.Tmux)
+	}
+	if r.Caps.Terminal {
+		t.Error("Caps.Terminal is true without a pane — there is nothing to attach to")
+	}
+}
+
+func TestRunFromSessionViewCarriesQuestionWhenBlocked(t *testing.T) {
+	_, r := runFromSessionView(hub.SessionView{
+		SessionID:   "abc",
+		TmuxPane:    "%1",
+		State:       hook.StatePermission,
+		LastMessage: "Allow Bash(rm -rf)?",
+	})
+	if r.State != StateBlocked {
+		t.Fatalf("State = %q, want blocked", r.State)
+	}
+	if r.Question == nil || r.Question.Text != "Allow Bash(rm -rf)?" {
+		t.Fatalf("Question = %+v, want the permission prompt", r.Question)
+	}
+	if r.Question.Via != "pane" {
+		t.Errorf("Question.Via = %q, want pane", r.Question.Via)
+	}
+}
+```
+
+- [ ] **Step 2: Check whether `hub.SessionView` exposes the pane**
+
+Run: `rg -n 'TmuxPane' hub/hub.go`
+
+`hub.SessionView` currently carries `TmuxSession` and `TmuxWindow` but **not**
+`TmuxPane`, while `hook.SessionState` does. Add the field to `hub.SessionView`
+and populate it wherever `TmuxSession`/`TmuxWindow` are set — it is the
+correlation key every other source needs:
+
+```go
+	TmuxPane    string `json:"tmux_pane,omitempty"`
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `go test ./runs/ -run TestRunFromSessionView -v`
+Expected: FAIL to compile — `undefined: runFromSessionView`.
+
+- [ ] **Step 4: Write the implementation**
+
+Create `runs/hooksource.go`:
+
+```go
+package runs
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/noamsto/houston/hub"
+)
+
+// HookSource publishes Claude Code hook state. It rides the existing hub rather
+// than re-watching the state dir and re-tailing transcripts.
+type HookSource struct{ hub *hub.Hub }
+
+func NewHookSource(h *hub.Hub) *HookSource { return &HookSource{hub: h} }
+
+func (s *HookSource) Name() string { return "hooks" }
+
+func (s *HookSource) Run(ctx context.Context, out chan<- Delta) error {
+	sub := s.hub.Subscribe()
+	defer s.hub.Unsubscribe(sub)
+
+	for _, v := range s.hub.Snapshot() {
+		key, r := runFromSessionView(v)
+		select {
+		case out <- Delta{Source: s.Name(), Key: key, Run: r}:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case v, ok := <-sub:
+			if !ok {
+				return nil
+			}
+			key, r := runFromSessionView(v)
+			select {
+			case out <- Delta{Source: s.Name(), Key: key, Run: r}:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+	}
+}
+
+// runFromSessionView converts one hub view into this source's layer. The key is
+// the tmux pane id when there is one, because that is what tmux and crew
+// deltas can also produce; a headless session falls back to its own id and
+// simply never correlates with them.
+func runFromSessionView(v hub.SessionView) (string, Run) {
+	r := Run{
+		Agent:     "claude",
+		State:     FromHookState(v.State),
+		Worktree:  v.CWD,
+		UpdatedAt: v.UpdatedAt,
+		Since:     v.Since,
+		Tokens:    Tokens{Input: v.InputTokens, Output: v.OutputTokens},
+		Activity: Activity{
+			Tool:    v.Tool,
+			Hint:    v.ToolInputHint,
+			Message: v.LastMessage,
+			Preview: v.Preview,
+			Turn:    v.Turn,
+		},
+	}
+	for _, c := range v.Trail {
+		r.Activity.Trail = append(r.Activity.Trail, TrailChip{
+			Tool: c.Tool, Hint: c.Hint, Done: c.Done, IsError: c.IsError,
+		})
+	}
+
+	key := "claude/" + v.SessionID
+	if v.TmuxPane != "" {
+		key = v.TmuxPane
+		win, _ := strconv.Atoi(v.TmuxWindow)
+		r.Tmux = &TmuxRef{Session: v.TmuxSession, Window: win, PaneID: v.TmuxPane}
+		r.Caps = Caps{Terminal: true, Reply: true, Kill: true}
+	}
+
+	if r.State == StateBlocked && v.LastMessage != "" {
+		r.Question = &Question{Text: v.LastMessage, Via: "pane"}
+	}
+	return key, r
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `go test ./runs/ -race -v` and `go test ./hub/...`
+Expected: PASS both.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add runs/hooksource.go runs/hooksource_test.go hub/hub.go
+git commit -m "feat(runs): hook source over the existing hub"
+```
+
+---
+
+### Task 4: `tmuxsource` — harvest lazytmux's user-options
+
+lazytmux already computes PR state, issue identity, crew membership, branch and
+worktree for every window, keeps them fresh, and parks them in tmux. Houston
+reads them; it does not recompute any of it.
+
+**Verified working on a live server** — two calls harvest everything:
+
+```
+$ tmux list-windows -a -F '#{session_name}|#{window_index}|#{@branch}|#{@issue_id}|#{@pr_number}|#{@crew_name}|#{@window_task}'
+lazytmux|2|feat/320-relay-sixel-and-osc-1337-graphics-for-no|#320|565|mauve|
+
+$ tmux list-panes -a -F '#{pane_id}|#{session_name}:#{window_index}|#{@claude_status}|#{@claude_task}'
+%307|houston:1|processing 1788848628 |and add a proper ci flows task for later
+```
+
+**Files:**
+- Create: `tmux/options.go`, `runs/tmuxsource.go`
+- Test: `tmux/options_test.go`, `runs/tmuxsource_test.go`
+
+**Interfaces:**
+- Produces:
+  - `tmux.WindowOptions` / `tmux.PaneOptions` structs
+  - `func (c *Client) ListWindowOptions() ([]WindowOptions, error)`
+  - `func (c *Client) ListPaneOptions() ([]PaneOptions, error)`
+  - `func ParseWindowOptions(out string) []WindowOptions` (pure, for tests)
+  - `func ParsePaneOptions(out string) []PaneOptions` (pure, for tests)
+  - `func NewTmuxSource(c *tmux.Client, every time.Duration) *TmuxSource`
+
+- [ ] **Step 1: Write the failing parser test**
+
+Create `tmux/options_test.go`:
+
+```go
+package tmux
+
+import "testing"
+
+func TestParseWindowOptions(t *testing.T) {
+	// Real output shape, including the common all-empty-options case.
+	out := "lazytmux|2|feat/320-relay|#320|565|mauve|open|passing|MERGEABLE||\n" +
+		"houston|1|main||||||||\n"
+
+	got := ParseWindowOptions(out)
+	if len(got) != 2 {
+		t.Fatalf("%d windows, want 2", len(got))
+	}
+
+	w := got[0]
+	if w.Session != "lazytmux" || w.Window != 2 {
+		t.Errorf("target = %s:%d, want lazytmux:2", w.Session, w.Window)
+	}
+	if w.Branch != "feat/320-relay" || w.IssueID != "#320" || w.PRNumber != "565" {
+		t.Errorf("got branch=%q issue=%q pr=%q", w.Branch, w.IssueID, w.PRNumber)
+	}
+	if w.CrewName != "mauve" || w.PRState != "open" || w.PRCheckState != "passing" {
+		t.Errorf("got crew=%q pr_state=%q checks=%q", w.CrewName, w.PRState, w.PRCheckState)
+	}
+
+	bare := got[1]
+	if bare.Branch != "main" || bare.IssueID != "" || bare.PRNumber != "" {
+		t.Errorf("a window with no enrichment should carry only its branch, got %+v", bare)
+	}
+}
+
+func TestParseWindowOptionsSkipsMalformedLines(t *testing.T) {
+	got := ParseWindowOptions("too|few|fields\n\nhouston|1|main||||||||\n")
+	if len(got) != 1 {
+		t.Fatalf("%d windows, want 1 — short and empty lines are skipped, not fatal", len(got))
+	}
+}
+
+func TestParsePaneOptions(t *testing.T) {
+	out := "%307|houston:1|processing 1788848628 |and add a ci task\n" +
+		"%283|dispatcher:1||\n"
+
+	got := ParsePaneOptions(out)
+	if len(got) != 2 {
+		t.Fatalf("%d panes, want 2", len(got))
+	}
+	if got[0].PaneID != "%307" || got[0].ClaudeStatus != "processing 1788848628 " {
+		t.Errorf("got %+v", got[0])
+	}
+	if got[0].ClaudeTask != "and add a ci task" {
+		t.Errorf("task = %q", got[0].ClaudeTask)
+	}
+	if got[1].ClaudeStatus != "" {
+		t.Errorf("a pane with no claude status should be empty, got %q", got[1].ClaudeStatus)
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./tmux/ -run TestParse.*Options -v`
+Expected: FAIL to compile — `undefined: ParseWindowOptions`.
+
+- [ ] **Step 3: Write `tmux/options.go`**
+
+```go
+package tmux
+
+import (
+	"strconv"
+	"strings"
+)
+
+// windowOptionsFormat harvests every lazytmux window user-option in one call.
+// tmux resolves #{@name} inline, so no per-window show-options loop is needed.
+const windowOptionsFormat = "#{session_name}|#{window_index}|#{@branch}|#{@issue_id}|" +
+	"#{@pr_number}|#{@crew_name}|#{@pr_state}|#{@pr_check_state}|#{@pr_mergeable}|" +
+	"#{@window_task}|#{@git_root}"
+
+const paneOptionsFormat = "#{pane_id}|#{session_name}:#{window_index}|#{@claude_status}|#{@claude_task}"
+
+// WindowOptions is lazytmux's per-window enrichment. Every field may be empty:
+// a window with no linked issue or PR simply has none.
+type WindowOptions struct {
+	Session      string
+	Window       int
+	Branch       string
+	IssueID      string
+	PRNumber     string
+	CrewName     string
+	PRState      string
+	PRCheckState string
+	PRMergeable  string
+	Task         string
+	GitRoot      string
+}
+
+type PaneOptions struct {
+	PaneID       string
+	Target       string // "session:window"
+	ClaudeStatus string
+	ClaudeTask   string
+}
+
+func (c *Client) ListWindowOptions() ([]WindowOptions, error) {
+	out, err := c.output("list-windows", "-a", "-F", windowOptionsFormat)
+	if err != nil {
+		return nil, err
+	}
+	return ParseWindowOptions(string(out)), nil
+}
+
+func (c *Client) ListPaneOptions() ([]PaneOptions, error) {
+	out, err := c.output("list-panes", "-a", "-F", paneOptionsFormat)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePaneOptions(string(out)), nil
+}
+
+func ParseWindowOptions(out string) []WindowOptions {
+	var res []WindowOptions
+	for _, line := range strings.Split(out, "\n") {
+		f := strings.Split(line, "|")
+		if len(f) < 11 {
+			continue
+		}
+		idx, err := strconv.Atoi(f[1])
+		if err != nil {
+			continue
+		}
+		res = append(res, WindowOptions{
+			Session: f[0], Window: idx, Branch: f[2], IssueID: f[3],
+			PRNumber: f[4], CrewName: f[5], PRState: f[6], PRCheckState: f[7],
+			PRMergeable: f[8], Task: f[9], GitRoot: f[10],
+		})
+	}
+	return res
+}
+
+func ParsePaneOptions(out string) []PaneOptions {
+	var res []PaneOptions
+	for _, line := range strings.Split(out, "\n") {
+		f := strings.Split(line, "|")
+		if len(f) < 4 {
+			continue
+		}
+		res = append(res, PaneOptions{
+			PaneID: f[0], Target: f[1], ClaudeStatus: f[2], ClaudeTask: f[3],
+		})
+	}
+	return res
+}
+```
+
+- [ ] **Step 4: Write the source test**
+
+Create `runs/tmuxsource_test.go`:
+
+```go
+package runs
+
+import (
+	"testing"
+
+	"github.com/noamsto/houston/tmux"
+)
+
+func TestDeltasFromTmuxJoinsPanesToWindows(t *testing.T) {
+	wins := []tmux.WindowOptions{{
+		Session: "lazytmux", Window: 2, Branch: "feat/320",
+		IssueID: "#320", PRNumber: "565", PRState: "open", PRCheckState: "passing",
+		CrewName: "mauve", GitRoot: "/home/n/git/lazytmux",
+	}}
+	panes := []tmux.PaneOptions{{
+		PaneID: "%459", Target: "lazytmux:2", ClaudeStatus: "processing 1788 ",
+	}}
+
+	got := deltasFromTmux(wins, panes)
+	if len(got) != 1 {
+		t.Fatalf("%d deltas, want 1", len(got))
+	}
+	d := got[0]
+	if d.Key != "%459" {
+		t.Fatalf("Key = %q, want the pane id", d.Key)
+	}
+	if d.Run.State != StateRunning {
+		t.Errorf("State = %q, want running (from @claude_status)", d.Run.State)
+	}
+	if d.Run.Branch != "feat/320" {
+		t.Errorf("Branch = %q — the pane must inherit its window's enrichment", d.Run.Branch)
+	}
+	if d.Run.Issue == nil || d.Run.Issue.ID != "#320" {
+		t.Errorf("Issue = %+v, want #320", d.Run.Issue)
+	}
+	if d.Run.PR == nil || d.Run.PR.Number != "565" || d.Run.PR.CheckState != "passing" {
+		t.Errorf("PR = %+v", d.Run.PR)
+	}
+	if d.Run.Crew == nil || d.Run.Crew.Name != "mauve" {
+		t.Errorf("Crew = %+v", d.Run.Crew)
+	}
+	if d.Run.Repo != "lazytmux" {
+		t.Errorf("Repo = %q, want the git root's base name", d.Run.Repo)
+	}
+}
+
+func TestDeltasFromTmuxOmitsAbsentEnrichment(t *testing.T) {
+	got := deltasFromTmux(
+		[]tmux.WindowOptions{{Session: "houston", Window: 1, Branch: "main"}},
+		[]tmux.PaneOptions{{PaneID: "%1", Target: "houston:1"}},
+	)
+	d := got[0].Run
+	if d.Issue != nil || d.PR != nil || d.Crew != nil {
+		t.Fatalf("absent options must stay nil, got issue=%+v pr=%+v crew=%+v", d.Issue, d.PR, d.Crew)
+	}
+	if d.Branch != "main" {
+		t.Errorf("Branch = %q, want main", d.Branch)
+	}
+}
+
+func TestDeltasFromTmuxSkipsPanesWithNoWindow(t *testing.T) {
+	got := deltasFromTmux(nil, []tmux.PaneOptions{{PaneID: "%9", Target: "ghost:1"}})
+	if len(got) != 0 {
+		t.Fatalf("%d deltas for a pane whose window was not listed, want 0", len(got))
+	}
+}
+```
+
+- [ ] **Step 5: Run it to verify it fails**
+
+Run: `go test ./runs/ -run TestDeltasFromTmux -v`
+Expected: FAIL to compile — `undefined: deltasFromTmux`.
+
+- [ ] **Step 6: Write `runs/tmuxsource.go`**
+
+```go
+package runs
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"time"
+
+	"github.com/noamsto/houston/tmux"
+)
+
+// TmuxSource reads the enrichment lazytmux already computes and parks in tmux
+// user-options: branch, worktree, linked issue, PR state and crew membership.
+// Houston never recomputes any of it.
+type TmuxSource struct {
+	client *tmux.Client
+	every  time.Duration
+}
+
+func NewTmuxSource(c *tmux.Client, every time.Duration) *TmuxSource {
+	if every <= 0 {
+		every = 2 * time.Second
+	}
+	return &TmuxSource{client: c, every: every}
+}
+
+func (s *TmuxSource) Name() string { return "tmux" }
+
+func (s *TmuxSource) Run(ctx context.Context, out chan<- Delta) error {
+	t := time.NewTicker(s.every)
+	defer t.Stop()
+
+	seen := map[string]bool{}
+	for {
+		wins, err := s.client.ListWindowOptions()
+		if err != nil {
+			slog.Debug("tmux window options", "error", err)
+		}
+		panes, err := s.client.ListPaneOptions()
+		if err != nil {
+			slog.Debug("tmux pane options", "error", err)
+		}
+
+		now := map[string]bool{}
+		for _, d := range deltasFromTmux(wins, panes) {
+			now[d.Key] = true
+			select {
+			case out <- d:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+		for key := range seen {
+			if !now[key] {
+				select {
+				case out <- Delta{Source: s.Name(), Key: key, Gone: true}:
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+			}
+		}
+		seen = now
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-t.C:
+		}
+	}
+}
+
+// deltasFromTmux joins each pane to its window's enrichment. A pane whose
+// window was not listed is skipped rather than emitted bare — it means the two
+// queries raced a window closing.
+func deltasFromTmux(wins []tmux.WindowOptions, panes []tmux.PaneOptions) []Delta {
+	byTarget := make(map[string]tmux.WindowOptions, len(wins))
+	for _, w := range wins {
+		byTarget[fmt.Sprintf("%s:%d", w.Session, w.Window)] = w
+	}
+
+	out := make([]Delta, 0, len(panes))
+	for _, p := range panes {
+		w, ok := byTarget[p.Target]
+		if !ok {
+			continue
+		}
+
+		r := Run{
+			State:    FromClaudeStatus(p.ClaudeStatus),
+			Branch:   w.Branch,
+			Worktree: w.GitRoot,
+			Tmux:     &TmuxRef{Session: w.Session, Window: w.Window, PaneID: p.PaneID},
+			Activity: Activity{Task: firstNonEmpty(p.ClaudeTask, w.Task)},
+			Caps:     Caps{Terminal: true, Reply: true, Kill: true},
+		}
+		if w.GitRoot != "" {
+			r.Repo = filepath.Base(w.GitRoot)
+		}
+		if w.IssueID != "" {
+			r.Issue = &IssueRef{ID: w.IssueID}
+		}
+		if w.PRNumber != "" && w.PRNumber != "none" {
+			r.PR = &PRRef{
+				Number: w.PRNumber, State: w.PRState,
+				CheckState: w.PRCheckState, Mergeable: w.PRMergeable,
+			}
+		}
+		if w.CrewName != "" {
+			r.Crew = &CrewRef{Name: w.CrewName}
+		}
+		out = append(out, Delta{Source: "tmux", Key: p.PaneID, Run: r})
+	}
+	return out
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+```
+
+- [ ] **Step 7: Run all tests**
+
+Run: `go test ./tmux/... ./runs/... -race`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add tmux/options.go tmux/options_test.go runs/tmuxsource.go runs/tmuxsource_test.go
+git commit -m "feat(runs): harvest lazytmux enrichment from tmux user-options"
+```
+
+---
+
+### Task 5: `crewsource` — the dispatcher bus
+
+The bus is an append-only JSONL log under `.git/crew/`. Records look like:
+
+```json
+{"ts":1788,"crew_id":"c1","from":"worker:fix/412#s1","to":"dispatcher:c1","kind":"status","body":{"state":"blocked","detail":"Keep the alias?"}}
+{"ts":1788,"crew_id":"c1","kind":"dispatch","branch":"fix/412","title":"fix the ws drop"}
+```
+
+**Files:**
+- Create: `runs/crewsource.go`
+- Test: `runs/crewsource_test.go`
+
+**Interfaces:**
+- Produces: `func NewCrewSource(repos []string, every time.Duration) *CrewSource`,
+  and `func deltasFromCrewLog(r io.Reader) map[string]Run` keyed by branch.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `runs/crewsource_test.go`:
+
+```go
+package runs
+
+import (
+	"strings"
+	"testing"
+)
+
+const crewFixture = `{"ts":1000,"crew_id":"c1","kind":"dispatch","branch":"fix/412","title":"fix the ws drop","tier":"standard"}
+{"ts":1100,"crew_id":"c1","from":"worker:fix/412#s1","kind":"status","body":{"state":"working"}}
+{"ts":1200,"crew_id":"c1","from":"worker:fix/412#s1","kind":"status","body":{"state":"blocked","detail":"Keep the legacy route?"}}
+{"ts":1300,"crew_id":"c1","from":"worker:feat/413#s2","kind":"status","body":{"state":"pr_open","pr_url":"https://github.com/x/y/pull/9"}}
+not json at all
+`
+
+func TestDeltasFromCrewLogTakesLatestStatePerBranch(t *testing.T) {
+	got := deltasFromCrewLog(strings.NewReader(crewFixture))
+
+	r, ok := got["fix/412"]
+	if !ok {
+		t.Fatalf("no entry for fix/412, got keys %v", keysOf(got))
+	}
+	if r.State != StateBlocked {
+		t.Errorf("State = %q, want blocked — the latest status wins", r.State)
+	}
+	if r.Question == nil || r.Question.Text != "Keep the legacy route?" {
+		t.Errorf("Question = %+v, want the blocking detail", r.Question)
+	}
+	if r.Question != nil && r.Question.Via != "crew" {
+		t.Errorf("Question.Via = %q, want crew — it is answered with `crew reply`", r.Question.Via)
+	}
+}
+
+func TestDeltasFromCrewLogCarriesDispatchMetadata(t *testing.T) {
+	got := deltasFromCrewLog(strings.NewReader(crewFixture))
+	r := got["fix/412"]
+	if r.Crew == nil || r.Crew.Name != "c1" || r.Crew.Tier != "standard" {
+		t.Fatalf("Crew = %+v, want name c1 tier standard", r.Crew)
+	}
+	if r.Branch != "fix/412" {
+		t.Errorf("Branch = %q", r.Branch)
+	}
+}
+
+func TestDeltasFromCrewLogSurvivesGarbageLines(t *testing.T) {
+	got := deltasFromCrewLog(strings.NewReader(crewFixture))
+	if _, ok := got["feat/413"]; !ok {
+		t.Fatal("a malformed line stopped later records being read")
+	}
+	if got["feat/413"].State != StateReview {
+		t.Errorf("feat/413 State = %q, want review", got["feat/413"].State)
+	}
+}
+
+func keysOf(m map[string]Run) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `go test ./runs/ -run TestDeltasFromCrewLog -v`
+Expected: FAIL to compile — `undefined: deltasFromCrewLog`.
+
+- [ ] **Step 3: Write `runs/crewsource.go`**
+
+```go
+package runs
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// CrewSource reads dispatcher's git-backed bus. It contributes the one thing
+// no other source can express: a worker blocked on a question addressed to you.
+type CrewSource struct {
+	repos []string // repo roots to look under for .git/crew
+	every time.Duration
+}
+
+func NewCrewSource(repos []string, every time.Duration) *CrewSource {
+	if every <= 0 {
+		every = 3 * time.Second
+	}
+	return &CrewSource{repos: repos, every: every}
+}
+
+func (s *CrewSource) Name() string { return "crew" }
+
+func (s *CrewSource) Run(ctx context.Context, out chan<- Delta) error {
+	t := time.NewTicker(s.every)
+	defer t.Stop()
+
+	for {
+		for branch, r := range s.scan() {
+			select {
+			case out <- Delta{Source: s.Name(), Key: "branch/" + branch, Run: r}:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-t.C:
+		}
+	}
+}
+
+func (s *CrewSource) scan() map[string]Run {
+	merged := map[string]Run{}
+	for _, repo := range s.repos {
+		logs, err := filepath.Glob(filepath.Join(repo, ".git", "crew", "*.jsonl"))
+		if err != nil {
+			continue
+		}
+		for _, path := range logs {
+			f, err := os.Open(path)
+			if err != nil {
+				slog.Debug("crew log", "path", path, "error", err)
+				continue
+			}
+			for branch, r := range deltasFromCrewLog(f) {
+				merged[branch] = r
+			}
+			_ = f.Close()
+		}
+	}
+	return merged
+}
+
+type crewRecord struct {
+	TS     int64  `json:"ts"`
+	CrewID string `json:"crew_id"`
+	From   string `json:"from"`
+	Kind   string `json:"kind"`
+	Branch string `json:"branch"`
+	Title  string `json:"title"`
+	Tier   string `json:"tier"`
+	Body   struct {
+		State  string `json:"state"`
+		Detail string `json:"detail"`
+		PRURL  string `json:"pr_url"`
+	} `json:"body"`
+}
+
+// deltasFromCrewLog folds one bus log into the latest state per branch. The bus
+// is append-only, so later records win.
+func deltasFromCrewLog(rd io.Reader) map[string]Run {
+	out := map[string]Run{}
+	sc := bufio.NewScanner(rd)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	for sc.Scan() {
+		var rec crewRecord
+		if err := json.Unmarshal(sc.Bytes(), &rec); err != nil {
+			continue // the bus is written by shell; a torn line is not fatal
+		}
+
+		branch := rec.Branch
+		if branch == "" {
+			branch = branchFromWorker(rec.From)
+		}
+		if branch == "" {
+			continue
+		}
+
+		r := out[branch]
+		r.Branch = branch
+		if r.Crew == nil {
+			r.Crew = &CrewRef{}
+		}
+		if rec.CrewID != "" {
+			r.Crew.Name = rec.CrewID
+		}
+		if rec.Tier != "" {
+			r.Crew.Tier = rec.Tier
+		}
+		if rec.Kind == "status" && rec.Body.State != "" {
+			r.State = FromCrewState(rec.Body.State)
+			r.UpdatedAt = rec.TS / 1000
+			r.Question = nil
+			if r.State == StateBlocked && rec.Body.Detail != "" {
+				r.Question = &Question{Text: rec.Body.Detail, Via: "crew"}
+			}
+		}
+		out[branch] = r
+	}
+	return out
+}
+
+// branchFromWorker turns "worker:fix/412#s1788-42" into "fix/412".
+func branchFromWorker(from string) string {
+	if !strings.HasPrefix(from, "worker:") {
+		return ""
+	}
+	rest := strings.TrimPrefix(from, "worker:")
+	if i := strings.LastIndex(rest, "#"); i >= 0 {
+		rest = rest[:i]
+	}
+	return rest
+}
+```
+
+Note the key is `branch/<name>`, not a pane id — a crew record knows its branch,
+not its pane. Joining crew runs to their panes needs the branch that
+`tmuxsource` publishes, and is deliberately **not** attempted here: it is a
+registry-level concern and belongs in the plan that adds the Crews tab. Until
+then a crew-backed run appears as its own entry, which is honest.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `go test ./runs/... -race`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add runs/crewsource.go runs/crewsource_test.go
+git commit -m "feat(runs): read dispatcher crew bus for blocked questions"
+```
+
+---
+
+### Task 6: `/api/runs` and `/api/runs/stream`
+
+Additive. The existing routes are untouched.
+
+**Files:**
+- Create: `server/runs_api.go`
+- Modify: `server/server.go`
+- Test: `server/runs_api_test.go`
+
+**Interfaces:**
+- Consumes: `runs.Registry` from Task 2, the sources from Tasks 3-5.
+- Produces: `Server.runs *runs.Registry`, two handlers.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `server/runs_api_test.go`:
+
+```go
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/noamsto/houston/runs"
+)
+
+func TestRunsSnapshotReturnsComposedRuns(t *testing.T) {
+	reg := runs.NewRegistry(runs.DefaultOrder)
+	reg.Apply(runs.Delta{Source: "tmux", Key: "%1", Run: runs.Run{Branch: "main"}})
+	reg.Apply(runs.Delta{Source: "hooks", Key: "%1", Run: runs.Run{State: runs.StateRunning}})
+
+	s := &Server{runs: reg}
+	rec := httptest.NewRecorder()
+	s.handleRunsSnapshot(rec, httptest.NewRequest("GET", "/api/runs", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d, want 200", rec.Code)
+	}
+	var got []runs.Run
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v — body %s", err, rec.Body.String())
+	}
+	if len(got) != 1 || got[0].State != runs.StateRunning || got[0].Branch != "main" {
+		t.Fatalf("got %+v, want one composed run", got)
+	}
+}
+
+func TestRunsSnapshotWithoutRegistryIs503(t *testing.T) {
+	s := &Server{} // registry never started
+	rec := httptest.NewRecorder()
+	s.handleRunsSnapshot(rec, httptest.NewRequest("GET", "/api/runs", nil))
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status %d, want 503", rec.Code)
+	}
+}
+
+func TestRunsRoutesAreBehindTheAuthGate(t *testing.T) {
+	// A new route registered outside apiMux would reopen the hole closed in #4.
+	dir := t.TempDir()
+	s, err := New(Config{StatusDir: dir, AuthEnabled: true})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "http://127.0.0.1/api/runs", nil)
+	req.Host = "127.0.0.1"
+	rec := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status %d, want 401 — /api/runs must require a token", rec.Code)
+	}
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `go test ./server/ -run TestRuns -v`
+Expected: FAIL to compile — `unknown field runs in struct literal`.
+
+- [ ] **Step 3: Write `server/runs_api.go`**
+
+```go
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+// handleRunsSnapshot returns every known run.
+//
+//	GET /api/runs → []runs.Run
+func (s *Server) handleRunsSnapshot(w http.ResponseWriter, _ *http.Request) {
+	if s.runs == nil {
+		http.Error(w, "run registry not started", http.StatusServiceUnavailable)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(s.runs.Snapshot())
+}
+
+// handleRunsStream emits run updates over SSE: one "snapshot" event, then one
+// "update" per composed change.
+//
+//	GET /api/runs/stream → text/event-stream
+func (s *Server) handleRunsStream(w http.ResponseWriter, r *http.Request) {
+	if s.runs == nil {
+		http.Error(w, "run registry not started", http.StatusServiceUnavailable)
+		return
+	}
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	h := w.Header()
+	h.Set("Content-Type", "text/event-stream")
+	h.Set("Cache-Control", "no-cache")
+	h.Set("Connection", "keep-alive")
+	h.Set("X-Accel-Buffering", "no")
+
+	snap, _ := json.Marshal(s.runs.Snapshot())
+	fmt.Fprintf(w, "event: snapshot\ndata: %s\n\n", snap)
+	flusher.Flush()
+
+	sub := s.runs.Subscribe()
+	defer s.runs.Unsubscribe(sub)
+
+	ping := time.NewTicker(25 * time.Second)
+	defer ping.Stop()
+
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case run, ok := <-sub:
+			if !ok {
+				return
+			}
+			b, err := json.Marshal(run)
+			if err != nil {
+				slog.Warn("runs stream marshal", "err", err)
+				continue
+			}
+			if _, err := fmt.Fprintf(w, "event: update\ndata: %s\n\n", b); err != nil {
+				return
+			}
+			flusher.Flush()
+		case <-ping.C:
+			if _, err := fmt.Fprint(w, ": ping\n\n"); err != nil {
+				return
+			}
+			flusher.Flush()
+		}
+	}
+}
+```
+
+- [ ] **Step 4: Wire it into `server/server.go`**
+
+Add to the `Server` struct:
+
+```go
+	runs *runs.Registry
+```
+
+In `New`, after the hub is started, build the registry and start the sources.
+Reuse the same context the hub uses:
+
+```go
+	reg := runs.NewRegistry(runs.DefaultOrder)
+	s.runs = reg
+
+	deltas := make(chan runs.Delta, 256)
+	go func() {
+		for d := range deltas {
+			reg.Apply(d)
+		}
+	}()
+
+	for _, src := range []runs.Source{
+		runs.NewHookSource(s.hub),
+		runs.NewTmuxSource(tmuxClient, 2*time.Second),
+		runs.NewCrewSource(crewRepoRoots(), 3*time.Second),
+	} {
+		go func(src runs.Source) {
+			if err := src.Run(ctx, deltas); err != nil && ctx.Err() == nil {
+				slog.Warn("run source stopped", "source", src.Name(), "error", err)
+			}
+		}(src)
+	}
+```
+
+Add a small helper that returns the repo roots to scan for `.git/crew`, derived
+from the git roots tmux already reports so no configuration is needed:
+
+```go
+// crewRepoRoots returns the distinct git roots tmux knows about, which is where
+// dispatcher's bus lives. Deriving them costs one tmux call and needs no config.
+func crewRepoRoots() []string {
+	c := tmux.NewClient()
+	wins, err := c.ListWindowOptions()
+	if err != nil {
+		return nil
+	}
+	seen := map[string]bool{}
+	var out []string
+	for _, w := range wins {
+		if w.GitRoot != "" && !seen[w.GitRoot] {
+			seen[w.GitRoot] = true
+			out = append(out, w.GitRoot)
+		}
+	}
+	return out
+}
+```
+
+Register the routes **on `apiMux`**, so they inherit the auth gate:
+
+```go
+	apiMux.HandleFunc("/api/runs", s.handleRunsSnapshot)
+	apiMux.HandleFunc("/api/runs/stream", s.handleRunsStream)
+```
+
+- [ ] **Step 5: Run the tests**
+
+Run: `go test ./server/... ./runs/... ./tmux/...`
+Expected: PASS. Then `go test ./runs/... ./tmux/... -race`.
+
+- [ ] **Step 6: Verify against the live server by hand**
+
+```bash
+just build && ./houston -addr 127.0.0.1:9095 &
+curl -s -H "Authorization: Bearer $(cat ~/.local/state/houston/token)" \
+     http://127.0.0.1:9095/api/runs | head -c 2000
+```
+
+Expect real runs with `branch`, and where lazytmux has enriched the window,
+`issue` and `pr` populated. Confirm `/api/sessions` and `/api/agents` still
+answer — this plan must not disturb them. Kill the server afterwards; do NOT run
+any tmux command that affects a server or session you did not create.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/ runs/
+git commit -m "feat(server): serve /api/runs alongside the existing routes"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec requirement | Task |
+|---|---|
+| `Run` model with `Caps` and `Stale` | 1 |
+| Single state vocabulary, three mappings | 1 |
+| `Source` interface + registry | 2 |
+| Per-field precedence hooks → crew → tmux | 2 |
+| Correlation on tmux pane id | 2, 3, 4 |
+| `hooksource` | 3 |
+| `tmuxsource` harvesting lazytmux options | 4 |
+| `crewsource` for blocked questions | 5 |
+| `GET /api/runs`, `GET /api/runs/stream` | 6 |
+| Deleting the old routes | **out of scope** — follow-up plan, after the UI moves |
+| Screen-scraping demoted to amp/generic | **out of scope** — happens when `/api/sessions` goes |
+| `Run.Host` for federation | field exists; no peer source yet |
+
+**Placeholder scan:** none.
+
+**Type consistency:** `Run`, `State`, `Delta`, `Source`, `Registry`,
+`NewRegistry`, `Apply`, `Snapshot`, `Subscribe`, `Unsubscribe`, `DefaultOrder`,
+`FromHookState`, `FromCrewState`, `FromClaudeStatus`, `runFromSessionView`,
+`deltasFromTmux`, `deltasFromCrewLog`, `ListWindowOptions`, `ListPaneOptions`,
+`ParseWindowOptions`, `ParsePaneOptions` are spelled identically everywhere.
+
+**One thing a reviewer should push on:** crew runs key on `branch/<name>` while
+hook and tmux runs key on a pane id, so a dispatcher worker currently appears
+twice — once as its pane, once as its branch. That is deliberate for this plan
+(joining them needs branch-to-pane resolution that belongs with the Crews tab)
+but it is visible in `/api/runs` output, and it must not be mistaken for a bug.

--- a/hub/hub.go
+++ b/hub/hub.go
@@ -26,22 +26,23 @@ type TrailChip struct {
 
 // SessionView is the DTO the server emits over SSE for one agent card.
 type SessionView struct {
-	SessionID      string          `json:"session_id"`
-	CWD            string          `json:"cwd,omitempty"`
-	TmuxSession    string          `json:"tmux_session,omitempty"`
-	TmuxWindow     string          `json:"tmux_window,omitempty"`
-	State          hook.State      `json:"state"`
-	Tool           string          `json:"tool,omitempty"`
-	ToolInputHint  string          `json:"tool_input_hint,omitempty"`
-	LastMessage    string          `json:"last_message,omitempty"`
-	Turn           int             `json:"turn"`
-	Since          int64           `json:"since,omitempty"`
-	UpdatedAt      int64           `json:"updated_at"`
-	Trail          []TrailChip     `json:"trail,omitempty"`
-	Preview        string          `json:"preview,omitempty"`
-	InputTokens    int             `json:"input_tokens"`
-	OutputTokens   int             `json:"output_tokens"`
-	TranscriptPath string          `json:"transcript_path,omitempty"`
+	SessionID      string      `json:"session_id"`
+	CWD            string      `json:"cwd,omitempty"`
+	TmuxSession    string      `json:"tmux_session,omitempty"`
+	TmuxWindow     string      `json:"tmux_window,omitempty"`
+	TmuxPane       string      `json:"tmux_pane,omitempty"`
+	State          hook.State  `json:"state"`
+	Tool           string      `json:"tool,omitempty"`
+	ToolInputHint  string      `json:"tool_input_hint,omitempty"`
+	LastMessage    string      `json:"last_message,omitempty"`
+	Turn           int         `json:"turn"`
+	Since          int64       `json:"since,omitempty"`
+	UpdatedAt      int64       `json:"updated_at"`
+	Trail          []TrailChip `json:"trail,omitempty"`
+	Preview        string      `json:"preview,omitempty"`
+	InputTokens    int         `json:"input_tokens"`
+	OutputTokens   int         `json:"output_tokens"`
+	TranscriptPath string      `json:"transcript_path,omitempty"`
 }
 
 // Hub aggregates hook state files + transcript tails and exposes updates.
@@ -406,6 +407,7 @@ func mergeStateIntoView(v *SessionView, s hook.SessionState) {
 	v.CWD = s.CWD
 	v.TmuxSession = s.TmuxSession
 	v.TmuxWindow = s.TmuxWindow
+	v.TmuxPane = s.TmuxPane
 	v.State = s.State
 	v.Tool = s.Tool
 	v.ToolInputHint = s.ToolInputHint

--- a/runs/crewsource.go
+++ b/runs/crewsource.go
@@ -1,0 +1,162 @@
+package runs
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/noamsto/houston/tmux"
+)
+
+// CrewSource reads dispatcher's git-backed bus. It contributes the one thing
+// no other source can express: a worker blocked on a question addressed to you.
+//
+// It derives its own repo roots from the same ListWindowOptions call tmuxsource
+// uses, rather than taking them from the caller — that keeps construction free
+// of I/O and self-contained.
+type CrewSource struct {
+	client *tmux.Client
+	every  time.Duration
+}
+
+func NewCrewSource(c *tmux.Client, every time.Duration) *CrewSource {
+	if every <= 0 {
+		every = 3 * time.Second
+	}
+	return &CrewSource{client: c, every: every}
+}
+
+func (s *CrewSource) Name() string { return "crew" }
+
+func (s *CrewSource) Run(ctx context.Context, out chan<- Delta) error {
+	t := time.NewTicker(s.every)
+	defer t.Stop()
+
+	for {
+		for branch, r := range s.scan() {
+			select {
+			case out <- Delta{Source: s.Name(), Key: "branch/" + branch, Run: r}:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-t.C:
+		}
+	}
+}
+
+func (s *CrewSource) scan() map[string]Run {
+	wins, err := s.client.ListWindowOptions()
+	if err != nil {
+		slog.Debug("crew source: list window options", "error", err)
+		return nil
+	}
+
+	roots := map[string]bool{}
+	for _, w := range wins {
+		if w.GitRoot != "" {
+			roots[w.GitRoot] = true
+		}
+	}
+
+	merged := map[string]Run{}
+	for repo := range roots {
+		logs, err := filepath.Glob(filepath.Join(repo, ".git", "crew", "*.jsonl"))
+		if err != nil {
+			continue
+		}
+		for _, path := range logs {
+			f, err := os.Open(path)
+			if err != nil {
+				slog.Debug("crew log", "path", path, "error", err)
+				continue
+			}
+			for branch, r := range deltasFromCrewLog(f) {
+				merged[branch] = r
+			}
+			_ = f.Close()
+		}
+	}
+	return merged
+}
+
+type crewRecord struct {
+	TS     int64  `json:"ts"`
+	CrewID string `json:"crew_id"`
+	From   string `json:"from"`
+	Kind   string `json:"kind"`
+	Branch string `json:"branch"`
+	Title  string `json:"title"`
+	Tier   string `json:"tier"`
+	Body   struct {
+		State  string `json:"state"`
+		Detail string `json:"detail"`
+		PRURL  string `json:"pr_url"`
+	} `json:"body"`
+}
+
+// deltasFromCrewLog folds one bus log into the latest state per branch. The bus
+// is append-only, so later records win.
+func deltasFromCrewLog(rd io.Reader) map[string]Run {
+	out := map[string]Run{}
+	sc := bufio.NewScanner(rd)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	for sc.Scan() {
+		var rec crewRecord
+		if err := json.Unmarshal(sc.Bytes(), &rec); err != nil {
+			continue // the bus is written by shell; a torn line is not fatal
+		}
+
+		branch := rec.Branch
+		if branch == "" {
+			branch = branchFromWorker(rec.From)
+		}
+		if branch == "" {
+			continue
+		}
+
+		r := out[branch]
+		r.Branch = branch
+		if r.Crew == nil {
+			r.Crew = &CrewRef{}
+		}
+		if rec.CrewID != "" {
+			r.Crew.Name = rec.CrewID
+		}
+		if rec.Tier != "" {
+			r.Crew.Tier = rec.Tier
+		}
+		if rec.Kind == "status" && rec.Body.State != "" {
+			r.State = FromCrewState(rec.Body.State)
+			r.UpdatedAt = rec.TS / 1000
+			r.Question = nil
+			if r.State == StateBlocked && rec.Body.Detail != "" {
+				r.Question = &Question{Text: rec.Body.Detail, Via: "crew"}
+			}
+		}
+		out[branch] = r
+	}
+	return out
+}
+
+// branchFromWorker turns "worker:fix/412#s1788-42" into "fix/412".
+func branchFromWorker(from string) string {
+	if !strings.HasPrefix(from, "worker:") {
+		return ""
+	}
+	rest := strings.TrimPrefix(from, "worker:")
+	if i := strings.LastIndex(rest, "#"); i >= 0 {
+		rest = rest[:i]
+	}
+	return rest
+}

--- a/runs/crewsource.go
+++ b/runs/crewsource.go
@@ -110,6 +110,10 @@ func (s *CrewSource) scanRoots(roots []string) map[string]Run {
 	return merged
 }
 
+// crewDirTimeout bounds the git call below so a hung git cannot park this
+// source's goroutine forever.
+const crewDirTimeout = 5 * time.Second
+
 // crewDir resolves where dispatcher writes its bus for a checkout.
 // lazytmux's @git_root is the worktree's top level, but dispatcher writes under
 // the COMMON git dir — and in a worktree <root>/.git is a file, not a
@@ -119,14 +123,19 @@ func (s *CrewSource) crewDir(root string) string {
 	if dir, ok := s.crewDirs[root]; ok {
 		return dir
 	}
-	out, err := exec.Command("git", "-C", root, "rev-parse", "--git-common-dir").Output()
+	ctx, cancel := context.WithTimeout(context.Background(), crewDirTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "git", "-C", root, "rev-parse", "--git-common-dir").Output()
 	if err != nil {
 		s.crewDirs[root] = ""
 		return ""
 	}
 	dir := strings.TrimSpace(string(out))
 	if !filepath.IsAbs(dir) {
-		// Older git answers relatively (".git"); resolve against the root.
+		// Whether this comes back relative or absolute depends on whether root
+		// is a worktree or the main checkout, not on git's version: verified on
+		// git 2.55, a worktree answers absolute and the main checkout answers
+		// relative (".git"). Resolve the relative case against root.
 		dir = filepath.Join(root, dir)
 	}
 	dir = filepath.Join(dir, "crew")
@@ -142,7 +151,12 @@ type crewRecord struct {
 	Branch string `json:"branch"`
 	Title  string `json:"title"`
 	Tier   string `json:"tier"`
-	Body   struct {
+	Engine string `json:"engine"`
+	Model  string `json:"model"`
+	// Session is a tmux session name, present on the dispatch record. It is
+	// useful for the later branch->pane join but is not used yet.
+	Session string `json:"session"`
+	Body    struct {
 		State  string `json:"state"`
 		Detail string `json:"detail"`
 		PRURL  string `json:"pr_url"`
@@ -180,6 +194,13 @@ func deltasFromCrewLog(rd io.Reader) map[string]Run {
 		}
 		if rec.Tier != "" {
 			r.Crew.Tier = rec.Tier
+		}
+		// Engine only appears on the dispatch record, but every status record
+		// for the branch shares this map entry, so it sticks once set. Without
+		// it a crew run carries no agent and the listing predicate would drop
+		// it — this source exists specifically to surface blocked questions.
+		if rec.Engine != "" {
+			r.Agent = rec.Engine
 		}
 		if rec.Kind == "status" && rec.Body.State != "" {
 			r.State = FromCrewState(rec.Body.State)

--- a/runs/crewsource.go
+++ b/runs/crewsource.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -23,13 +24,18 @@ import (
 type CrewSource struct {
 	client *tmux.Client
 	every  time.Duration
+
+	// crewDirs caches root -> bus directory, keyed by lazytmux's @git_root.
+	// scan() runs only on this source's own goroutine, so a plain map needs no
+	// mutex — do not add one, and do not read this from another goroutine.
+	crewDirs map[string]string
 }
 
 func NewCrewSource(c *tmux.Client, every time.Duration) *CrewSource {
 	if every <= 0 {
 		every = 3 * time.Second
 	}
-	return &CrewSource{client: c, every: every}
+	return &CrewSource{client: c, every: every, crewDirs: map[string]string{}}
 }
 
 func (s *CrewSource) Name() string { return "crew" }
@@ -68,9 +74,24 @@ func (s *CrewSource) scan() map[string]Run {
 		}
 	}
 
-	merged := map[string]Run{}
+	rootList := make([]string, 0, len(roots))
 	for repo := range roots {
-		logs, err := filepath.Glob(filepath.Join(repo, ".git", "crew", "*.jsonl"))
+		rootList = append(rootList, repo)
+	}
+	return s.scanRoots(rootList)
+}
+
+// scanRoots reads every root's crew bus and folds it into the latest state per
+// branch. Split out from scan() so the root list can be injected in tests
+// without going through tmux.
+func (s *CrewSource) scanRoots(roots []string) map[string]Run {
+	merged := map[string]Run{}
+	for _, repo := range roots {
+		dir := s.crewDir(repo)
+		if dir == "" {
+			continue
+		}
+		logs, err := filepath.Glob(filepath.Join(dir, "*.jsonl"))
 		if err != nil {
 			continue
 		}
@@ -87,6 +108,30 @@ func (s *CrewSource) scan() map[string]Run {
 		}
 	}
 	return merged
+}
+
+// crewDir resolves where dispatcher writes its bus for a checkout.
+// lazytmux's @git_root is the worktree's top level, but dispatcher writes under
+// the COMMON git dir — and in a worktree <root>/.git is a file, not a
+// directory, so joining ".git/crew" there finds nothing. Worktree-per-branch is
+// the normal case here, not an edge case.
+func (s *CrewSource) crewDir(root string) string {
+	if dir, ok := s.crewDirs[root]; ok {
+		return dir
+	}
+	out, err := exec.Command("git", "-C", root, "rev-parse", "--git-common-dir").Output()
+	if err != nil {
+		s.crewDirs[root] = ""
+		return ""
+	}
+	dir := strings.TrimSpace(string(out))
+	if !filepath.IsAbs(dir) {
+		// Older git answers relatively (".git"); resolve against the root.
+		dir = filepath.Join(root, dir)
+	}
+	dir = filepath.Join(dir, "crew")
+	s.crewDirs[root] = dir
+	return dir
 }
 
 type crewRecord struct {

--- a/runs/crewsource_test.go
+++ b/runs/crewsource_test.go
@@ -1,0 +1,60 @@
+package runs
+
+import (
+	"strings"
+	"testing"
+)
+
+const crewFixture = `{"ts":1000,"crew_id":"c1","kind":"dispatch","branch":"fix/412","title":"fix the ws drop","tier":"standard"}
+{"ts":1100,"crew_id":"c1","from":"worker:fix/412#s1","kind":"status","body":{"state":"working"}}
+{"ts":1200,"crew_id":"c1","from":"worker:fix/412#s1","kind":"status","body":{"state":"blocked","detail":"Keep the legacy route?"}}
+{"ts":1300,"crew_id":"c1","from":"worker:feat/413#s2","kind":"status","body":{"state":"pr_open","pr_url":"https://github.com/x/y/pull/9"}}
+not json at all
+`
+
+func TestDeltasFromCrewLogTakesLatestStatePerBranch(t *testing.T) {
+	got := deltasFromCrewLog(strings.NewReader(crewFixture))
+
+	r, ok := got["fix/412"]
+	if !ok {
+		t.Fatalf("no entry for fix/412, got keys %v", keysOf(got))
+	}
+	if r.State != StateBlocked {
+		t.Errorf("State = %q, want blocked — the latest status wins", r.State)
+	}
+	if r.Question == nil || r.Question.Text != "Keep the legacy route?" {
+		t.Errorf("Question = %+v, want the blocking detail", r.Question)
+	}
+	if r.Question != nil && r.Question.Via != "crew" {
+		t.Errorf("Question.Via = %q, want crew — it is answered with `crew reply`", r.Question.Via)
+	}
+}
+
+func TestDeltasFromCrewLogCarriesDispatchMetadata(t *testing.T) {
+	got := deltasFromCrewLog(strings.NewReader(crewFixture))
+	r := got["fix/412"]
+	if r.Crew == nil || r.Crew.Name != "c1" || r.Crew.Tier != "standard" {
+		t.Fatalf("Crew = %+v, want name c1 tier standard", r.Crew)
+	}
+	if r.Branch != "fix/412" {
+		t.Errorf("Branch = %q", r.Branch)
+	}
+}
+
+func TestDeltasFromCrewLogSurvivesGarbageLines(t *testing.T) {
+	got := deltasFromCrewLog(strings.NewReader(crewFixture))
+	if _, ok := got["feat/413"]; !ok {
+		t.Fatal("a malformed line stopped later records being read")
+	}
+	if got["feat/413"].State != StateReview {
+		t.Errorf("feat/413 State = %q, want review", got["feat/413"].State)
+	}
+}
+
+func keysOf(m map[string]Run) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/runs/crewsource_test.go
+++ b/runs/crewsource_test.go
@@ -1,6 +1,9 @@
 package runs
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -48,6 +51,52 @@ func TestDeltasFromCrewLogSurvivesGarbageLines(t *testing.T) {
 	}
 	if got["feat/413"].State != StateReview {
 		t.Errorf("feat/413 State = %q, want review", got["feat/413"].State)
+	}
+}
+
+func TestScanFindsBusFromInsideAWorktree(t *testing.T) {
+	// Worktree-per-branch is this project's mandated topology, and it is the
+	// case that was broken: <worktree>/.git is a file, so the bus lives under
+	// the main checkout's git dir, not the worktree's.
+	main := t.TempDir()
+	for _, args := range [][]string{
+		{"init", "-q", "-b", "main"},
+		{"commit", "-q", "--allow-empty", "-m", "seed"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = main
+		cmd.Env = append(os.Environ(), "GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Skipf("git unavailable: %v %s", err, out)
+		}
+	}
+
+	wt := filepath.Join(t.TempDir(), "wt")
+	cmd := exec.Command("git", "worktree", "add", "-q", "-b", "feat/x", wt)
+	cmd.Dir = main
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Skipf("git worktree unavailable: %v %s", err, out)
+	}
+
+	busDir := filepath.Join(main, ".git", "crew")
+	if err := os.MkdirAll(busDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	line := `{"ts":1000,"crew_id":"c1","from":"worker:feat/x#s1","kind":"status","body":{"state":"blocked","detail":"Keep the alias?"}}` + "\n"
+	if err := os.WriteFile(filepath.Join(busDir, "events.jsonl"), []byte(line), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &CrewSource{crewDirs: map[string]string{}}
+	got := s.scanRoots([]string{wt})
+
+	r, ok := got["feat/x"]
+	if !ok {
+		t.Fatalf("scan found nothing from inside a worktree — keys %v", keysOf(got))
+	}
+	if r.State != StateBlocked || r.Question == nil {
+		t.Fatalf("got %+v, want a blocked run carrying its question", r)
 	}
 }
 

--- a/runs/crewsource_test.go
+++ b/runs/crewsource_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-const crewFixture = `{"ts":1000,"crew_id":"c1","kind":"dispatch","branch":"fix/412","title":"fix the ws drop","tier":"standard"}
+const crewFixture = `{"ts":1000,"crew_id":"c1","kind":"dispatch","branch":"fix/412","title":"fix the ws drop","tier":"standard","engine":"claude","model":"sonnet","session":"houston"}
 {"ts":1100,"crew_id":"c1","from":"worker:fix/412#s1","kind":"status","body":{"state":"working"}}
 {"ts":1200,"crew_id":"c1","from":"worker:fix/412#s1","kind":"status","body":{"state":"blocked","detail":"Keep the legacy route?"}}
 {"ts":1300,"crew_id":"c1","from":"worker:feat/413#s2","kind":"status","body":{"state":"pr_open","pr_url":"https://github.com/x/y/pull/9"}}
@@ -41,6 +41,9 @@ func TestDeltasFromCrewLogCarriesDispatchMetadata(t *testing.T) {
 	}
 	if r.Branch != "fix/412" {
 		t.Errorf("Branch = %q", r.Branch)
+	}
+	if r.Agent != "claude" {
+		t.Errorf("Agent = %q, want claude — without it a crew run has no agent and is never listed", r.Agent)
 	}
 }
 

--- a/runs/hooksource.go
+++ b/runs/hooksource.go
@@ -3,9 +3,14 @@ package runs
 import (
 	"context"
 	"strconv"
+	"time"
 
 	"github.com/noamsto/houston/hub"
 )
+
+// hookGoneCheckInterval is how often HookSource diffs against hub.Snapshot to
+// catch a session hub deleted without broadcasting (see Run).
+const hookGoneCheckInterval = 5 * time.Second
 
 // HookSource publishes Claude Code hook state. It rides the existing hub rather
 // than re-watching the state dir and re-tailing transcripts.
@@ -19,14 +24,30 @@ func (s *HookSource) Run(ctx context.Context, out chan<- Delta) error {
 	sub := s.hub.Subscribe()
 	defer s.hub.Unsubscribe(sub)
 
-	for _, v := range s.hub.Snapshot() {
-		key, r := runFromSessionView(v)
+	seen := map[string]bool{}
+	emit := func(key string, r Run) error {
+		seen[key] = true
 		select {
 		case out <- Delta{Source: s.Name(), Key: key, Run: r}:
+			return nil
 		case <-ctx.Done():
 			return ctx.Err()
 		}
 	}
+
+	for _, v := range s.hub.Snapshot() {
+		key, r := runFromSessionView(v)
+		if err := emit(key, r); err != nil {
+			return err
+		}
+	}
+
+	// hub deletes a session on file removal and broadcasts nothing about it,
+	// so a killed agent would otherwise stay listed forever at its last known
+	// state, capabilities and all. Diff against hub.Snapshot on a ticker to
+	// catch that.
+	t := time.NewTicker(hookGoneCheckInterval)
+	defer t.Stop()
 
 	for {
 		select {
@@ -37,10 +58,25 @@ func (s *HookSource) Run(ctx context.Context, out chan<- Delta) error {
 				return nil
 			}
 			key, r := runFromSessionView(v)
-			select {
-			case out <- Delta{Source: s.Name(), Key: key, Run: r}:
-			case <-ctx.Done():
-				return ctx.Err()
+			if err := emit(key, r); err != nil {
+				return err
+			}
+		case <-t.C:
+			now := map[string]bool{}
+			for _, v := range s.hub.Snapshot() {
+				key, _ := runFromSessionView(v)
+				now[key] = true
+			}
+			for key := range seen {
+				if now[key] {
+					continue
+				}
+				delete(seen, key)
+				select {
+				case out <- Delta{Source: s.Name(), Key: key, Gone: true}:
+				case <-ctx.Done():
+					return ctx.Err()
+				}
 			}
 		}
 	}

--- a/runs/hooksource.go
+++ b/runs/hooksource.go
@@ -1,0 +1,87 @@
+package runs
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/noamsto/houston/hub"
+)
+
+// HookSource publishes Claude Code hook state. It rides the existing hub rather
+// than re-watching the state dir and re-tailing transcripts.
+type HookSource struct{ hub *hub.Hub }
+
+func NewHookSource(h *hub.Hub) *HookSource { return &HookSource{hub: h} }
+
+func (s *HookSource) Name() string { return "hooks" }
+
+func (s *HookSource) Run(ctx context.Context, out chan<- Delta) error {
+	sub := s.hub.Subscribe()
+	defer s.hub.Unsubscribe(sub)
+
+	for _, v := range s.hub.Snapshot() {
+		key, r := runFromSessionView(v)
+		select {
+		case out <- Delta{Source: s.Name(), Key: key, Run: r}:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case v, ok := <-sub:
+			if !ok {
+				return nil
+			}
+			key, r := runFromSessionView(v)
+			select {
+			case out <- Delta{Source: s.Name(), Key: key, Run: r}:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+	}
+}
+
+// runFromSessionView converts one hub view into this source's layer. The key is
+// the tmux pane id when there is one, because that is what tmux and crew
+// deltas can also produce; a headless session falls back to its own id and
+// simply never correlates with them.
+func runFromSessionView(v hub.SessionView) (string, Run) {
+	r := Run{
+		Agent:     "claude",
+		State:     FromHookState(v.State),
+		Worktree:  v.CWD,
+		UpdatedAt: v.UpdatedAt,
+		Since:     v.Since,
+		Tokens:    Tokens{Input: v.InputTokens, Output: v.OutputTokens},
+		Activity: Activity{
+			Tool:    v.Tool,
+			Hint:    v.ToolInputHint,
+			Message: v.LastMessage,
+			Preview: v.Preview,
+			Turn:    v.Turn,
+		},
+	}
+	for _, c := range v.Trail {
+		r.Activity.Trail = append(r.Activity.Trail, TrailChip{
+			Tool: c.Tool, Hint: c.Hint, Done: c.Done, IsError: c.IsError,
+		})
+	}
+
+	key := "claude/" + v.SessionID
+	if v.TmuxPane != "" {
+		key = v.TmuxPane
+		win, _ := strconv.Atoi(v.TmuxWindow)
+		r.Tmux = &TmuxRef{Session: v.TmuxSession, Window: win, PaneID: v.TmuxPane}
+		r.Caps = Caps{Terminal: true, Reply: true, Kill: true}
+	}
+
+	if r.State == StateBlocked && v.LastMessage != "" {
+		r.Question = &Question{Text: v.LastMessage, Via: "pane"}
+	}
+	return key, r
+}

--- a/runs/hooksource_test.go
+++ b/runs/hooksource_test.go
@@ -1,0 +1,67 @@
+package runs
+
+import (
+	"testing"
+
+	"github.com/noamsto/houston/hook"
+	"github.com/noamsto/houston/hub"
+)
+
+func TestRunFromSessionViewKeysOnPane(t *testing.T) {
+	key, r := runFromSessionView(hub.SessionView{
+		SessionID:   "abc-123",
+		TmuxSession: "houston",
+		TmuxWindow:  "1",
+		TmuxPane:    "%307",
+		State:       hook.StateToolRunning,
+		Tool:        "Bash",
+	})
+
+	if key != "%307" {
+		t.Fatalf("key = %q, want the tmux pane id — that is what every source correlates on", key)
+	}
+	if r.State != StateRunning {
+		t.Errorf("State = %q, want %q", r.State, StateRunning)
+	}
+	if r.Tmux == nil || r.Tmux.PaneID != "%307" || r.Tmux.Session != "houston" || r.Tmux.Window != 1 {
+		t.Errorf("TmuxRef = %+v, want session houston window 1 pane %%307", r.Tmux)
+	}
+	if r.Agent != "claude" {
+		t.Errorf("Agent = %q, want claude", r.Agent)
+	}
+	if !r.Caps.Terminal || !r.Caps.Reply {
+		t.Errorf("Caps = %+v, want terminal and reply for a pane-backed run", r.Caps)
+	}
+}
+
+func TestRunFromSessionViewFallsBackToSessionID(t *testing.T) {
+	key, r := runFromSessionView(hub.SessionView{SessionID: "abc-123"})
+
+	if key != "claude/abc-123" {
+		t.Fatalf("key = %q, want claude/abc-123 when there is no pane", key)
+	}
+	if r.Tmux != nil {
+		t.Errorf("TmuxRef = %+v, want nil without a pane", r.Tmux)
+	}
+	if r.Caps.Terminal {
+		t.Error("Caps.Terminal is true without a pane — there is nothing to attach to")
+	}
+}
+
+func TestRunFromSessionViewCarriesQuestionWhenBlocked(t *testing.T) {
+	_, r := runFromSessionView(hub.SessionView{
+		SessionID:   "abc",
+		TmuxPane:    "%1",
+		State:       hook.StatePermission,
+		LastMessage: "Allow Bash(rm -rf)?",
+	})
+	if r.State != StateBlocked {
+		t.Fatalf("State = %q, want blocked", r.State)
+	}
+	if r.Question == nil || r.Question.Text != "Allow Bash(rm -rf)?" {
+		t.Fatalf("Question = %+v, want the permission prompt", r.Question)
+	}
+	if r.Question.Via != "pane" {
+		t.Errorf("Question.Via = %q, want pane", r.Question.Via)
+	}
+}

--- a/runs/registry.go
+++ b/runs/registry.go
@@ -64,16 +64,18 @@ func (r *Registry) Apply(d Delta) {
 		r.layers[d.Key][d.Source] = d.Run
 	}
 	composed, live := r.composeLocked(d.Key)
-	subs := make([]chan Run, 0, len(r.subs))
-	for ch := range r.subs {
-		subs = append(subs, ch)
-	}
 	r.mu.Unlock()
 
 	if !live {
 		return
 	}
-	for _, ch := range subs {
+
+	// Fan out under RLock, as hub.broadcast does. Unsubscribe takes the write
+	// lock to close a channel, so it cannot close one while we hold this —
+	// which is what stops a send racing a close and panicking.
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for ch := range r.subs {
 		select {
 		case ch <- composed:
 		default: // a slow subscriber drops updates, never blocks the source
@@ -92,7 +94,16 @@ func (r *Registry) composeLocked(key string) (Run, bool) {
 	for name := range bySource {
 		names = append(names, name)
 	}
-	sort.Slice(names, func(i, j int) bool { return r.order[names[i]] < r.order[names[j]] })
+	// A name absent from order is strictly lowest precedence (merged first),
+	// rather than tying with index 0 and landing wherever the unstable sort
+	// happens to put it.
+	rank := func(name string) int {
+		if i, ok := r.order[name]; ok {
+			return i
+		}
+		return -1
+	}
+	sort.Slice(names, func(i, j int) bool { return rank(names[i]) < rank(names[j]) })
 
 	var out Run
 	for _, name := range names {
@@ -151,7 +162,7 @@ func mergeInto(dst *Run, src Run) {
 		dst.Activity.Task = src.Activity.Task
 	}
 	if len(src.Activity.Trail) > 0 {
-		dst.Activity.Trail = src.Activity.Trail
+		dst.Activity.Trail = append([]TrailChip(nil), src.Activity.Trail...)
 	}
 	if src.Activity.Preview != "" {
 		dst.Activity.Preview = src.Activity.Preview

--- a/runs/registry.go
+++ b/runs/registry.go
@@ -1,0 +1,222 @@
+package runs
+
+import (
+	"context"
+	"sort"
+	"sync"
+)
+
+// Delta is one source's view of one run. A source publishes only the fields it
+// owns; everything else stays zero and is filled by another layer.
+type Delta struct {
+	Source string
+	Key    string // correlation key — the tmux pane id where there is one
+	Run    Run
+	Gone   bool // this source no longer describes Key
+}
+
+// Source produces Deltas until ctx is cancelled.
+type Source interface {
+	Name() string
+	Run(ctx context.Context, out chan<- Delta) error
+}
+
+// DefaultOrder is the precedence, lowest first. Hooks win because they fire
+// synchronously with the event they describe; tmux options lose because they
+// are a periodic scrape.
+var DefaultOrder = []string{"tmux", "crew", "hooks"}
+
+// Registry composes per-source layers into one Run per key.
+type Registry struct {
+	order map[string]int
+
+	mu     sync.RWMutex
+	layers map[string]map[string]Run // key -> source -> layer
+	subs   map[chan Run]struct{}
+}
+
+func NewRegistry(order []string) *Registry {
+	idx := make(map[string]int, len(order))
+	for i, name := range order {
+		idx[name] = i
+	}
+	return &Registry{
+		order:  idx,
+		layers: map[string]map[string]Run{},
+		subs:   map[chan Run]struct{}{},
+	}
+}
+
+// Apply records a source's layer and broadcasts the recomposed run.
+func (r *Registry) Apply(d Delta) {
+	r.mu.Lock()
+	if d.Gone {
+		if bySource, ok := r.layers[d.Key]; ok {
+			delete(bySource, d.Source)
+			if len(bySource) == 0 {
+				delete(r.layers, d.Key)
+			}
+		}
+	} else {
+		if r.layers[d.Key] == nil {
+			r.layers[d.Key] = map[string]Run{}
+		}
+		r.layers[d.Key][d.Source] = d.Run
+	}
+	composed, live := r.composeLocked(d.Key)
+	subs := make([]chan Run, 0, len(r.subs))
+	for ch := range r.subs {
+		subs = append(subs, ch)
+	}
+	r.mu.Unlock()
+
+	if !live {
+		return
+	}
+	for _, ch := range subs {
+		select {
+		case ch <- composed:
+		default: // a slow subscriber drops updates, never blocks the source
+		}
+	}
+}
+
+// composeLocked merges one key's layers in precedence order. Caller holds mu.
+func (r *Registry) composeLocked(key string) (Run, bool) {
+	bySource, ok := r.layers[key]
+	if !ok || len(bySource) == 0 {
+		return Run{}, false
+	}
+
+	names := make([]string, 0, len(bySource))
+	for name := range bySource {
+		names = append(names, name)
+	}
+	sort.Slice(names, func(i, j int) bool { return r.order[names[i]] < r.order[names[j]] })
+
+	var out Run
+	for _, name := range names {
+		mergeInto(&out, bySource[name])
+	}
+	out.ID = key
+	return out, true
+}
+
+// mergeInto copies every set field of src over dst. A zero field means "this
+// source has no opinion", so it never blanks a value a lower layer supplied.
+func mergeInto(dst *Run, src Run) {
+	if src.Host != "" {
+		dst.Host = src.Host
+	}
+	if src.Agent != "" {
+		dst.Agent = src.Agent
+	}
+	if src.State != "" {
+		dst.State = src.State
+	}
+	if src.Repo != "" {
+		dst.Repo = src.Repo
+	}
+	if src.Branch != "" {
+		dst.Branch = src.Branch
+	}
+	if src.Worktree != "" {
+		dst.Worktree = src.Worktree
+	}
+	if src.Tmux != nil {
+		dst.Tmux = src.Tmux
+	}
+	if src.Issue != nil {
+		dst.Issue = src.Issue
+	}
+	if src.PR != nil {
+		dst.PR = src.PR
+	}
+	if src.Crew != nil {
+		dst.Crew = src.Crew
+	}
+	if src.Question != nil {
+		dst.Question = src.Question
+	}
+	if src.Activity.Tool != "" {
+		dst.Activity.Tool = src.Activity.Tool
+	}
+	if src.Activity.Hint != "" {
+		dst.Activity.Hint = src.Activity.Hint
+	}
+	if src.Activity.Message != "" {
+		dst.Activity.Message = src.Activity.Message
+	}
+	if src.Activity.Task != "" {
+		dst.Activity.Task = src.Activity.Task
+	}
+	if len(src.Activity.Trail) > 0 {
+		dst.Activity.Trail = src.Activity.Trail
+	}
+	if src.Activity.Preview != "" {
+		dst.Activity.Preview = src.Activity.Preview
+	}
+	if src.Activity.Turn != 0 {
+		dst.Activity.Turn = src.Activity.Turn
+	}
+	if src.Tokens.Input != 0 {
+		dst.Tokens.Input = src.Tokens.Input
+	}
+	if src.Tokens.Output != 0 {
+		dst.Tokens.Output = src.Tokens.Output
+	}
+	if src.Since != 0 {
+		dst.Since = src.Since
+	}
+	if src.UpdatedAt > dst.UpdatedAt {
+		dst.UpdatedAt = src.UpdatedAt
+	}
+	if src.Stale {
+		dst.Stale = true
+	}
+	if src.Caps.Terminal {
+		dst.Caps.Terminal = true
+	}
+	if src.Caps.Reply {
+		dst.Caps.Reply = true
+	}
+	if src.Caps.Kill {
+		dst.Caps.Kill = true
+	}
+}
+
+func (r *Registry) Snapshot() []Run {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	keys := make([]string, 0, len(r.layers))
+	for k := range r.layers {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	out := make([]Run, 0, len(keys))
+	for _, k := range keys {
+		if run, ok := r.composeLocked(k); ok {
+			out = append(out, run)
+		}
+	}
+	return out
+}
+
+func (r *Registry) Subscribe() chan Run {
+	ch := make(chan Run, 64)
+	r.mu.Lock()
+	r.subs[ch] = struct{}{}
+	r.mu.Unlock()
+	return ch
+}
+
+func (r *Registry) Unsubscribe(ch chan Run) {
+	r.mu.Lock()
+	if _, ok := r.subs[ch]; ok {
+		delete(r.subs, ch)
+		close(ch)
+	}
+	r.mu.Unlock()
+}

--- a/runs/registry.go
+++ b/runs/registry.go
@@ -2,8 +2,11 @@ package runs
 
 import (
 	"context"
+	"encoding/base64"
 	"sort"
+	"strings"
 	"sync"
+	"sync/atomic"
 )
 
 // Delta is one source's view of one run. A source publishes only the fields it
@@ -26,13 +29,23 @@ type Source interface {
 // are a periodic scrape.
 var DefaultOrder = []string{"tmux", "crew", "hooks"}
 
+// sub is one subscriber's channel plus whether an update was dropped since the
+// last check. dropped is atomic because the hot fan-out path in Apply only
+// holds RLock — it must not need the write lock just to flag a drop.
+type sub struct {
+	ch      chan Run
+	dropped atomic.Bool
+}
+
 // Registry composes per-source layers into one Run per key.
 type Registry struct {
 	order map[string]int
 
-	mu     sync.RWMutex
-	layers map[string]map[string]Run // key -> source -> layer
-	subs   map[chan Run]struct{}
+	mu         sync.RWMutex
+	layers     map[string]map[string]Run // key -> source -> layer
+	listedKeys map[string]bool           // key -> currently listed (an agent run)
+	lastSig    map[string]string         // key -> signature of the last broadcast update
+	subs       map[chan Run]*sub
 }
 
 func NewRegistry(order []string) *Registry {
@@ -41,9 +54,11 @@ func NewRegistry(order []string) *Registry {
 		idx[name] = i
 	}
 	return &Registry{
-		order:  idx,
-		layers: map[string]map[string]Run{},
-		subs:   map[chan Run]struct{}{},
+		order:      idx,
+		layers:     map[string]map[string]Run{},
+		listedKeys: map[string]bool{},
+		lastSig:    map[string]string{},
+		subs:       map[chan Run]*sub{},
 	}
 }
 
@@ -64,21 +79,56 @@ func (r *Registry) Apply(d Delta) {
 		r.layers[d.Key][d.Source] = d.Run
 	}
 	composed, live := r.composeLocked(d.Key)
+
+	// Edge-tracked removal: a key is listed only while some layer describes it
+	// AND the composed run has an agent. Broadcast a removal only on the
+	// was-listed -> not-listed edge — that covers both "last layer gone" and
+	// "agent lost" in one place, and means a never-listed pane (a plain shell,
+	// say) emits nothing, ever. Without tracking the edge there is a real
+	// wedge: the hooks layer can go Gone while the tmux layer survives, the
+	// key stays live in r.layers, Agent drops to "", the update is correctly
+	// suppressed below — but nothing would ever tell a subscriber the run left.
+	listed := live && composed.listed()
+	was := r.listedKeys[d.Key]
+	switch {
+	case listed:
+		r.listedKeys[d.Key] = true
+	case was:
+		delete(r.listedKeys, d.Key)
+	}
+
+	var payload Run
+	broadcast := false
+
+	switch {
+	case listed:
+		sig := runSignature(composed)
+		if r.lastSig[d.Key] != sig {
+			r.lastSig[d.Key] = sig
+			payload = composed
+			broadcast = true
+		}
+	case was:
+		delete(r.lastSig, d.Key)
+		payload = Run{ID: idFor(d.Key), Removed: true}
+		broadcast = true
+	}
 	r.mu.Unlock()
 
-	if !live {
+	if !broadcast {
 		return
 	}
 
-	// Fan out under RLock, as hub.broadcast does. Unsubscribe takes the write
-	// lock to close a channel, so it cannot close one while we hold this —
-	// which is what stops a send racing a close and panicking.
+	// Fan out under RLock, as before. Unsubscribe takes the write lock to
+	// close a channel, so it cannot close one while we hold this — which is
+	// what stops a send racing a close and panicking.
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	for ch := range r.subs {
+	for _, sb := range r.subs {
 		select {
-		case ch <- composed:
-		default: // a slow subscriber drops updates, never blocks the source
+		case sb.ch <- payload:
+		default: // a slow subscriber drops updates; flag it, never block the source
+			sb.dropped.Store(true)
 		}
 	}
 }
@@ -109,8 +159,64 @@ func (r *Registry) composeLocked(key string) (Run, bool) {
 	for _, name := range names {
 		mergeInto(&out, bySource[name])
 	}
-	out.ID = key
+	out.ID = idFor(key)
 	return out, true
+}
+
+// idFor derives a URL-path-safe Run.ID from a source's correlation key. The
+// key itself keeps flowing internally unchanged — it is load-bearing for layer
+// bookkeeping — only the externally visible ID differs. Without this, "%307"
+// decodes as a path segment to "/07", and "branch/fix/412" or "claude/<sid>"
+// contain slashes that break /api/runs/{id} segment routing outright.
+func idFor(key string) string {
+	switch {
+	case strings.HasPrefix(key, "%"):
+		return "pane-" + strings.TrimPrefix(key, "%")
+	case strings.HasPrefix(key, "claude/"):
+		return "sess-" + strings.TrimPrefix(key, "claude/")
+	case strings.HasPrefix(key, "branch/"):
+		b := strings.TrimPrefix(key, "branch/")
+		return "branch-" + base64.RawURLEncoding.EncodeToString([]byte(b))
+	default:
+		return "key-" + base64.RawURLEncoding.EncodeToString([]byte(key))
+	}
+}
+
+// runSignature is a cheap comparable summary of the fields that matter to a
+// subscriber, mirroring hub.broadcastIfChanged: skip fan-out when nothing
+// material changed since the last broadcast for this key, so a poller that
+// re-emits an unchanged layer every tick does not cost every subscriber an
+// SSE event every tick too.
+func runSignature(r Run) string {
+	var b strings.Builder
+	b.WriteString(r.Agent)
+	b.WriteByte('|')
+	b.WriteString(string(r.State))
+	b.WriteByte('|')
+	b.WriteString(r.Repo)
+	b.WriteByte('|')
+	b.WriteString(r.Branch)
+	b.WriteByte('|')
+	b.WriteString(r.Worktree)
+	b.WriteByte('|')
+	if r.Issue != nil {
+		b.WriteString(r.Issue.ID)
+	}
+	b.WriteByte('|')
+	if r.PR != nil {
+		b.WriteString(r.PR.Number + "," + r.PR.State + "," + r.PR.CheckState + "," + r.PR.Mergeable)
+	}
+	b.WriteByte('|')
+	if r.Crew != nil {
+		b.WriteString(r.Crew.Name + "," + r.Crew.Tier)
+	}
+	b.WriteByte('|')
+	if r.Question != nil {
+		b.WriteString(r.Question.Text)
+	}
+	b.WriteByte('|')
+	b.WriteString(r.Activity.Tool + "," + r.Activity.Hint + "," + r.Activity.Message + "," + r.Activity.Task + "," + r.Activity.Preview)
+	return b.String()
 }
 
 // mergeInto copies every set field of src over dst. A zero field means "this
@@ -208,7 +314,7 @@ func (r *Registry) Snapshot() []Run {
 
 	out := make([]Run, 0, len(keys))
 	for _, k := range keys {
-		if run, ok := r.composeLocked(k); ok {
+		if run, ok := r.composeLocked(k); ok && run.listed() {
 			out = append(out, run)
 		}
 	}
@@ -218,7 +324,7 @@ func (r *Registry) Snapshot() []Run {
 func (r *Registry) Subscribe() chan Run {
 	ch := make(chan Run, 64)
 	r.mu.Lock()
-	r.subs[ch] = struct{}{}
+	r.subs[ch] = &sub{ch: ch}
 	r.mu.Unlock()
 	return ch
 }
@@ -230,4 +336,17 @@ func (r *Registry) Unsubscribe(ch chan Run) {
 		close(ch)
 	}
 	r.mu.Unlock()
+}
+
+// Dirty reports whether ch missed at least one update since the last call,
+// and clears the flag. The SSE handler uses this on its keepalive tick to
+// decide whether a bare ping is enough or a full resync is owed.
+func (r *Registry) Dirty(ch chan Run) bool {
+	r.mu.RLock()
+	sb, ok := r.subs[ch]
+	r.mu.RUnlock()
+	if !ok {
+		return false
+	}
+	return sb.dropped.Swap(false)
 }

--- a/runs/registry.go
+++ b/runs/registry.go
@@ -80,14 +80,12 @@ func (r *Registry) Apply(d Delta) {
 	}
 	composed, live := r.composeLocked(d.Key)
 
-	// Edge-tracked removal: a key is listed only while some layer describes it
-	// AND the composed run has an agent. Broadcast a removal only on the
-	// was-listed -> not-listed edge — that covers both "last layer gone" and
-	// "agent lost" in one place, and means a never-listed pane (a plain shell,
-	// say) emits nothing, ever. Without tracking the edge there is a real
-	// wedge: the hooks layer can go Gone while the tmux layer survives, the
-	// key stays live in r.layers, Agent drops to "", the update is correctly
-	// suppressed below — but nothing would ever tell a subscriber the run left.
+	// A key is listed only while some layer describes it AND the composed run
+	// has an agent. Removal fires on the listed -> not-listed edge, which
+	// covers both "last layer gone" and "agent lost", and means a plain shell
+	// emits nothing ever. The edge is load-bearing: without it, a hooks layer
+	// going Gone while the tmux layer survives leaves the key live with no
+	// agent, so the update is suppressed and nothing tells the subscriber.
 	listed := live && composed.listed()
 	was := r.listedKeys[d.Key]
 	switch {

--- a/runs/registry_test.go
+++ b/runs/registry_test.go
@@ -1,7 +1,10 @@
 package runs
 
 import (
+	"reflect"
+	"sync"
 	"testing"
+	"time"
 )
 
 func TestPrecedenceHooksBeatTmux(t *testing.T) {
@@ -85,5 +88,110 @@ func TestSubscribeReceivesComposedRun(t *testing.T) {
 	}
 	if last.State != StateRunning || last.Branch != "main" {
 		t.Fatalf("subscriber got %+v, want the composed run, not one layer", last)
+	}
+}
+
+func TestApplyDoesNotRaceSubscribeClose(t *testing.T) {
+	// A send on a closed channel panics; select/default does not protect
+	// against it — it only guards a full buffer, not a closed one. Apply used
+	// to copy the subscriber set under Lock, release it, then send, which
+	// left a window for Unsubscribe to close a channel out from under it.
+	// This spins concurrent Apply against concurrent Subscribe/Unsubscribe
+	// churn to prove that window is real, not theoretical.
+	r := NewRegistry(DefaultOrder)
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					r.Apply(Delta{Source: "hooks", Key: "%1", Run: Run{State: StateRunning}})
+				}
+			}
+		}()
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				ch := r.Subscribe()
+				r.Unsubscribe(ch)
+			}
+		}
+	}()
+
+	time.Sleep(200 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+}
+
+func TestPointerRefsReplaceWholesale(t *testing.T) {
+	// Nested refs are swapped, not merged. This is safe only while every source
+	// that publishes one publishes it complete — tmux owns Issue/PR/Crew, and
+	// hooks and tmux both publish a full TmuxRef. If a source ever starts
+	// emitting a partial ref, this test is where that shows up.
+	r := NewRegistry(DefaultOrder)
+	r.Apply(Delta{Source: "tmux", Key: "%1", Run: Run{Issue: &IssueRef{ID: "#1", Title: "rich"}}})
+	r.Apply(Delta{Source: "hooks", Key: "%1", Run: Run{Issue: &IssueRef{ID: "#1"}}})
+
+	got := r.Snapshot()[0]
+	if got.Issue.Title != "" {
+		t.Fatalf("Issue.Title = %q — if refs ever merge field-by-field, update the sources that rely on wholesale replacement", got.Issue.Title)
+	}
+}
+
+func TestMergeIntoCoversEveryField(t *testing.T) {
+	// Reflection, not a list: an enumerated test is correct only until someone
+	// adds a field to Run. A dropped field would never reach the API and no
+	// other test would notice.
+	var src Run
+	fillNonZero(reflect.ValueOf(&src).Elem())
+
+	var dst Run
+	mergeInto(&dst, src)
+
+	v := reflect.ValueOf(dst)
+	tp := v.Type()
+	for i := 0; i < v.NumField(); i++ {
+		if tp.Field(i).Name == "ID" {
+			continue // set by composeLocked from the key, deliberately not merged
+		}
+		if v.Field(i).IsZero() {
+			t.Errorf("mergeInto drops %s — it will never reach the API", tp.Field(i).Name)
+		}
+	}
+}
+
+// fillNonZero sets every field of v, recursively, to a distinctive non-zero value.
+func fillNonZero(v reflect.Value) {
+	switch v.Kind() {
+	case reflect.String:
+		v.SetString("x")
+	case reflect.Int, reflect.Int64:
+		v.SetInt(7)
+	case reflect.Bool:
+		v.SetBool(true)
+	case reflect.Ptr:
+		v.Set(reflect.New(v.Type().Elem()))
+		fillNonZero(v.Elem())
+	case reflect.Slice:
+		v.Set(reflect.MakeSlice(v.Type(), 1, 1))
+		fillNonZero(v.Index(0))
+	case reflect.Struct:
+		for i := 0; i < v.NumField(); i++ {
+			fillNonZero(v.Field(i))
+		}
 	}
 }

--- a/runs/registry_test.go
+++ b/runs/registry_test.go
@@ -209,12 +209,10 @@ func TestIdForIsURLPathSafe(t *testing.T) {
 }
 
 func TestApplyDoesNotRaceSubscribeClose(t *testing.T) {
-	// A send on a closed channel panics; select/default does not protect
-	// against it — it only guards a full buffer, not a closed one. Apply used
-	// to copy the subscriber set under Lock, release it, then send, which
-	// left a window for Unsubscribe to close a channel out from under it.
-	// This spins concurrent Apply against concurrent Subscribe/Unsubscribe
-	// churn to prove that window is real, not theoretical.
+	// A send on a closed channel panics, and select/default does not protect
+	// against it — that only guards a full buffer, not a closed one. Spinning
+	// Apply against Subscribe/Unsubscribe churn is what makes the window
+	// reachable; a sequential test cannot reach it at all.
 	r := NewRegistry(DefaultOrder)
 
 	stop := make(chan struct{})

--- a/runs/registry_test.go
+++ b/runs/registry_test.go
@@ -1,7 +1,10 @@
 package runs
 
 import (
+	"encoding/base64"
+	"fmt"
 	"reflect"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -10,7 +13,7 @@ import (
 func TestPrecedenceHooksBeatTmux(t *testing.T) {
 	r := NewRegistry(DefaultOrder)
 	r.Apply(Delta{Source: "tmux", Key: "%1", Run: Run{State: StateIdle, Branch: "main"}})
-	r.Apply(Delta{Source: "hooks", Key: "%1", Run: Run{State: StateRunning}})
+	r.Apply(Delta{Source: "hooks", Key: "%1", Run: Run{Agent: "claude", State: StateRunning}})
 
 	got := r.Snapshot()
 	if len(got) != 1 {
@@ -27,7 +30,7 @@ func TestPrecedenceHooksBeatTmux(t *testing.T) {
 
 func TestLowerPrecedenceCannotBlankAHigherField(t *testing.T) {
 	r := NewRegistry(DefaultOrder)
-	r.Apply(Delta{Source: "hooks", Key: "%1", Run: Run{State: StateRunning}})
+	r.Apply(Delta{Source: "hooks", Key: "%1", Run: Run{Agent: "claude", State: StateRunning}})
 	r.Apply(Delta{Source: "tmux", Key: "%1", Run: Run{State: ""}})
 
 	if got := r.Snapshot()[0].State; got != StateRunning {
@@ -38,7 +41,7 @@ func TestLowerPrecedenceCannotBlankAHigherField(t *testing.T) {
 func TestCrewBeatsTmuxButNotHooks(t *testing.T) {
 	r := NewRegistry(DefaultOrder)
 	r.Apply(Delta{Source: "tmux", Key: "%1", Run: Run{State: StateIdle}})
-	r.Apply(Delta{Source: "crew", Key: "%1", Run: Run{State: StateBlocked}})
+	r.Apply(Delta{Source: "crew", Key: "%1", Run: Run{Agent: "claude", State: StateBlocked}})
 	if got := r.Snapshot()[0].State; got != StateBlocked {
 		t.Fatalf("State = %q, want %q", got, StateBlocked)
 	}
@@ -51,7 +54,10 @@ func TestCrewBeatsTmuxButNotHooks(t *testing.T) {
 
 func TestGoneRemovesOnlyThatSourcesLayer(t *testing.T) {
 	r := NewRegistry(DefaultOrder)
-	r.Apply(Delta{Source: "tmux", Key: "%1", Run: Run{Branch: "main"}})
+	// tmux carries its own Agent here — a real tmux layer does, whenever the
+	// pane's @claude_status is non-empty — so the run stays listed once hooks
+	// leaves and this test still exercises "the tmux layer survives".
+	r.Apply(Delta{Source: "tmux", Key: "%1", Run: Run{Agent: "claude", Branch: "main"}})
 	r.Apply(Delta{Source: "hooks", Key: "%1", Run: Run{State: StateRunning}})
 
 	r.Apply(Delta{Source: "hooks", Key: "%1", Gone: true})
@@ -70,12 +76,64 @@ func TestGoneRemovesOnlyThatSourcesLayer(t *testing.T) {
 	}
 }
 
+func TestSnapshotOmitsUnlistedRuns(t *testing.T) {
+	r := NewRegistry(DefaultOrder)
+	r.Apply(Delta{Source: "tmux", Key: "%1", Run: Run{Branch: "main"}}) // no agent — a plain pane
+
+	if n := len(r.Snapshot()); n != 0 {
+		t.Fatalf("%d runs, want 0 — a pane with no agent is a workspace pane, not a run", n)
+	}
+}
+
+func TestRemovalFiresOnlyOnTheListedToUnlistedEdge(t *testing.T) {
+	r := NewRegistry(DefaultOrder)
+	sub := r.Subscribe()
+	defer r.Unsubscribe(sub)
+
+	r.Apply(Delta{Source: "tmux", Key: "%1", Run: Run{Branch: "main"}}) // not listed — no broadcast at all
+	select {
+	case run := <-sub:
+		t.Fatalf("got a broadcast for a never-listed pane: %+v", run)
+	default:
+	}
+
+	r.Apply(Delta{Source: "hooks", Key: "%1", Run: Run{Agent: "claude", State: StateRunning}}) // now listed
+	select {
+	case run := <-sub:
+		if run.Removed {
+			t.Fatalf("got a removal on first listing, want the composed run")
+		}
+	default:
+		t.Fatal("no broadcast for the first listed update")
+	}
+
+	// The agent-bearing layer leaves; the tmux layer (no agent) survives. This
+	// is the wedge case: the key stays live in r.layers, but Agent drops to ""
+	// and the run must be reported gone.
+	r.Apply(Delta{Source: "hooks", Key: "%1", Gone: true})
+	select {
+	case run := <-sub:
+		if !run.Removed {
+			t.Fatalf("got %+v, want a removal — the run lost its only agent-bearing layer", run)
+		}
+		if run.ID == "" {
+			t.Fatal("removal payload has no ID")
+		}
+	default:
+		t.Fatal("no removal broadcast on the listed -> unlisted edge")
+	}
+
+	if n := len(r.Snapshot()); n != 0 {
+		t.Fatalf("%d runs after the agent-bearing layer left, want 0 (Snapshot must use the same listed() predicate)", n)
+	}
+}
+
 func TestSubscribeReceivesComposedRun(t *testing.T) {
 	r := NewRegistry(DefaultOrder)
 	sub := r.Subscribe()
 	defer r.Unsubscribe(sub)
 
-	r.Apply(Delta{Source: "tmux", Key: "%1", Run: Run{Branch: "main"}})
+	r.Apply(Delta{Source: "tmux", Key: "%1", Run: Run{Agent: "claude", Branch: "main"}})
 	r.Apply(Delta{Source: "hooks", Key: "%1", Run: Run{State: StateRunning}})
 
 	var last Run
@@ -88,6 +146,65 @@ func TestSubscribeReceivesComposedRun(t *testing.T) {
 	}
 	if last.State != StateRunning || last.Branch != "main" {
 		t.Fatalf("subscriber got %+v, want the composed run, not one layer", last)
+	}
+}
+
+func TestApplyDedupesUnchangedUpdates(t *testing.T) {
+	r := NewRegistry(DefaultOrder)
+	sub := r.Subscribe()
+	defer r.Unsubscribe(sub)
+
+	d := Delta{Source: "hooks", Key: "%1", Run: Run{Agent: "claude", State: StateRunning}}
+	r.Apply(d)
+	r.Apply(d) // identical — must not re-broadcast
+
+	if n := len(sub); n != 1 {
+		t.Fatalf("%d buffered broadcasts, want 1 — an unchanged re-apply must be deduped", n)
+	}
+}
+
+func TestDirtyReflectsADroppedUpdate(t *testing.T) {
+	r := NewRegistry(DefaultOrder)
+	ch := r.Subscribe()
+	defer r.Unsubscribe(ch)
+
+	if r.Dirty(ch) {
+		t.Fatal("Dirty before any drop, want false")
+	}
+
+	// Fill the channel buffer, then force one more distinct broadcast so the
+	// send hits the default branch and flags a drop. Each apply must produce a
+	// different signature or dedupe would swallow it before it ever reaches
+	// the channel.
+	for i := 0; i < cap(ch)+1; i++ {
+		r.Apply(Delta{Source: "hooks", Key: "%1", Run: Run{
+			Agent: "claude", State: StateRunning,
+			Activity: Activity{Message: fmt.Sprintf("m%d", i)},
+		}})
+	}
+
+	if !r.Dirty(ch) {
+		t.Fatal("Dirty after a drop, want true")
+	}
+	if r.Dirty(ch) {
+		t.Fatal("Dirty must clear after being read")
+	}
+}
+
+func TestIdForIsURLPathSafe(t *testing.T) {
+	cases := []struct{ key, want string }{
+		{"%307", "pane-307"},
+		{"claude/abc-123", "sess-abc-123"},
+		{"branch/fix/412", "branch-" + base64.RawURLEncoding.EncodeToString([]byte("fix/412"))},
+	}
+	for _, c := range cases {
+		got := idFor(c.key)
+		if got != c.want {
+			t.Errorf("idFor(%q) = %q, want %q", c.key, got, c.want)
+		}
+		if strings.ContainsAny(got, "/%") {
+			t.Errorf("idFor(%q) = %q, not URL-path-safe", c.key, got)
+		}
 	}
 }
 
@@ -105,17 +222,23 @@ func TestApplyDoesNotRaceSubscribeClose(t *testing.T) {
 
 	for i := 0; i < 50; i++ {
 		wg.Add(1)
-		go func() {
+		go func(n int) {
 			defer wg.Done()
-			for {
+			for turn := 0; ; turn++ {
 				select {
 				case <-stop:
 					return
 				default:
-					r.Apply(Delta{Source: "hooks", Key: "%1", Run: Run{State: StateRunning}})
+					// Vary the payload every call — otherwise dedupe collapses
+					// everything after the first send and this stops
+					// exercising the fan-out path this test is about.
+					r.Apply(Delta{Source: "hooks", Key: "%1", Run: Run{
+						Agent: "claude", State: StateRunning,
+						Activity: Activity{Message: fmt.Sprintf("%d-%d", n, turn)},
+					}})
 				}
 			}
-		}()
+		}(i)
 	}
 
 	wg.Add(1)
@@ -144,7 +267,7 @@ func TestPointerRefsReplaceWholesale(t *testing.T) {
 	// emitting a partial ref, this test is where that shows up.
 	r := NewRegistry(DefaultOrder)
 	r.Apply(Delta{Source: "tmux", Key: "%1", Run: Run{Issue: &IssueRef{ID: "#1", Title: "rich"}}})
-	r.Apply(Delta{Source: "hooks", Key: "%1", Run: Run{Issue: &IssueRef{ID: "#1"}}})
+	r.Apply(Delta{Source: "hooks", Key: "%1", Run: Run{Agent: "claude", Issue: &IssueRef{ID: "#1"}}})
 
 	got := r.Snapshot()[0]
 	if got.Issue.Title != "" {
@@ -165,8 +288,11 @@ func TestMergeIntoCoversEveryField(t *testing.T) {
 	v := reflect.ValueOf(dst)
 	tp := v.Type()
 	for i := 0; i < v.NumField(); i++ {
-		if tp.Field(i).Name == "ID" {
+		switch tp.Field(i).Name {
+		case "ID":
 			continue // set by composeLocked from the key, deliberately not merged
+		case "Removed":
+			continue // set only by the registry when broadcasting a removal, never by a source
 		}
 		if v.Field(i).IsZero() {
 			t.Errorf("mergeInto drops %s — it will never reach the API", tp.Field(i).Name)

--- a/runs/registry_test.go
+++ b/runs/registry_test.go
@@ -1,0 +1,89 @@
+package runs
+
+import (
+	"testing"
+)
+
+func TestPrecedenceHooksBeatTmux(t *testing.T) {
+	r := NewRegistry(DefaultOrder)
+	r.Apply(Delta{Source: "tmux", Key: "%1", Run: Run{State: StateIdle, Branch: "main"}})
+	r.Apply(Delta{Source: "hooks", Key: "%1", Run: Run{State: StateRunning}})
+
+	got := r.Snapshot()
+	if len(got) != 1 {
+		t.Fatalf("%d runs, want 1 — both deltas key on the same pane", len(got))
+	}
+	if got[0].State != StateRunning {
+		t.Errorf("State = %q, want %q — hooks outrank tmux", got[0].State, StateRunning)
+	}
+	if got[0].Branch != "main" {
+		t.Errorf("Branch = %q, want %q — tmux still supplies fields hooks leaves empty",
+			got[0].Branch, "main")
+	}
+}
+
+func TestLowerPrecedenceCannotBlankAHigherField(t *testing.T) {
+	r := NewRegistry(DefaultOrder)
+	r.Apply(Delta{Source: "hooks", Key: "%1", Run: Run{State: StateRunning}})
+	r.Apply(Delta{Source: "tmux", Key: "%1", Run: Run{State: ""}})
+
+	if got := r.Snapshot()[0].State; got != StateRunning {
+		t.Fatalf("State = %q, want %q — an empty field must not overwrite a set one", got, StateRunning)
+	}
+}
+
+func TestCrewBeatsTmuxButNotHooks(t *testing.T) {
+	r := NewRegistry(DefaultOrder)
+	r.Apply(Delta{Source: "tmux", Key: "%1", Run: Run{State: StateIdle}})
+	r.Apply(Delta{Source: "crew", Key: "%1", Run: Run{State: StateBlocked}})
+	if got := r.Snapshot()[0].State; got != StateBlocked {
+		t.Fatalf("State = %q, want %q", got, StateBlocked)
+	}
+
+	r.Apply(Delta{Source: "hooks", Key: "%1", Run: Run{State: StateRunning}})
+	if got := r.Snapshot()[0].State; got != StateRunning {
+		t.Fatalf("State = %q, want %q", got, StateRunning)
+	}
+}
+
+func TestGoneRemovesOnlyThatSourcesLayer(t *testing.T) {
+	r := NewRegistry(DefaultOrder)
+	r.Apply(Delta{Source: "tmux", Key: "%1", Run: Run{Branch: "main"}})
+	r.Apply(Delta{Source: "hooks", Key: "%1", Run: Run{State: StateRunning}})
+
+	r.Apply(Delta{Source: "hooks", Key: "%1", Gone: true})
+
+	got := r.Snapshot()
+	if len(got) != 1 {
+		t.Fatalf("%d runs, want 1 — the tmux layer still describes this pane", len(got))
+	}
+	if got[0].Branch != "main" {
+		t.Errorf("Branch = %q, want main", got[0].Branch)
+	}
+
+	r.Apply(Delta{Source: "tmux", Key: "%1", Gone: true})
+	if n := len(r.Snapshot()); n != 0 {
+		t.Fatalf("%d runs after the last layer went away, want 0", n)
+	}
+}
+
+func TestSubscribeReceivesComposedRun(t *testing.T) {
+	r := NewRegistry(DefaultOrder)
+	sub := r.Subscribe()
+	defer r.Unsubscribe(sub)
+
+	r.Apply(Delta{Source: "tmux", Key: "%1", Run: Run{Branch: "main"}})
+	r.Apply(Delta{Source: "hooks", Key: "%1", Run: Run{State: StateRunning}})
+
+	var last Run
+	for i := 0; i < 2; i++ {
+		select {
+		case last = <-sub:
+		default:
+			t.Fatalf("only %d broadcasts received", i)
+		}
+	}
+	if last.State != StateRunning || last.Branch != "main" {
+		t.Fatalf("subscriber got %+v, want the composed run, not one layer", last)
+	}
+}

--- a/runs/run.go
+++ b/runs/run.go
@@ -1,0 +1,101 @@
+// Package runs models one agent run — a Claude Code, Codex, Cursor, amp,
+// OpenCode or pi session — independent of where it happens to be running.
+package runs
+
+// Run is one agent run, anywhere. It is the only object the UI lists.
+type Run struct {
+	ID    string `json:"id"`
+	Host  string `json:"host,omitempty"` // "" means local
+	Agent string `json:"agent"`
+	State State  `json:"state"`
+
+	Repo     string `json:"repo,omitempty"`
+	Branch   string `json:"branch,omitempty"`
+	Worktree string `json:"worktree,omitempty"`
+
+	Tmux  *TmuxRef  `json:"tmux,omitempty"`
+	Issue *IssueRef `json:"issue,omitempty"`
+	PR    *PRRef    `json:"pr,omitempty"`
+	Crew  *CrewRef  `json:"crew,omitempty"`
+
+	Activity Activity  `json:"activity"`
+	Question *Question `json:"question,omitempty"`
+	Tokens   Tokens    `json:"tokens"`
+
+	Since     int64 `json:"since,omitempty"`
+	UpdatedAt int64 `json:"updated_at"`
+
+	// Stale means a source stopped reporting. The Run keeps its last known
+	// values and says so; it is never a State, because a stale run still has
+	// one.
+	Stale bool `json:"stale,omitempty"`
+
+	Caps Caps `json:"caps"`
+}
+
+// TmuxRef locates a run's pane. Nil for agents with no pane.
+type TmuxRef struct {
+	Session string `json:"session"`
+	Window  int    `json:"window"`
+	PaneID  string `json:"pane_id"` // "%307"
+}
+
+type IssueRef struct {
+	ID       string `json:"id"` // "#320"
+	Title    string `json:"title,omitempty"`
+	URL      string `json:"url,omitempty"`
+	Provider string `json:"provider,omitempty"`
+}
+
+type PRRef struct {
+	Number     string `json:"number"`
+	State      string `json:"state,omitempty"`
+	CheckState string `json:"check_state,omitempty"`
+	Mergeable  string `json:"mergeable,omitempty"`
+	Draft      bool   `json:"draft,omitempty"`
+	URL        string `json:"url,omitempty"`
+}
+
+type CrewRef struct {
+	Name  string `json:"name"`
+	Color string `json:"color,omitempty"`
+	Tier  string `json:"tier,omitempty"`
+}
+
+// Activity is what the run is doing right now.
+type Activity struct {
+	Tool    string      `json:"tool,omitempty"`
+	Hint    string      `json:"hint,omitempty"`
+	Message string      `json:"message,omitempty"`
+	Task    string      `json:"task,omitempty"`
+	Trail   []TrailChip `json:"trail,omitempty"`
+	Preview string      `json:"preview,omitempty"`
+	Turn    int         `json:"turn,omitempty"`
+}
+
+type TrailChip struct {
+	Tool    string `json:"tool"`
+	Hint    string `json:"hint,omitempty"`
+	Done    bool   `json:"done"`
+	IsError bool   `json:"error,omitempty"`
+}
+
+// Question is the thing a human answers. Non-nil implies State == StateBlocked.
+type Question struct {
+	Text string `json:"text"`
+	// Via is how an answer is delivered: "pane" or "crew".
+	Via string `json:"via"`
+}
+
+type Tokens struct {
+	Input  int `json:"input"`
+	Output int `json:"output"`
+}
+
+// Caps is what this run supports right now. The UI renders affordances from
+// capabilities rather than branching on Agent, so a new agent needs no UI change.
+type Caps struct {
+	Terminal bool `json:"terminal"`
+	Reply    bool `json:"reply"`
+	Kill     bool `json:"kill"`
+}

--- a/runs/run.go
+++ b/runs/run.go
@@ -28,10 +28,23 @@ type Run struct {
 	// Stale means a source stopped reporting. The Run keeps its last known
 	// values and says so; it is never a State, because a stale run still has
 	// one.
+	//
+	// No source sets this yet — federated peers will need it once one exists.
+	// mergeInto ORs it stickily, which means nothing can ever clear it once
+	// set; revisit that merge rule when a source actually starts setting it.
 	Stale bool `json:"stale,omitempty"`
 
 	Caps Caps `json:"caps"`
+
+	// Removed marks a broadcast-only payload telling subscribers a run left
+	// the listing. Only ID is set alongside it; every other field is zero.
+	// Never present in Snapshot or in a source's layer.
+	Removed bool `json:"removed,omitempty"`
 }
+
+// listed reports whether a composed Run is an agent run and therefore belongs
+// in /api/runs. A pane with no agent is a workspace pane, not a run.
+func (r Run) listed() bool { return r.Agent != "" }
 
 // TmuxRef locates a run's pane. Nil for agents with no pane.
 type TmuxRef struct {

--- a/runs/state.go
+++ b/runs/state.go
@@ -1,0 +1,93 @@
+package runs
+
+import (
+	"strings"
+
+	"github.com/noamsto/houston/hook"
+)
+
+// State is houston's single vocabulary for what a run is doing. Three upstream
+// vocabularies map into it — Claude Code hooks, the dispatcher crew bus, and
+// lazytmux's @claude_status — and they disagree with each other, so this is the
+// only place the reconciliation lives.
+type State string
+
+const (
+	StateThinking   State = "thinking"
+	StateRunning    State = "running"
+	StateBlocked    State = "blocked"
+	StateCompacting State = "compacting"
+	StateReview     State = "review"
+	StateDone       State = "done"
+	StateFailed     State = "failed"
+	StateIdle       State = "idle"
+)
+
+// AllStates lists every state, for exhaustiveness tests.
+func AllStates() []State {
+	return []State{
+		StateThinking, StateRunning, StateBlocked, StateCompacting,
+		StateReview, StateDone, StateFailed, StateIdle,
+	}
+}
+
+// NeedsAttention reports whether a human is required. Exactly one state says
+// yes: it drives the badge, the sort order and later the push notification, so
+// nothing else may claim it.
+func (s State) NeedsAttention() bool { return s == StateBlocked }
+
+func FromHookState(s hook.State) State {
+	switch s {
+	case hook.StateThinking, hook.StateStarting:
+		return StateThinking
+	case hook.StateToolRunning:
+		return StateRunning
+	case hook.StateWaiting, hook.StatePermission:
+		return StateBlocked
+	case hook.StateCompacting:
+		return StateCompacting
+	case hook.StateEnded:
+		return StateDone
+	default:
+		return StateIdle
+	}
+}
+
+func FromCrewState(s string) State {
+	switch s {
+	case "working":
+		return StateRunning
+	case "blocked":
+		return StateBlocked
+	case "pr_open":
+		return StateReview
+	case "done":
+		return StateDone
+	case "failed", "exited":
+		return StateFailed
+	default:
+		return StateIdle
+	}
+}
+
+// FromClaudeStatus reads lazytmux's @claude_status pane option, whose format is
+// "<state> <epoch> <unseen>". Only the first field is a state.
+func FromClaudeStatus(v string) State {
+	word, _, _ := strings.Cut(strings.TrimSpace(v), " ")
+	switch word {
+	case "processing":
+		return StateRunning
+	case "waiting", "denied":
+		return StateBlocked
+	case "compacting":
+		return StateCompacting
+	case "error":
+		return StateFailed
+	case "done":
+		return StateDone
+	default:
+		// Covers "idle", "interrupted" and the empty string. Interrupting is
+		// something the user did deliberately, so it must not raise a badge.
+		return StateIdle
+	}
+}

--- a/runs/state.go
+++ b/runs/state.go
@@ -1,6 +1,7 @@
 package runs
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/noamsto/houston/hook"
@@ -90,4 +91,19 @@ func FromClaudeStatus(v string) State {
 		// something the user did deliberately, so it must not raise a badge.
 		return StateIdle
 	}
+}
+
+// ClaudeStatusEpoch parses the second field of lazytmux's @claude_status pane
+// option — "<state> <epoch> <unseen>" — into a unix-seconds timestamp. Zero if
+// the field is missing or not a number.
+func ClaudeStatusEpoch(v string) int64 {
+	fields := strings.Fields(v)
+	if len(fields) < 2 {
+		return 0
+	}
+	n, err := strconv.ParseInt(fields[1], 10, 64)
+	if err != nil {
+		return 0
+	}
+	return n
 }

--- a/runs/state_test.go
+++ b/runs/state_test.go
@@ -1,0 +1,84 @@
+package runs
+
+import (
+	"testing"
+
+	"github.com/noamsto/houston/hook"
+)
+
+func TestFromHookState(t *testing.T) {
+	tests := map[hook.State]State{
+		hook.StateThinking:    StateThinking,
+		hook.StateStarting:    StateThinking,
+		hook.StateToolRunning: StateRunning,
+		hook.StateWaiting:     StateBlocked,
+		hook.StatePermission:  StateBlocked,
+		hook.StateCompacting:  StateCompacting,
+		hook.StateEnded:       StateDone,
+	}
+	for in, want := range tests {
+		if got := FromHookState(in); got != want {
+			t.Errorf("FromHookState(%q) = %q, want %q", in, got, want)
+		}
+	}
+	if got := FromHookState(hook.State("nonsense")); got != StateIdle {
+		t.Errorf("unknown hook state = %q, want %q", got, StateIdle)
+	}
+}
+
+func TestFromCrewState(t *testing.T) {
+	tests := map[string]State{
+		"working": StateRunning,
+		"blocked": StateBlocked,
+		"pr_open": StateReview,
+		"done":    StateDone,
+		"failed":  StateFailed,
+		"exited":  StateFailed,
+	}
+	for in, want := range tests {
+		if got := FromCrewState(in); got != want {
+			t.Errorf("FromCrewState(%q) = %q, want %q", in, got, want)
+		}
+	}
+	if got := FromCrewState(""); got != StateIdle {
+		t.Errorf("empty crew state = %q, want %q", got, StateIdle)
+	}
+}
+
+func TestFromClaudeStatus(t *testing.T) {
+	// The value is lazytmux's "@claude_status", whose first field is the state.
+	tests := map[string]State{
+		"processing 1788848628 ":  StateRunning,
+		"waiting 1788848628 1":    StateBlocked,
+		"denied 1788848628 ":      StateBlocked,
+		"compacting 1788848628 ":  StateCompacting,
+		"error 1788848628 ":       StateFailed,
+		"done 1788848628 ":        StateDone,
+		"idle 1788846509 ":        StateIdle,
+		"interrupted 1788846509 ": StateIdle,
+		"":                        StateIdle,
+	}
+	for in, want := range tests {
+		if got := FromClaudeStatus(in); got != want {
+			t.Errorf("FromClaudeStatus(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestBlockedIsTheOnlyNeedsYouState(t *testing.T) {
+	// Exactly one state means "a human is required". The badge, the sort order
+	// and (later) push notifications all key off this, so nothing else may
+	// claim it.
+	needsYou := 0
+	for _, s := range AllStates() {
+		if s.NeedsAttention() {
+			needsYou++
+		}
+	}
+	if needsYou != 1 {
+		t.Fatalf("%d states report NeedsAttention, want exactly 1 (blocked)", needsYou)
+	}
+	if !StateBlocked.NeedsAttention() {
+		t.Fatal("blocked does not report NeedsAttention")
+	}
+}

--- a/runs/tmuxsource.go
+++ b/runs/tmuxsource.go
@@ -1,0 +1,124 @@
+package runs
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"time"
+
+	"github.com/noamsto/houston/tmux"
+)
+
+// TmuxSource reads the enrichment lazytmux already computes and parks in tmux
+// user-options: branch, worktree, linked issue, PR state and crew membership.
+// Houston never recomputes any of it.
+type TmuxSource struct {
+	client *tmux.Client
+	every  time.Duration
+}
+
+func NewTmuxSource(c *tmux.Client, every time.Duration) *TmuxSource {
+	if every <= 0 {
+		every = 2 * time.Second
+	}
+	return &TmuxSource{client: c, every: every}
+}
+
+func (s *TmuxSource) Name() string { return "tmux" }
+
+func (s *TmuxSource) Run(ctx context.Context, out chan<- Delta) error {
+	t := time.NewTicker(s.every)
+	defer t.Stop()
+
+	seen := map[string]bool{}
+	for {
+		wins, err := s.client.ListWindowOptions()
+		if err != nil {
+			slog.Debug("tmux window options", "error", err)
+		}
+		panes, err := s.client.ListPaneOptions()
+		if err != nil {
+			slog.Debug("tmux pane options", "error", err)
+		}
+
+		now := map[string]bool{}
+		for _, d := range deltasFromTmux(wins, panes) {
+			now[d.Key] = true
+			select {
+			case out <- d:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+		for key := range seen {
+			if !now[key] {
+				select {
+				case out <- Delta{Source: s.Name(), Key: key, Gone: true}:
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+			}
+		}
+		seen = now
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-t.C:
+		}
+	}
+}
+
+// deltasFromTmux joins each pane to its window's enrichment. A pane whose
+// window was not listed is skipped rather than emitted bare — it means the two
+// queries raced a window closing.
+func deltasFromTmux(wins []tmux.WindowOptions, panes []tmux.PaneOptions) []Delta {
+	byTarget := make(map[string]tmux.WindowOptions, len(wins))
+	for _, w := range wins {
+		byTarget[fmt.Sprintf("%s:%d", w.Session, w.Window)] = w
+	}
+
+	out := make([]Delta, 0, len(panes))
+	for _, p := range panes {
+		w, ok := byTarget[p.Target]
+		if !ok {
+			continue
+		}
+
+		r := Run{
+			State:    FromClaudeStatus(p.ClaudeStatus),
+			Branch:   w.Branch,
+			Worktree: w.GitRoot,
+			Tmux:     &TmuxRef{Session: w.Session, Window: w.Window, PaneID: p.PaneID},
+			Activity: Activity{Task: firstNonEmpty(p.ClaudeTask, w.Task)},
+			Caps:     Caps{Terminal: true, Reply: true, Kill: true},
+		}
+		if w.GitRoot != "" {
+			r.Repo = filepath.Base(w.GitRoot)
+		}
+		if w.IssueID != "" {
+			r.Issue = &IssueRef{ID: w.IssueID}
+		}
+		if w.PRNumber != "" && w.PRNumber != "none" {
+			r.PR = &PRRef{
+				Number: w.PRNumber, State: w.PRState,
+				CheckState: w.PRCheckState, Mergeable: w.PRMergeable,
+			}
+		}
+		if w.CrewName != "" {
+			r.Crew = &CrewRef{Name: w.CrewName}
+		}
+		out = append(out, Delta{Source: "tmux", Key: p.PaneID, Run: r})
+	}
+	return out
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/runs/tmuxsource.go
+++ b/runs/tmuxsource.go
@@ -10,15 +10,23 @@ import (
 	"github.com/noamsto/houston/tmux"
 )
 
+// lister is what TmuxSource needs from a tmux client — narrow enough that a
+// fake can drive TmuxSource.Run in tests without shelling out. *tmux.Client
+// satisfies it already, so no production call site changes.
+type lister interface {
+	ListWindowOptions() ([]tmux.WindowOptions, error)
+	ListPaneOptions() ([]tmux.PaneOptions, error)
+}
+
 // TmuxSource reads the enrichment lazytmux already computes and parks in tmux
 // user-options: branch, worktree, linked issue, PR state and crew membership.
 // Houston never recomputes any of it.
 type TmuxSource struct {
-	client *tmux.Client
+	client lister
 	every  time.Duration
 }
 
-func NewTmuxSource(c *tmux.Client, every time.Duration) *TmuxSource {
+func NewTmuxSource(c lister, every time.Duration) *TmuxSource {
 	if every <= 0 {
 		every = 2 * time.Second
 	}
@@ -91,12 +99,20 @@ func deltasFromTmux(wins []tmux.WindowOptions, panes []tmux.PaneOptions) []Delta
 		}
 
 		r := Run{
-			State:    FromClaudeStatus(p.ClaudeStatus),
-			Branch:   w.Branch,
-			Worktree: w.GitRoot,
-			Tmux:     &TmuxRef{Session: w.Session, Window: w.Window, PaneID: p.PaneID},
-			Activity: Activity{Task: firstNonEmpty(p.ClaudeTask, w.Task)},
-			Caps:     Caps{Terminal: true, Reply: true, Kill: true},
+			State:     FromClaudeStatus(p.ClaudeStatus),
+			UpdatedAt: ClaudeStatusEpoch(p.ClaudeStatus),
+			Branch:    w.Branch,
+			Worktree:  w.GitRoot,
+			Tmux:      &TmuxRef{Session: w.Session, Window: w.Window, PaneID: p.PaneID},
+			Activity:  Activity{Task: firstNonEmpty(p.ClaudeTask, w.Task)},
+			Caps:      Caps{Terminal: true, Reply: true, Kill: true},
+		}
+		// A pane is an agent run only once lazytmux reports a claude_status for
+		// it — an empty status means a shell, build or htop, and the enrichment
+		// above (branch, issue, PR, crew) still reaches it harmlessly, but it
+		// must not turn into a listed run in /api/runs.
+		if p.ClaudeStatus != "" {
+			r.Agent = "claude"
 		}
 		if w.GitRoot != "" {
 			r.Repo = filepath.Base(w.GitRoot)

--- a/runs/tmuxsource.go
+++ b/runs/tmuxsource.go
@@ -33,34 +33,38 @@ func (s *TmuxSource) Run(ctx context.Context, out chan<- Delta) error {
 
 	seen := map[string]bool{}
 	for {
-		wins, err := s.client.ListWindowOptions()
-		if err != nil {
-			slog.Debug("tmux window options", "error", err)
+		wins, winErr := s.client.ListWindowOptions()
+		if winErr != nil {
+			slog.Debug("tmux window options", "error", winErr)
 		}
-		panes, err := s.client.ListPaneOptions()
-		if err != nil {
-			slog.Debug("tmux pane options", "error", err)
+		panes, paneErr := s.client.ListPaneOptions()
+		if paneErr != nil {
+			slog.Debug("tmux pane options", "error", paneErr)
 		}
 
-		now := map[string]bool{}
-		for _, d := range deltasFromTmux(wins, panes) {
-			now[d.Key] = true
-			select {
-			case out <- d:
-			case <-ctx.Done():
-				return ctx.Err()
-			}
-		}
-		for key := range seen {
-			if !now[key] {
+		// A transient tmux error is not evidence that every pane vanished:
+		// skip the tick entirely rather than emitting Gone for everything seen.
+		if winErr == nil && paneErr == nil {
+			now := map[string]bool{}
+			for _, d := range deltasFromTmux(wins, panes) {
+				now[d.Key] = true
 				select {
-				case out <- Delta{Source: s.Name(), Key: key, Gone: true}:
+				case out <- d:
 				case <-ctx.Done():
 					return ctx.Err()
 				}
 			}
+			for key := range seen {
+				if !now[key] {
+					select {
+					case out <- Delta{Source: s.Name(), Key: key, Gone: true}:
+					case <-ctx.Done():
+						return ctx.Err()
+					}
+				}
+			}
+			seen = now
 		}
-		seen = now
 
 		select {
 		case <-ctx.Done():

--- a/runs/tmuxsource_test.go
+++ b/runs/tmuxsource_test.go
@@ -1,0 +1,66 @@
+package runs
+
+import (
+	"testing"
+
+	"github.com/noamsto/houston/tmux"
+)
+
+func TestDeltasFromTmuxJoinsPanesToWindows(t *testing.T) {
+	wins := []tmux.WindowOptions{{
+		Session: "lazytmux", Window: 2, Branch: "feat/320",
+		IssueID: "#320", PRNumber: "565", PRState: "open", PRCheckState: "passing",
+		CrewName: "mauve", GitRoot: "/home/n/git/lazytmux",
+	}}
+	panes := []tmux.PaneOptions{{
+		PaneID: "%459", Target: "lazytmux:2", ClaudeStatus: "processing 1788 ",
+	}}
+
+	got := deltasFromTmux(wins, panes)
+	if len(got) != 1 {
+		t.Fatalf("%d deltas, want 1", len(got))
+	}
+	d := got[0]
+	if d.Key != "%459" {
+		t.Fatalf("Key = %q, want the pane id", d.Key)
+	}
+	if d.Run.State != StateRunning {
+		t.Errorf("State = %q, want running (from @claude_status)", d.Run.State)
+	}
+	if d.Run.Branch != "feat/320" {
+		t.Errorf("Branch = %q — the pane must inherit its window's enrichment", d.Run.Branch)
+	}
+	if d.Run.Issue == nil || d.Run.Issue.ID != "#320" {
+		t.Errorf("Issue = %+v, want #320", d.Run.Issue)
+	}
+	if d.Run.PR == nil || d.Run.PR.Number != "565" || d.Run.PR.CheckState != "passing" {
+		t.Errorf("PR = %+v", d.Run.PR)
+	}
+	if d.Run.Crew == nil || d.Run.Crew.Name != "mauve" {
+		t.Errorf("Crew = %+v", d.Run.Crew)
+	}
+	if d.Run.Repo != "lazytmux" {
+		t.Errorf("Repo = %q, want the git root's base name", d.Run.Repo)
+	}
+}
+
+func TestDeltasFromTmuxOmitsAbsentEnrichment(t *testing.T) {
+	got := deltasFromTmux(
+		[]tmux.WindowOptions{{Session: "houston", Window: 1, Branch: "main"}},
+		[]tmux.PaneOptions{{PaneID: "%1", Target: "houston:1"}},
+	)
+	d := got[0].Run
+	if d.Issue != nil || d.PR != nil || d.Crew != nil {
+		t.Fatalf("absent options must stay nil, got issue=%+v pr=%+v crew=%+v", d.Issue, d.PR, d.Crew)
+	}
+	if d.Branch != "main" {
+		t.Errorf("Branch = %q, want main", d.Branch)
+	}
+}
+
+func TestDeltasFromTmuxSkipsPanesWithNoWindow(t *testing.T) {
+	got := deltasFromTmux(nil, []tmux.PaneOptions{{PaneID: "%9", Target: "ghost:1"}})
+	if len(got) != 0 {
+		t.Fatalf("%d deltas for a pane whose window was not listed, want 0", len(got))
+	}
+}

--- a/runs/tmuxsource_test.go
+++ b/runs/tmuxsource_test.go
@@ -135,9 +135,9 @@ func TestTmuxSourceRun(t *testing.T) {
 
 	f := &fakeLister{steps: []fakeStep{
 		{wins: []tmux.WindowOptions{claudeWin}, panes: []tmux.PaneOptions{claudePane}}, // tick 1: pane present
-		{err: errors.New("tmux boom")},                                                 // tick 2: transient error
+		{err: errors.New("tmux boom")}, // tick 2: transient error
 		{wins: []tmux.WindowOptions{claudeWin}, panes: []tmux.PaneOptions{claudePane}}, // tick 3: still present — proves tick 2 retired nothing
-		{wins: nil, panes: nil},                                                        // tick 4: pane genuinely gone
+		{wins: nil, panes: nil}, // tick 4: pane genuinely gone
 	}}
 
 	src := NewTmuxSource(f, 5*time.Millisecond)
@@ -165,12 +165,10 @@ func TestTmuxSourceRun(t *testing.T) {
 		t.Fatalf("tick 1: got %+v, want a live claude-agent delta for %%1", d)
 	}
 
-	// Tick 2 (the error tick) must emit nothing. The discriminator is this
-	// second receive: a regression that emits Gone on error would produce
-	// update, Gone, update, Gone here, which is why this must check !d.Gone
-	// specifically rather than just "a Gone eventually arrives" — the old,
-	// weaker assertion could not tell a correct run from that regression,
-	// since the tail of both sequences ends in a Gone for %1 either way.
+	// Tick 2 (the error tick) must emit nothing, and this second receive is
+	// the only place that shows it: a regression emitting Gone on error yields
+	// update, Gone, update, Gone, whose tail is identical to the correct
+	// sequence. Assert !d.Gone here, not merely that a Gone arrives later.
 	d = recv(t)
 	if d.Gone || d.Key != "%1" {
 		t.Fatalf("got %+v, want tick 3's live update for %%1 — the error tick must not have retired it", d)

--- a/runs/tmuxsource_test.go
+++ b/runs/tmuxsource_test.go
@@ -1,7 +1,10 @@
 package runs
 
 import (
+	"context"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/noamsto/houston/tmux"
 )
@@ -42,6 +45,12 @@ func TestDeltasFromTmuxJoinsPanesToWindows(t *testing.T) {
 	if d.Run.Repo != "lazytmux" {
 		t.Errorf("Repo = %q, want the git root's base name", d.Run.Repo)
 	}
+	if d.Run.Agent != "claude" {
+		t.Errorf("Agent = %q, want claude — a non-empty @claude_status makes this an agent run", d.Run.Agent)
+	}
+	if d.Run.UpdatedAt != 1788 {
+		t.Errorf("UpdatedAt = %d, want 1788 — the second field of @claude_status is the epoch", d.Run.UpdatedAt)
+	}
 }
 
 func TestDeltasFromTmuxOmitsAbsentEnrichment(t *testing.T) {
@@ -62,5 +71,125 @@ func TestDeltasFromTmuxSkipsPanesWithNoWindow(t *testing.T) {
 	got := deltasFromTmux(nil, []tmux.PaneOptions{{PaneID: "%9", Target: "ghost:1"}})
 	if len(got) != 0 {
 		t.Fatalf("%d deltas for a pane whose window was not listed, want 0", len(got))
+	}
+}
+
+func TestDeltasFromTmuxLeavesAgentEmptyWithNoClaudeStatus(t *testing.T) {
+	// A shell, a build, htop — the enrichment (branch, worktree) still reaches
+	// the layer harmlessly, but it must not turn into a listed run.
+	got := deltasFromTmux(
+		[]tmux.WindowOptions{{Session: "houston", Window: 1, Branch: "main"}},
+		[]tmux.PaneOptions{{PaneID: "%1", Target: "houston:1"}},
+	)
+	if got[0].Run.Agent != "" {
+		t.Fatalf("Agent = %q, want empty — no @claude_status means no agent", got[0].Run.Agent)
+	}
+	if got[0].Run.Branch != "main" {
+		t.Fatalf("Branch = %q, enrichment must still reach a plain pane's layer", got[0].Run.Branch)
+	}
+}
+
+// fakeLister drives TmuxSource.Run in tests without shelling out to tmux. It
+// replays one step per call, repeating the last step once steps run out.
+type fakeLister struct {
+	steps []fakeStep
+	calls int
+}
+
+type fakeStep struct {
+	wins  []tmux.WindowOptions
+	panes []tmux.PaneOptions
+	err   error
+}
+
+func (f *fakeLister) step() fakeStep {
+	i := f.calls
+	if i >= len(f.steps) {
+		i = len(f.steps) - 1
+	}
+	f.calls++
+	return f.steps[i]
+}
+
+func (f *fakeLister) ListWindowOptions() ([]tmux.WindowOptions, error) {
+	s := f.step()
+	return s.wins, s.err
+}
+
+func (f *fakeLister) ListPaneOptions() ([]tmux.PaneOptions, error) {
+	// step() must only be called once per tick; ListWindowOptions already
+	// advanced the cursor for this tick, so replay the same step here.
+	i := f.calls - 1
+	if i < 0 {
+		i = 0
+	}
+	if i >= len(f.steps) {
+		i = len(f.steps) - 1
+	}
+	return f.steps[i].panes, f.steps[i].err
+}
+
+func TestTmuxSourceRun(t *testing.T) {
+	claudePane := tmux.PaneOptions{PaneID: "%1", Target: "houston:1", ClaudeStatus: "processing 1 "}
+	claudeWin := tmux.WindowOptions{Session: "houston", Window: 1, Branch: "main"}
+
+	f := &fakeLister{steps: []fakeStep{
+		{wins: []tmux.WindowOptions{claudeWin}, panes: []tmux.PaneOptions{claudePane}}, // tick 1: pane present
+		{err: errors.New("tmux boom")},                                                 // tick 2: transient error
+		{wins: []tmux.WindowOptions{claudeWin}, panes: []tmux.PaneOptions{claudePane}}, // tick 3: still present — proves tick 2 retired nothing
+		{wins: nil, panes: nil},                                                        // tick 4: pane genuinely gone
+	}}
+
+	src := NewTmuxSource(f, 5*time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	out := make(chan Delta, 16)
+	done := make(chan error, 1)
+	go func() { done <- src.Run(ctx, out) }()
+
+	recv := func(t *testing.T) Delta {
+		t.Helper()
+		select {
+		case d := <-out:
+			return d
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for a delta")
+			return Delta{}
+		}
+	}
+
+	// Tick 1: the pane is listed, agent set from its claude_status.
+	d := recv(t)
+	if d.Gone || d.Key != "%1" || d.Run.Agent != "claude" {
+		t.Fatalf("tick 1: got %+v, want a live claude-agent delta for %%1", d)
+	}
+
+	// Tick 2 (the error tick) must emit nothing. The discriminator is this
+	// second receive: a regression that emits Gone on error would produce
+	// update, Gone, update, Gone here, which is why this must check !d.Gone
+	// specifically rather than just "a Gone eventually arrives" — the old,
+	// weaker assertion could not tell a correct run from that regression,
+	// since the tail of both sequences ends in a Gone for %1 either way.
+	d = recv(t)
+	if d.Gone || d.Key != "%1" {
+		t.Fatalf("got %+v, want tick 3's live update for %%1 — the error tick must not have retired it", d)
+	}
+
+	// Tick 4: the pane is genuinely gone.
+	d = recv(t)
+	if !d.Gone || d.Key != "%1" {
+		t.Fatalf("got %+v, want tick 4's Gone for %%1", d)
+	}
+
+	select {
+	case extra := <-out:
+		t.Fatalf("unexpected extra delta %+v", extra)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	cancel()
+	if err := <-done; err != context.Canceled {
+		t.Fatalf("Run returned %v, want context.Canceled", err)
 	}
 }

--- a/server/runs_api.go
+++ b/server/runs_api.go
@@ -41,11 +41,10 @@ func (s *Server) handleRunsStream(w http.ResponseWriter, r *http.Request) {
 	h.Set("Connection", "keep-alive")
 	h.Set("X-Accel-Buffering", "no")
 
-	// Subscribe before writing the snapshot: anything that changes in that
-	// window must land in the channel, not get missed. Updates that arrive
-	// while the snapshot is being written just buffer — the snapshot is
-	// written first, so a replayed update afterward is same-or-newer and
-	// harmless.
+	// Subscribe before writing the snapshot, so a change during the write
+	// lands in the channel instead of being missed. Ordering makes a replay
+	// harmless: the snapshot goes out first, so a buffered update is
+	// same-or-newer.
 	sub := s.runs.Subscribe()
 	defer s.runs.Unsubscribe(sub)
 

--- a/server/runs_api.go
+++ b/server/runs_api.go
@@ -1,0 +1,78 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+// handleRunsSnapshot returns every known run.
+//
+//	GET /api/runs → []runs.Run
+func (s *Server) handleRunsSnapshot(w http.ResponseWriter, _ *http.Request) {
+	if s.runs == nil {
+		http.Error(w, "run registry not started", http.StatusServiceUnavailable)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(s.runs.Snapshot())
+}
+
+// handleRunsStream emits run updates over SSE: one "snapshot" event, then one
+// "update" per composed change.
+//
+//	GET /api/runs/stream → text/event-stream
+func (s *Server) handleRunsStream(w http.ResponseWriter, r *http.Request) {
+	if s.runs == nil {
+		http.Error(w, "run registry not started", http.StatusServiceUnavailable)
+		return
+	}
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	h := w.Header()
+	h.Set("Content-Type", "text/event-stream")
+	h.Set("Cache-Control", "no-cache")
+	h.Set("Connection", "keep-alive")
+	h.Set("X-Accel-Buffering", "no")
+
+	snap, _ := json.Marshal(s.runs.Snapshot())
+	fmt.Fprintf(w, "event: snapshot\ndata: %s\n\n", snap)
+	flusher.Flush()
+
+	sub := s.runs.Subscribe()
+	defer s.runs.Unsubscribe(sub)
+
+	ping := time.NewTicker(25 * time.Second)
+	defer ping.Stop()
+
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case run, ok := <-sub:
+			if !ok {
+				return
+			}
+			b, err := json.Marshal(run)
+			if err != nil {
+				slog.Warn("runs stream marshal", "err", err)
+				continue
+			}
+			if _, err := fmt.Fprintf(w, "event: update\ndata: %s\n\n", b); err != nil {
+				return
+			}
+			flusher.Flush()
+		case <-ping.C:
+			if _, err := fmt.Fprint(w, ": ping\n\n"); err != nil {
+				return
+			}
+			flusher.Flush()
+		}
+	}
+}

--- a/server/runs_api.go
+++ b/server/runs_api.go
@@ -41,12 +41,17 @@ func (s *Server) handleRunsStream(w http.ResponseWriter, r *http.Request) {
 	h.Set("Connection", "keep-alive")
 	h.Set("X-Accel-Buffering", "no")
 
+	// Subscribe before writing the snapshot: anything that changes in that
+	// window must land in the channel, not get missed. Updates that arrive
+	// while the snapshot is being written just buffer — the snapshot is
+	// written first, so a replayed update afterward is same-or-newer and
+	// harmless.
+	sub := s.runs.Subscribe()
+	defer s.runs.Unsubscribe(sub)
+
 	snap, _ := json.Marshal(s.runs.Snapshot())
 	fmt.Fprintf(w, "event: snapshot\ndata: %s\n\n", snap)
 	flusher.Flush()
-
-	sub := s.runs.Subscribe()
-	defer s.runs.Unsubscribe(sub)
 
 	ping := time.NewTicker(25 * time.Second)
 	defer ping.Stop()
@@ -69,7 +74,20 @@ func (s *Server) handleRunsStream(w http.ResponseWriter, r *http.Request) {
 			}
 			flusher.Flush()
 		case <-ping.C:
-			if _, err := fmt.Fprint(w, ": ping\n\n"); err != nil {
+			// A dropped update is otherwise permanent — the registry only
+			// dedupes redundant re-emissions, it does not retry a drop. If
+			// this subscriber missed one, a full resync is owed instead of a
+			// bare keepalive.
+			if s.runs.Dirty(sub) {
+				snap, err := json.Marshal(s.runs.Snapshot())
+				if err != nil {
+					slog.Warn("runs stream resync marshal", "err", err)
+					continue
+				}
+				if _, err := fmt.Fprintf(w, "event: snapshot\ndata: %s\n\n", snap); err != nil {
+					return
+				}
+			} else if _, err := fmt.Fprint(w, ": ping\n\n"); err != nil {
 				return
 			}
 			flusher.Flush()

--- a/server/runs_api_test.go
+++ b/server/runs_api_test.go
@@ -1,10 +1,13 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/noamsto/houston/runs"
 )
@@ -12,7 +15,7 @@ import (
 func TestRunsSnapshotReturnsComposedRuns(t *testing.T) {
 	reg := runs.NewRegistry(runs.DefaultOrder)
 	reg.Apply(runs.Delta{Source: "tmux", Key: "%1", Run: runs.Run{Branch: "main"}})
-	reg.Apply(runs.Delta{Source: "hooks", Key: "%1", Run: runs.Run{State: runs.StateRunning}})
+	reg.Apply(runs.Delta{Source: "hooks", Key: "%1", Run: runs.Run{Agent: "claude", State: runs.StateRunning}})
 
 	s := &Server{runs: reg}
 	rec := httptest.NewRecorder()
@@ -37,6 +40,54 @@ func TestRunsSnapshotWithoutRegistryIs503(t *testing.T) {
 
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Fatalf("status %d, want 503", rec.Code)
+	}
+}
+
+func TestRunsStreamDeliversARemoval(t *testing.T) {
+	reg := runs.NewRegistry(runs.DefaultOrder)
+	reg.Apply(runs.Delta{Source: "hooks", Key: "%1", Run: runs.Run{Agent: "claude", State: runs.StateRunning}})
+
+	s := &Server{runs: reg}
+	rec := httptest.NewRecorder()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	req := httptest.NewRequest(http.MethodGet, "/api/runs/stream", nil).WithContext(ctx)
+
+	done := make(chan struct{})
+	go func() {
+		s.handleRunsStream(rec, req)
+		close(done)
+	}()
+
+	waitForBody := func(substr string, timeout time.Duration) bool {
+		deadline := time.Now().Add(timeout)
+		for time.Now().Before(deadline) {
+			if strings.Contains(rec.Body.String(), substr) {
+				return true
+			}
+			time.Sleep(25 * time.Millisecond)
+		}
+		return false
+	}
+
+	if !waitForBody("event: snapshot", time.Second) {
+		t.Fatalf("snapshot event never sent\n%s", rec.Body.String())
+	}
+
+	// The run's only agent-bearing layer leaves — the registry must report it
+	// as removed, not just fall silent.
+	reg.Apply(runs.Delta{Source: "hooks", Key: "%1", Gone: true})
+
+	if !waitForBody(`"removed":true`, 2*time.Second) {
+		t.Fatalf("removal never reached the client\n%s", rec.Body.String())
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Errorf("handler did not return after cancel")
 	}
 }
 

--- a/server/runs_api_test.go
+++ b/server/runs_api_test.go
@@ -1,0 +1,59 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/noamsto/houston/runs"
+)
+
+func TestRunsSnapshotReturnsComposedRuns(t *testing.T) {
+	reg := runs.NewRegistry(runs.DefaultOrder)
+	reg.Apply(runs.Delta{Source: "tmux", Key: "%1", Run: runs.Run{Branch: "main"}})
+	reg.Apply(runs.Delta{Source: "hooks", Key: "%1", Run: runs.Run{State: runs.StateRunning}})
+
+	s := &Server{runs: reg}
+	rec := httptest.NewRecorder()
+	s.handleRunsSnapshot(rec, httptest.NewRequest("GET", "/api/runs", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d, want 200", rec.Code)
+	}
+	var got []runs.Run
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v — body %s", err, rec.Body.String())
+	}
+	if len(got) != 1 || got[0].State != runs.StateRunning || got[0].Branch != "main" {
+		t.Fatalf("got %+v, want one composed run", got)
+	}
+}
+
+func TestRunsSnapshotWithoutRegistryIs503(t *testing.T) {
+	s := &Server{} // registry never started
+	rec := httptest.NewRecorder()
+	s.handleRunsSnapshot(rec, httptest.NewRequest("GET", "/api/runs", nil))
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status %d, want 503", rec.Code)
+	}
+}
+
+func TestRunsRoutesAreBehindTheAuthGate(t *testing.T) {
+	// A new route registered outside apiMux would reopen the hole closed in #4.
+	dir := t.TempDir()
+	s, err := New(Config{StatusDir: dir, AuthEnabled: true})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "http://127.0.0.1/api/runs", nil)
+	req.Host = "127.0.0.1"
+	rec := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status %d, want 401 — /api/runs must require a token", rec.Code)
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -26,6 +26,7 @@ import (
 	"github.com/noamsto/houston/internal/ansi"
 	"github.com/noamsto/houston/opencode"
 	"github.com/noamsto/houston/parser"
+	"github.com/noamsto/houston/runs"
 	"github.com/noamsto/houston/status"
 	"github.com/noamsto/houston/tmux"
 )
@@ -88,6 +89,9 @@ type Server struct {
 
 	// Agent-card hub (new) — aggregates hook state + transcript tails.
 	hub *hub.Hub
+
+	// runs composes the hook, tmux and crew sources into one Run per key.
+	runs *runs.Registry
 
 	auth  *authGate
 	hosts *hostGate
@@ -152,6 +156,28 @@ func New(cfg Config) (*Server, error) {
 		}
 	}()
 
+	reg := runs.NewRegistry(runs.DefaultOrder)
+	s.runs = reg
+
+	deltas := make(chan runs.Delta, 256)
+	go func() {
+		for d := range deltas {
+			reg.Apply(d)
+		}
+	}()
+
+	for _, src := range []runs.Source{
+		runs.NewHookSource(s.hub),
+		runs.NewTmuxSource(tmuxClient, 2*time.Second),
+		runs.NewCrewSource(tmuxClient, 3*time.Second),
+	} {
+		go func(src runs.Source) {
+			if err := src.Run(context.Background(), deltas); err != nil && !errors.Is(err, context.Canceled) {
+				slog.Warn("run source stopped", "source", src.Name(), "error", err)
+			}
+		}(src)
+	}
+
 	// Initialize OpenCode integration if enabled
 	if cfg.OpenCodeEnabled {
 		var opts []opencode.DiscoveryOption
@@ -213,6 +239,8 @@ func (s *Server) Handler() http.Handler {
 	apiMux.HandleFunc("/api/opencode/session/", s.handleAPIOpenCodeSession)
 	apiMux.HandleFunc("/api/agents", s.handleAgentsSnapshot)
 	apiMux.HandleFunc("/api/agents/stream", s.handleAgentsStream)
+	apiMux.HandleFunc("/api/runs", s.handleRunsSnapshot)
+	apiMux.HandleFunc("/api/runs/stream", s.handleRunsStream)
 	mux.Handle("/api/", s.auth.middleware(apiMux))
 
 	// The host gate wraps everything, including "/", so a rebound domain is

--- a/tmux/options.go
+++ b/tmux/options.go
@@ -1,0 +1,87 @@
+package tmux
+
+import (
+	"strconv"
+	"strings"
+)
+
+// windowOptionsFormat harvests every lazytmux window user-option in one call.
+// tmux resolves #{@name} inline, so no per-window show-options loop is needed.
+const windowOptionsFormat = "#{session_name}|#{window_index}|#{@branch}|#{@issue_id}|" +
+	"#{@pr_number}|#{@crew_name}|#{@pr_state}|#{@pr_check_state}|#{@pr_mergeable}|" +
+	"#{@window_task}|#{@git_root}"
+
+const paneOptionsFormat = "#{pane_id}|#{session_name}:#{window_index}|#{@claude_status}|#{@claude_task}"
+
+// WindowOptions is lazytmux's per-window enrichment. Every field may be empty:
+// a window with no linked issue or PR simply has none.
+type WindowOptions struct {
+	Session      string
+	Window       int
+	Branch       string
+	IssueID      string
+	PRNumber     string
+	CrewName     string
+	PRState      string
+	PRCheckState string
+	PRMergeable  string
+	Task         string
+	GitRoot      string
+}
+
+type PaneOptions struct {
+	PaneID       string
+	Target       string // "session:window"
+	ClaudeStatus string
+	ClaudeTask   string
+}
+
+func (c *Client) ListWindowOptions() ([]WindowOptions, error) {
+	out, err := c.output("list-windows", "-a", "-F", windowOptionsFormat)
+	if err != nil {
+		return nil, err
+	}
+	return ParseWindowOptions(string(out)), nil
+}
+
+func (c *Client) ListPaneOptions() ([]PaneOptions, error) {
+	out, err := c.output("list-panes", "-a", "-F", paneOptionsFormat)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePaneOptions(string(out)), nil
+}
+
+func ParseWindowOptions(out string) []WindowOptions {
+	var res []WindowOptions
+	for _, line := range strings.Split(out, "\n") {
+		f := strings.Split(line, "|")
+		if len(f) < 11 {
+			continue
+		}
+		idx, err := strconv.Atoi(f[1])
+		if err != nil {
+			continue
+		}
+		res = append(res, WindowOptions{
+			Session: f[0], Window: idx, Branch: f[2], IssueID: f[3],
+			PRNumber: f[4], CrewName: f[5], PRState: f[6], PRCheckState: f[7],
+			PRMergeable: f[8], Task: f[9], GitRoot: f[10],
+		})
+	}
+	return res
+}
+
+func ParsePaneOptions(out string) []PaneOptions {
+	var res []PaneOptions
+	for _, line := range strings.Split(out, "\n") {
+		f := strings.Split(line, "|")
+		if len(f) < 4 {
+			continue
+		}
+		res = append(res, PaneOptions{
+			PaneID: f[0], Target: f[1], ClaudeStatus: f[2], ClaudeTask: f[3],
+		})
+	}
+	return res
+}

--- a/tmux/options.go
+++ b/tmux/options.go
@@ -5,13 +5,19 @@ import (
 	"strings"
 )
 
+// optSep separates fields below. tmux emits option values verbatim, and free
+// text like @window_task is captured from a user prompt — it can contain "|"
+// (e.g. "run x | grep y"), which would shift every later field. \x1f (ASCII
+// unit separator) is not something a user types, so it round-trips safely.
+const optSep = "\x1f"
+
 // windowOptionsFormat harvests every lazytmux window user-option in one call.
 // tmux resolves #{@name} inline, so no per-window show-options loop is needed.
-const windowOptionsFormat = "#{session_name}|#{window_index}|#{@branch}|#{@issue_id}|" +
-	"#{@pr_number}|#{@crew_name}|#{@pr_state}|#{@pr_check_state}|#{@pr_mergeable}|" +
-	"#{@window_task}|#{@git_root}"
+const windowOptionsFormat = "#{session_name}" + optSep + "#{window_index}" + optSep + "#{@branch}" + optSep + "#{@issue_id}" + optSep +
+	"#{@pr_number}" + optSep + "#{@crew_name}" + optSep + "#{@pr_state}" + optSep + "#{@pr_check_state}" + optSep + "#{@pr_mergeable}" + optSep +
+	"#{@window_task}" + optSep + "#{@git_root}"
 
-const paneOptionsFormat = "#{pane_id}|#{session_name}:#{window_index}|#{@claude_status}|#{@claude_task}"
+const paneOptionsFormat = "#{pane_id}" + optSep + "#{session_name}:#{window_index}" + optSep + "#{@claude_status}" + optSep + "#{@claude_task}"
 
 // WindowOptions is lazytmux's per-window enrichment. Every field may be empty:
 // a window with no linked issue or PR simply has none.
@@ -55,8 +61,8 @@ func (c *Client) ListPaneOptions() ([]PaneOptions, error) {
 func ParseWindowOptions(out string) []WindowOptions {
 	var res []WindowOptions
 	for _, line := range strings.Split(out, "\n") {
-		f := strings.Split(line, "|")
-		if len(f) < 11 {
+		f := strings.Split(line, optSep)
+		if len(f) != 11 {
 			continue
 		}
 		idx, err := strconv.Atoi(f[1])
@@ -75,8 +81,8 @@ func ParseWindowOptions(out string) []WindowOptions {
 func ParsePaneOptions(out string) []PaneOptions {
 	var res []PaneOptions
 	for _, line := range strings.Split(out, "\n") {
-		f := strings.Split(line, "|")
-		if len(f) < 4 {
+		f := strings.Split(line, optSep)
+		if len(f) != 4 {
 			continue
 		}
 		res = append(res, PaneOptions{

--- a/tmux/options_test.go
+++ b/tmux/options_test.go
@@ -1,0 +1,56 @@
+package tmux
+
+import "testing"
+
+func TestParseWindowOptions(t *testing.T) {
+	// Real output shape, including the common all-empty-options case.
+	out := "lazytmux|2|feat/320-relay|#320|565|mauve|open|passing|MERGEABLE||\n" +
+		"houston|1|main||||||||\n"
+
+	got := ParseWindowOptions(out)
+	if len(got) != 2 {
+		t.Fatalf("%d windows, want 2", len(got))
+	}
+
+	w := got[0]
+	if w.Session != "lazytmux" || w.Window != 2 {
+		t.Errorf("target = %s:%d, want lazytmux:2", w.Session, w.Window)
+	}
+	if w.Branch != "feat/320-relay" || w.IssueID != "#320" || w.PRNumber != "565" {
+		t.Errorf("got branch=%q issue=%q pr=%q", w.Branch, w.IssueID, w.PRNumber)
+	}
+	if w.CrewName != "mauve" || w.PRState != "open" || w.PRCheckState != "passing" {
+		t.Errorf("got crew=%q pr_state=%q checks=%q", w.CrewName, w.PRState, w.PRCheckState)
+	}
+
+	bare := got[1]
+	if bare.Branch != "main" || bare.IssueID != "" || bare.PRNumber != "" {
+		t.Errorf("a window with no enrichment should carry only its branch, got %+v", bare)
+	}
+}
+
+func TestParseWindowOptionsSkipsMalformedLines(t *testing.T) {
+	got := ParseWindowOptions("too|few|fields\n\nhouston|1|main||||||||\n")
+	if len(got) != 1 {
+		t.Fatalf("%d windows, want 1 — short and empty lines are skipped, not fatal", len(got))
+	}
+}
+
+func TestParsePaneOptions(t *testing.T) {
+	out := "%307|houston:1|processing 1788848628 |and add a ci task\n" +
+		"%283|dispatcher:1||\n"
+
+	got := ParsePaneOptions(out)
+	if len(got) != 2 {
+		t.Fatalf("%d panes, want 2", len(got))
+	}
+	if got[0].PaneID != "%307" || got[0].ClaudeStatus != "processing 1788848628 " {
+		t.Errorf("got %+v", got[0])
+	}
+	if got[0].ClaudeTask != "and add a ci task" {
+		t.Errorf("task = %q", got[0].ClaudeTask)
+	}
+	if got[1].ClaudeStatus != "" {
+		t.Errorf("a pane with no claude status should be empty, got %q", got[1].ClaudeStatus)
+	}
+}

--- a/tmux/options_test.go
+++ b/tmux/options_test.go
@@ -4,8 +4,8 @@ import "testing"
 
 func TestParseWindowOptions(t *testing.T) {
 	// Real output shape, including the common all-empty-options case.
-	out := "lazytmux|2|feat/320-relay|#320|565|mauve|open|passing|MERGEABLE||\n" +
-		"houston|1|main||||||||\n"
+	out := "lazytmux\x1f2\x1ffeat/320-relay\x1f#320\x1f565\x1fmauve\x1fopen\x1fpassing\x1fMERGEABLE\x1f\x1f\n" +
+		"houston\x1f1\x1fmain\x1f\x1f\x1f\x1f\x1f\x1f\x1f\x1f\n"
 
 	got := ParseWindowOptions(out)
 	if len(got) != 2 {
@@ -30,15 +30,33 @@ func TestParseWindowOptions(t *testing.T) {
 }
 
 func TestParseWindowOptionsSkipsMalformedLines(t *testing.T) {
-	got := ParseWindowOptions("too|few|fields\n\nhouston|1|main||||||||\n")
+	got := ParseWindowOptions("too\x1ffew\x1ffields\n\nhouston\x1f1\x1fmain\x1f\x1f\x1f\x1f\x1f\x1f\x1f\x1f\n")
 	if len(got) != 1 {
 		t.Fatalf("%d windows, want 1 — short and empty lines are skipped, not fatal", len(got))
 	}
 }
 
+func TestParseWindowOptionsSurvivesPipeInFreeText(t *testing.T) {
+	// @window_task is free text captured from a user prompt, so it can contain
+	// anything. With a "|" delimiter this shifted GitRoot into garbage and
+	// silently dropped the real value.
+	out := "houston\x1f1\x1fmain\x1f\x1f\x1f\x1f\x1f\x1f\x1frun x | grep fail\x1f/home/n/git/houston\n"
+
+	got := ParseWindowOptions(out)
+	if len(got) != 1 {
+		t.Fatalf("%d windows, want 1", len(got))
+	}
+	if got[0].Task != "run x | grep fail" {
+		t.Errorf("Task = %q, want the pipe preserved inside the field", got[0].Task)
+	}
+	if got[0].GitRoot != "/home/n/git/houston" {
+		t.Errorf("GitRoot = %q — a pipe in an earlier field shifted it", got[0].GitRoot)
+	}
+}
+
 func TestParsePaneOptions(t *testing.T) {
-	out := "%307|houston:1|processing 1788848628 |and add a ci task\n" +
-		"%283|dispatcher:1||\n"
+	out := "%307\x1fhouston:1\x1fprocessing 1788848628 \x1fand add a ci task\n" +
+		"%283\x1fdispatcher:1\x1f\x1f\n"
 
 	got := ParsePaneOptions(out)
 	if len(got) != 2 {


### PR DESCRIPTION
Third of the #2 milestones. Makes the **agent run** the thing houston is a list of,
and serves it at `/api/runs` **alongside** the existing routes — nothing is deleted,
nothing breaks. Moving the UI across and retiring `/api/sessions`, `/api/agents` and
`/api/pane/*` is a separate plan, so there is never a window where neither API is
trustworthy.

## What it adds

A `runs/` package with one `Run` model and **one state vocabulary**. Three upstream
vocabularies map into it — Claude Code hooks, dispatcher's crew bus, and lazytmux's
`@claude_status` — and they disagree with each other, so `runs/state.go` is the only
place that reconciliation lives. Exactly one state, `blocked`, means *a human is
required*; a test asserts exactly one, because the badge, the sort order and future
notifications all key off it.

**Sources publish sparse layers; a registry composes them.** Each source writes only
the fields it owns under its own name, and the registry merges by a fixed precedence
(`tmux → crew → hooks`, lowest first). A zero field means "no opinion", so a lower
layer survives where a higher one is silent. Precedence is one ordered slice rather
than merge logic spread across writers, which makes it a table test.

Three sources ship:

- **hooks** — rides the existing hub, so no new file watching or transcript tailing.
- **tmux** — reads what **lazytmux already computes**: branch, worktree, linked issue,
  PR number/state/checks, crew name. Two format-string calls harvest everything; tmux
  resolves `#{@name}` inline. houston does no GitHub polling, no `gh`, no enrichment of
  its own.
- **crew** — tails dispatcher's append-only JSONL bus for the one thing nothing else
  can express: a worker blocked on a question addressed to you.

Runs correlate on the **tmux pane id**, which hooks and tmux both produce. Crew records
know their branch rather than their pane, so a dispatcher worker currently appears
twice — once as its pane, once as its branch. Joining them needs branch-to-pane
resolution that belongs with the Crews tab; it is deliberate, not a bug.

## Verified against a live server

8 tmux panes → 32 runs, and the difference is the point:

| | | |
|---|---|---|
| 5 | `pane-*` | only panes with `@claude_status`; 3 plain shells correctly excluded |
| 22 | `sess-*` | Claude sessions the hub knows from transcripts, no pane attached |
| 5 | `branch-*` | dispatcher crew workers |

Enrichment intact: `pane-459` carries issue `#320` and PR `565` (open, checks passing,
mergeable) — all from tmux options. `/api/sessions` and `/api/agents` still answer, and
unauthenticated `/api/runs` returns 401.

## Seven defects found in review, none by the test suite

Worth listing, because the shape is consistent — every one was in the plan text, and
every one passed a green suite:

| Defect | Consequence |
|---|---|
| `Apply` copied subscribers then sent outside the lock | `send on closed channel` **panic** whenever a browser disconnected during activity. `hub.broadcast` already had the correct pattern; the plan deviated from it |
| `CrewSource` joined `.git/crew` on the worktree path | In a worktree `.git` is a *file*, and dispatcher writes under the common git dir — so it silently found nothing, in the topology this project mandates for all work |
| Both parsers split on `\|`, positionally | `@window_task` is free text from a user prompt; "run x \| grep y" shifted every later field. `len(f) < 11` could not catch it — a shifted row has *more* fields |
| A transient tmux error emitted `Gone` for everything | One flaky call deleted every run from the UI |
| Every pane was listed as an agent run | Shells, builds and `htop` arrived with `agent:""` |
| `Run.ID` was not URL-path-safe | `%307` decodes to `/api/runs/07`; `branch/fix/412` breaks segment routing — and `/api/runs/{id}` is the next plan |
| The stream had no removal event | A client's list only ever grew until it reconnected |

Two were proven before being fixed rather than after: the panic was reproduced with a
concurrency stress test, and the pipe shift with `tmux set @probe 'a\|b'` on a live
server. Delimiter is now `\x1f` with exact field-count checks, so an embedded separator
fails loudly instead of silently.

## Design notes worth knowing

- **A run exists only if some source claims an agent.** The tmux layer still publishes
  enrichment for every pane — branch and PR data are harmless alone — but sets `Agent`
  only when `@claude_status` is present. Filtering the whole delta instead would have
  starved a hooks-only Claude pane of its branch and PR.
- **Removal rides an edge, not a state.** `listed → not-listed` fires exactly one
  removal, covering both "last layer gone" and "agent lost". Without the edge, a hooks
  layer going away while the tmux layer survives leaves a live key with no agent — the
  update suppressed and the run wedged on screen forever.
- **Dedupe is paired with a dirty flag**, mirroring `PaneSub` in the terminal path.
  Signature-compare alone would make a dropped update permanent, since only the
  redundant 2s re-emission healed one before. A resync now costs one snapshot, and only
  when a drop actually happened.
- **Sources run under `context.Background()`**, matching how the hub is already started.
  A proper `Server.Start(ctx)/Close()` is a follow-up; half a lifecycle would be worse
  than none.

## Follow-ups, not in this PR

- **`Caps` can go stale true.** `mergeInto` ORs capabilities and never clears them, and
  the hooks layer keeps asserting `Terminal: true` from a `TmuxPane` that outlives the
  pane in the state file. The UI will offer an attach button for a dead pane. This is
  **not** fixable in the change-detection layer — `Caps.Terminal` never transitions
  true→false, so adding it to the signature would broadcast nothing. It needs `Caps`
  derived at composition time from what is currently true.
- **Nothing evicts finished runs.** `CrewSource` never emits `Gone`, so branches from an
  append-only log accumulate; the hub's 24h discovery window keeps ended sessions. On
  the live check that is 15 `done` and 6 `blocked` sessions aged 0h–5.3h. All 32 runs
  carry a usable `updated_at`, so the Fleet UI has what it needs to apply a staleness
  cutoff — and it must, or a permanently lit badge destroys the one signal this
  redesign is built around.
- `runSignature` omits `Tokens`, so token counts refresh only when something else
  changes.
- `crewDir` caches negative results for the process lifetime.
- No CI on this repo — tracked in #6.

https://claude.ai/code/session_01S3QQF9tpsskteWqRJN3Hn6
