### PR TITLE
feat(ui): Mocha design system and the mobile fleet shell

### DIFF
--- a/docs/superpowers/plans/2026-09-08-mocha-fleet-shell.md
+++ b/docs/superpowers/plans/2026-09-08-mocha-fleet-shell.md
@@ -1,0 +1,979 @@
+# Mocha design system and the Fleet shell — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Put the agent-run fleet on screen — a Catppuccin Mocha design system, a `useRuns()` store over `/api/runs/stream`, and the mobile 4-tab shell with the Fleet tab live.
+
+**Architecture:** Additive. The existing `#/agents` and `#/panes` views keep working untouched; the new shell mounts at `#/fleet`. Mocha tokens are added alongside the current ones rather than replacing them, so nothing existing changes colour until the old views are deleted in a later plan.
+
+**Tech Stack:** React 19, TypeScript, Vite. No new dependencies — no CSS framework, no component library, no state library. CSS custom properties and plain `useState`/`useEffect`, matching what `ui/` already does.
+
+**Spec:** `docs/superpowers/specs/2026-09-07-houston-overhaul-design.md` — "UI: two shells, one store". The visual direction (Instrument Mocha) and the 4-tab shell were chosen from mockups in an earlier design session.
+
+## Global Constraints
+
+- **No new dependencies.** `ui/package.json` gains nothing.
+- **Additive only.** Do not modify or delete `AgentsView`, `AgentCard`, `agents.css`,
+  `Sidebar`, `TerminalArea`, or any existing hook. The old views must still work.
+- **Palette is Catppuccin Mocha**, and every colour comes from a token. No hex
+  literals in component files.
+- **Mobile first.** The target is a phone held in one hand. Tap targets ≥ 44px.
+- **Lint and types must pass:** `cd ui && npx eslint .` and `npx tsc -b`. Both are
+  pre-commit hooks (`flake.nix:32,42`).
+- The dev server proxies `/api` to `localhost:9090` (`ui/vite.config.ts`). To see real
+  data, run `just dev` in one shell and `just ui-dev` in another, and open the Go
+  server's port once so the browser holds the auth cookie.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `ui/src/theme/mocha.css` | Catppuccin Mocha palette + semantic aliases | **Create** |
+| `ui/src/api/runs.ts` | TS mirror of the Go `Run` types | **Create** |
+| `ui/src/hooks/useRuns.ts` | SSE store over `/api/runs/stream` | **Create** |
+| `ui/src/fleet/staleness.ts` | The freshness rule, in one place | **Create** |
+| `ui/src/fleet/RunCard.tsx` | One run | **Create** |
+| `ui/src/fleet/FleetView.tsx` | Grouped list, filters, badge | **Create** |
+| `ui/src/fleet/Shell.tsx` | 4-tab shell | **Create** |
+| `ui/src/fleet/fleet.css` | Shell + card styles | **Create** |
+| `ui/src/App.tsx` | Route `#/fleet` to the new shell | Modify (additive) |
+
+A new `ui/src/fleet/` directory rather than growing `components/`: it is a self-contained
+surface that a later plan will promote to the default, and keeping it separate makes the
+eventual deletion of the old views a directory removal rather than an untangling.
+
+---
+
+### Task 1: Mocha tokens and the run type
+
+**Files:**
+- Create: `ui/src/theme/mocha.css`, `ui/src/api/runs.ts`
+- Test: none — these are declarations. Task 3 exercises the types.
+
+**Interfaces:**
+- Produces: CSS custom properties under `.mocha`; TS types `Run`, `RunState`, `TmuxRef`, `IssueRef`, `PRRef`, `CrewRef`, `Activity`, `TrailChip`, `Question`, `Tokens`, `Caps`.
+
+- [ ] **Step 1: Write `ui/src/theme/mocha.css`**
+
+```css
+/*
+ * Catppuccin Mocha. Scoped to .mocha so it can coexist with the old views'
+ * tokens until those are deleted.
+ *
+ * Raw palette first, then semantic aliases. Components use only the semantic
+ * names — a component naming --ctp-mauve directly is a bug, because it pins a
+ * colour to a meaning it does not own.
+ */
+.mocha {
+  --ctp-base: #1e1e2e;
+  --ctp-mantle: #181825;
+  --ctp-crust: #11111b;
+  --ctp-surface0: #313244;
+  --ctp-surface1: #45475a;
+  --ctp-surface2: #585b70;
+  --ctp-overlay0: #6c7086;
+  --ctp-overlay1: #7f849c;
+  --ctp-overlay2: #9399b2;
+  --ctp-subtext0: #a6adc8;
+  --ctp-subtext1: #bac2de;
+  --ctp-text: #cdd6f4;
+  --ctp-green: #a6e3a1;
+  --ctp-red: #f38ba8;
+  --ctp-yellow: #f9e2af;
+  --ctp-peach: #fab387;
+  --ctp-blue: #89b4fa;
+  --ctp-mauve: #cba6f7;
+  --ctp-teal: #94e2d5;
+
+  --bg: var(--ctp-mantle);
+  --bg-raised: var(--ctp-base);
+  --bg-sunken: var(--ctp-crust);
+  --line: var(--ctp-surface0);
+  --line-strong: var(--ctp-surface1);
+  --text: var(--ctp-text);
+  --text-dim: var(--ctp-overlay2);
+  --text-faint: var(--ctp-overlay0);
+  --accent: var(--ctp-mauve);
+
+  /* One colour per run state. blocked is the only "needs you" colour and must
+     not be reused for anything else, or the badge stops meaning one thing. */
+  --state-blocked: var(--ctp-red);
+  --state-running: var(--ctp-green);
+  --state-thinking: var(--ctp-yellow);
+  --state-review: var(--ctp-blue);
+  --state-done: var(--ctp-overlay0);
+  --state-failed: var(--ctp-peach);
+  --state-idle: var(--ctp-overlay0);
+  --state-compacting: var(--ctp-teal);
+
+  --host-local: var(--ctp-blue);
+  --host-remote: var(--ctp-peach);
+
+  --font-ui: -apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', sans-serif;
+  --font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+
+  --tap: 44px; /* minimum touch target */
+}
+```
+
+- [ ] **Step 2: Write `ui/src/api/runs.ts`**
+
+Mirror the Go types exactly. Field names come from the `json:` tags in `runs/run.go`; do not invent camelCase.
+
+```ts
+// Mirror of runs.State (Go). Exactly one state means "a human is required".
+export type RunState =
+  | 'thinking'
+  | 'running'
+  | 'blocked'
+  | 'compacting'
+  | 'review'
+  | 'done'
+  | 'failed'
+  | 'idle'
+
+export interface TmuxRef {
+  session: string
+  window: number
+  pane_id: string
+}
+
+export interface IssueRef {
+  id: string
+  title?: string
+  url?: string
+  provider?: string
+}
+
+export interface PRRef {
+  number: string
+  state?: string
+  check_state?: string
+  mergeable?: string
+  draft?: boolean
+  url?: string
+}
+
+export interface CrewRef {
+  name: string
+  color?: string
+  tier?: string
+}
+
+export interface TrailChip {
+  tool: string
+  hint?: string
+  done: boolean
+  error?: boolean
+}
+
+export interface Activity {
+  tool?: string
+  hint?: string
+  message?: string
+  task?: string
+  trail?: TrailChip[]
+  preview?: string
+  turn?: number
+}
+
+export interface Question {
+  text: string
+  via: string // "pane" | "crew"
+}
+
+export interface Tokens {
+  input: number
+  output: number
+}
+
+export interface Caps {
+  terminal: boolean
+  reply: boolean
+  kill: boolean
+}
+
+// Mirror of runs.Run.
+//
+// A removal arrives as an ordinary `update` event carrying only `id` and
+// `removed: true` — every other field is empty, so consumers must check
+// `removed` before reading anything else.
+export interface Run {
+  id: string
+  host?: string
+  agent: string
+  state: RunState
+  repo?: string
+  branch?: string
+  worktree?: string
+  tmux?: TmuxRef
+  issue?: IssueRef
+  pr?: PRRef
+  crew?: CrewRef
+  activity: Activity
+  question?: Question
+  tokens: Tokens
+  since?: number
+  updated_at: number
+  stale?: boolean
+  caps: Caps
+  removed?: boolean
+}
+```
+
+- [ ] **Step 3: Verify types and lint**
+
+Run: `cd ui && npx tsc -b && npx eslint .`
+Expected: no output from either.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add ui/src/theme/mocha.css ui/src/api/runs.ts
+git commit -m "feat(ui): Catppuccin Mocha tokens and the Run type"
+```
+
+---
+
+### Task 2: The freshness rule, in one place
+
+The live API returns finished and detached sessions alongside live ones — on a real
+server, 22 of 32 runs, six of them reporting `blocked` and aged up to 5.3 hours. If the
+Fleet badge counts those, it is permanently lit and the one signal this redesign exists
+for is dead.
+
+Age alone is the wrong discriminator: a genuinely blocked agent waiting five hours is
+exactly what you want to see. So the rule is deliberately asymmetric — **nothing that
+reports `blocked` is ever hidden**, but the badge only counts recent ones.
+
+**Files:**
+- Create: `ui/src/fleet/staleness.ts`, `ui/src/fleet/staleness.test.ts`
+
+**Interfaces:**
+- Produces: `FRESH_MS`, `isFresh(run, now)`, `needsYou(run, now)`, `isHistory(run, now)`
+
+- [ ] **Step 1: Write the failing test**
+
+`ui/src/fleet/staleness.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest'
+import { FRESH_MS, isFresh, isHistory, needsYou } from './staleness'
+import type { Run } from '../api/runs'
+
+const now = 1_800_000_000_000 // fixed ms
+
+function run(p: Partial<Run>): Run {
+  return {
+    id: 'pane-1', agent: 'claude', state: 'idle',
+    activity: {}, tokens: { input: 0, output: 0 },
+    caps: { terminal: false, reply: false, kill: false },
+    updated_at: Math.floor(now / 1000),
+    ...p,
+  } as Run
+}
+
+const agoSec = (ms: number) => Math.floor((now - ms) / 1000)
+
+describe('staleness', () => {
+  it('counts a recently blocked run as needing you', () => {
+    expect(needsYou(run({ state: 'blocked' }), now)).toBe(true)
+  })
+
+  it('does not count a long-stale blocked run toward the badge', () => {
+    const old = run({ state: 'blocked', updated_at: agoSec(FRESH_MS + 60_000) })
+    expect(needsYou(old, now)).toBe(false)
+  })
+
+  it('never treats a blocked run as history, however old', () => {
+    // Hiding something that asked for input is the worse failure.
+    const old = run({ state: 'blocked', updated_at: agoSec(FRESH_MS * 10) })
+    expect(isHistory(old, now)).toBe(false)
+  })
+
+  it('treats a long-finished run as history', () => {
+    expect(isHistory(run({ state: 'done', updated_at: agoSec(FRESH_MS + 1) }), now)).toBe(true)
+    expect(isHistory(run({ state: 'failed', updated_at: agoSec(FRESH_MS + 1) }), now)).toBe(true)
+  })
+
+  it('keeps a just-finished run out of history so it does not vanish mid-glance', () => {
+    expect(isHistory(run({ state: 'done', updated_at: agoSec(1000) }), now)).toBe(false)
+  })
+
+  it('never treats a running or thinking run as history', () => {
+    for (const state of ['running', 'thinking', 'review', 'compacting'] as const) {
+      const old = run({ state, updated_at: agoSec(FRESH_MS * 5) })
+      expect(isHistory(old, now)).toBe(false)
+    }
+  })
+
+  it('reports freshness from updated_at', () => {
+    expect(isFresh(run({ updated_at: agoSec(1000) }), now)).toBe(true)
+    expect(isFresh(run({ updated_at: agoSec(FRESH_MS + 1) }), now)).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Add vitest**
+
+`ui/` has no test runner. Add one — it is a devDependency for the UI's own tests, not a
+runtime dependency, and the plan's "no new dependencies" constraint is about shipping
+code:
+
+```bash
+cd ui && npm install -D vitest
+```
+
+Add to `ui/package.json` scripts: `"test": "vitest run"`.
+
+If you would rather not add vitest, return BLOCKED and say so — do **not** silently drop
+the tests. This rule is the difference between the badge working and not, and it must be
+pinned.
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `cd ui && npx vitest run`
+Expected: FAIL — `Cannot find module './staleness'`.
+
+- [ ] **Step 4: Write `ui/src/fleet/staleness.ts`**
+
+```ts
+import type { Run } from '../api/runs'
+
+/**
+ * How recently a run must have reported to count as fresh.
+ *
+ * Tuned against real data: a live server carried 22 finished-or-detached runs
+ * alongside 10 live ones, six of them still reporting `blocked` from up to five
+ * hours earlier. Move this if an hour proves wrong in practice — it is the only
+ * number that decides what the badge counts.
+ */
+export const FRESH_MS = 60 * 60 * 1000
+
+export function isFresh(run: Run, now: number): boolean {
+  if (!run.updated_at) return false
+  return now - run.updated_at * 1000 <= FRESH_MS
+}
+
+/**
+ * needsYou drives the badge and the sort. A run that asked for input long ago
+ * is almost always a session that ended while waiting, and counting it would
+ * leave the badge permanently lit — but see isHistory: it is still shown.
+ */
+export function needsYou(run: Run, now: number): boolean {
+  return run.state === 'blocked' && isFresh(run, now)
+}
+
+/**
+ * isHistory marks a run as foldable behind the "All" filter. Only terminal
+ * states qualify, and only once stale: a run that is blocked, running or
+ * thinking is never history however old it looks, because hiding something
+ * that is waiting on you is the worse failure.
+ */
+export function isHistory(run: Run, now: number): boolean {
+  if (run.state !== 'done' && run.state !== 'failed') return false
+  return !isFresh(run, now)
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cd ui && npx vitest run`
+Expected: PASS, 7 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ui/src/fleet/staleness.ts ui/src/fleet/staleness.test.ts ui/package.json ui/package-lock.json
+git commit -m "feat(ui): freshness rule for the fleet badge"
+```
+
+---
+
+### Task 3: `useRuns()` — the store
+
+**Files:**
+- Create: `ui/src/hooks/useRuns.ts`
+- Test: `ui/src/hooks/useRuns.test.ts`
+
+**Interfaces:**
+- Consumes: `Run` from Task 1.
+- Produces: `useRuns()` returning `{ runs: Run[]; connected: boolean }`, and
+  `applyEvent(map, run)` exported for the test.
+
+- [ ] **Step 1: Write the failing test**
+
+`ui/src/hooks/useRuns.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest'
+import { applyEvent } from './useRuns'
+import type { Run } from '../api/runs'
+
+function run(id: string, p: Partial<Run> = {}): Run {
+  return {
+    id, agent: 'claude', state: 'running',
+    activity: {}, tokens: { input: 0, output: 0 },
+    caps: { terminal: true, reply: true, kill: true },
+    updated_at: 1000,
+    ...p,
+  } as Run
+}
+
+describe('applyEvent', () => {
+  it('adds an unseen run', () => {
+    const next = applyEvent(new Map(), run('pane-1'))
+    expect(next.get('pane-1')?.state).toBe('running')
+  })
+
+  it('replaces an existing run wholesale', () => {
+    const first = applyEvent(new Map(), run('pane-1', { state: 'running' }))
+    const next = applyEvent(first, run('pane-1', { state: 'blocked' }))
+    expect(next.get('pane-1')?.state).toBe('blocked')
+    expect(next.size).toBe(1)
+  })
+
+  it('deletes on a removal, which carries only id and removed', () => {
+    // The server sends Run{ID, Removed:true} with every other field empty, as
+    // an ordinary `update` — not a distinct event type.
+    const first = applyEvent(new Map(), run('pane-1'))
+    const next = applyEvent(first, { id: 'pane-1', removed: true } as Run)
+    expect(next.has('pane-1')).toBe(false)
+  })
+
+  it('ignores a removal for a run it never had', () => {
+    const next = applyEvent(new Map(), { id: 'ghost', removed: true } as Run)
+    expect(next.size).toBe(0)
+  })
+
+  it('does not mutate the map it was given', () => {
+    const first = applyEvent(new Map(), run('pane-1'))
+    applyEvent(first, run('pane-2'))
+    expect(first.size).toBe(1)
+  })
+})
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cd ui && npx vitest run useRuns`
+Expected: FAIL — `Cannot find module './useRuns'`.
+
+- [ ] **Step 3: Write `ui/src/hooks/useRuns.ts`**
+
+```ts
+import { useEffect, useState } from 'react'
+import type { Run } from '../api/runs'
+
+/**
+ * applyEvent folds one streamed Run into the map, returning a new map.
+ *
+ * A removal arrives as an ordinary update carrying only `id` and `removed`, so
+ * it must be checked before any other field is read.
+ */
+export function applyEvent(runs: Map<string, Run>, r: Run): Map<string, Run> {
+  const next = new Map(runs)
+  if (r.removed) {
+    next.delete(r.id)
+    return next
+  }
+  next.set(r.id, r)
+  return next
+}
+
+/**
+ * Subscribes to /api/runs/stream. The server sends one `snapshot` event on
+ * connect and one `update` per composed change; it also re-sends a full
+ * `snapshot` when it detects this subscriber missed an update, so a snapshot
+ * arriving mid-stream is a resync and replaces the map wholesale.
+ */
+export function useRuns() {
+  const [runs, setRuns] = useState<Map<string, Run>>(new Map())
+  const [connected, setConnected] = useState(false)
+
+  useEffect(() => {
+    const es = new EventSource('/api/runs/stream')
+
+    es.addEventListener('open', () => setConnected(true))
+
+    es.addEventListener('snapshot', (ev: MessageEvent<string>) => {
+      try {
+        const arr = JSON.parse(ev.data) as Run[]
+        setRuns(new Map(arr.map((r) => [r.id, r])))
+        setConnected(true)
+      } catch (e) {
+        console.error('runs snapshot parse failed', e)
+      }
+    })
+
+    es.addEventListener('update', (ev: MessageEvent<string>) => {
+      try {
+        const r = JSON.parse(ev.data) as Run
+        setRuns((prev) => applyEvent(prev, r))
+      } catch (e) {
+        console.error('runs update parse failed', e)
+      }
+    })
+
+    es.onerror = () => setConnected(false) // EventSource retries on its own
+
+    return () => es.close()
+  }, [])
+
+  return { runs: Array.from(runs.values()), connected }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd ui && npx vitest run`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ui/src/hooks/useRuns.ts ui/src/hooks/useRuns.test.ts
+git commit -m "feat(ui): useRuns store over the runs stream"
+```
+
+---
+
+### Task 4: The Fleet view
+
+**Files:**
+- Create: `ui/src/fleet/RunCard.tsx`, `ui/src/fleet/FleetView.tsx`, `ui/src/fleet/fleet.css`
+
+**Interfaces:**
+- Consumes: `useRuns`, `Run`, `needsYou`, `isHistory`, `isFresh`.
+- Produces: `<FleetView />`, `<RunCard run={} now={} />`.
+
+- [ ] **Step 1: Write `ui/src/fleet/fleet.css`**
+
+Card structure from the approved "Instrument Mocha" direction: rounded raised surfaces
+on a mantle ground, sans labels with mono for data, a status dot, one accent reserved
+for "needs you".
+
+```css
+.fleet {
+  position: absolute;
+  inset: 0;
+  overflow-y: auto;
+  background: var(--bg);
+  color: var(--text-dim);
+  font-family: var(--font-ui);
+  font-size: 14px;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.fleet-nav {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 14px;
+  background: color-mix(in srgb, var(--bg) 92%, transparent);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--line);
+}
+.fleet-nav h1 { margin: 0; font-size: 16px; font-weight: 600; color: var(--text); }
+.fleet-badge {
+  font-size: 12px; font-weight: 600; padding: 3px 10px; border-radius: 999px;
+  background: color-mix(in srgb, var(--state-blocked) 22%, transparent);
+  color: var(--state-blocked);
+}
+.fleet-badge.quiet { background: var(--ctp-surface0); color: var(--text-faint); }
+
+.fleet-filters { display: flex; gap: 4px; padding: 10px 12px 4px; }
+.fleet-filters button {
+  flex: 1; min-height: 34px; border: 1px solid var(--line); border-radius: 8px;
+  background: var(--bg-raised); color: var(--text-faint);
+  font: inherit; font-size: 12.5px; cursor: pointer;
+}
+.fleet-filters button.on {
+  background: var(--ctp-surface0); color: var(--text); font-weight: 600;
+  border-color: var(--line-strong);
+}
+
+.fleet-group {
+  display: flex; justify-content: space-between;
+  padding: 14px 14px 6px; font-size: 12px; font-weight: 600; color: var(--text-faint);
+}
+.fleet-group .host-local { color: var(--host-local); }
+.fleet-group .host-remote { color: var(--host-remote); }
+
+.run-card {
+  display: block; width: calc(100% - 20px); margin: 0 10px 8px;
+  padding: 11px 12px; border-radius: 10px; text-align: left;
+  background: var(--bg-raised); border: 1px solid var(--line);
+  color: inherit; font: inherit; cursor: pointer;
+  min-height: var(--tap);
+}
+.run-card.attention { border-color: color-mix(in srgb, var(--state-blocked) 45%, var(--line)); }
+.run-card.history { opacity: 0.55; }
+
+.run-head { display: flex; align-items: center; gap: 8px; margin-bottom: 5px; }
+.run-dot { width: 8px; height: 8px; border-radius: 50%; flex: none; }
+.run-name {
+  color: var(--text); font-size: 14px; font-weight: 600; letter-spacing: -0.01em;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.run-age { margin-left: auto; flex: none; font-size: 12px; color: var(--text-faint); }
+.run-age.stale { font-style: italic; }
+
+.run-sub {
+  font-family: var(--font-mono); font-size: 12px; color: var(--text-dim);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.run-question {
+  margin-top: 9px; padding: 9px 10px; border-radius: 8px;
+  background: var(--bg-sunken); color: var(--ctp-subtext1);
+  font-size: 13px; line-height: 1.45;
+}
+.run-chips { display: flex; flex-wrap: wrap; gap: 5px; margin-top: 8px; }
+.run-chip {
+  font-size: 11px; padding: 2.5px 7px; border-radius: 5px;
+  background: var(--ctp-surface0); color: var(--text-dim);
+}
+.run-chip.pr { background: color-mix(in srgb, var(--state-running) 18%, transparent); color: var(--state-running); }
+.run-chip.pr.failing { background: color-mix(in srgb, var(--state-blocked) 18%, transparent); color: var(--state-blocked); }
+.run-chip.issue { background: color-mix(in srgb, var(--accent) 18%, transparent); color: var(--accent); }
+
+.fleet-empty { padding: 40px 20px; text-align: center; color: var(--text-faint); font-size: 13px; }
+```
+
+- [ ] **Step 2: Write `ui/src/fleet/RunCard.tsx`**
+
+```tsx
+import type { Run } from '../api/runs'
+import { isFresh, isHistory, needsYou } from './staleness'
+
+function agoLabel(updatedAt: number, now: number): string {
+  const s = Math.max(0, Math.floor(now / 1000 - updatedAt))
+  if (s < 60) return `${s}s`
+  const m = Math.floor(s / 60)
+  if (m < 60) return `${m}m`
+  const h = Math.floor(m / 60)
+  if (h < 24) return `${h}h`
+  return `${Math.floor(h / 24)}d`
+}
+
+/** The one line describing what this run is doing right now. */
+function subtitle(run: Run): string {
+  const a = run.activity
+  if (run.state === 'blocked') return a.message || 'waiting on you'
+  if (a.tool) return a.hint ? `${a.tool} · ${a.hint}` : a.tool
+  if (a.task) return a.task
+  if (run.pr) return `PR #${run.pr.number}${run.pr.check_state ? ` · ${run.pr.check_state}` : ''}`
+  return run.state
+}
+
+export function RunCard({ run, now, onOpen }: { run: Run; now: number; onOpen?: (r: Run) => void }) {
+  const attention = needsYou(run, now)
+  const history = isHistory(run, now)
+  const stale = !isFresh(run, now)
+
+  return (
+    <button
+      type="button"
+      className={`run-card${attention ? ' attention' : ''}${history ? ' history' : ''}`}
+      onClick={() => onOpen?.(run)}
+    >
+      <div className="run-head">
+        <span className="run-dot" style={{ background: `var(--state-${run.state})` }} />
+        <span className="run-name">{run.repo ? `${run.repo}/${run.branch ?? ''}` : run.branch || run.id}</span>
+        <span className={`run-age${stale ? ' stale' : ''}`}>{agoLabel(run.updated_at, now)}</span>
+      </div>
+
+      <div className="run-sub">{subtitle(run)}</div>
+
+      {run.question && <div className="run-question">{run.question.text}</div>}
+
+      <div className="run-chips">
+        <span className="run-chip">{run.agent}</span>
+        {run.issue && <span className="run-chip issue">{run.issue.id}</span>}
+        {run.pr && (
+          <span className={`run-chip pr${run.pr.check_state === 'failure' ? ' failing' : ''}`}>
+            #{run.pr.number}
+          </span>
+        )}
+        {run.crew && <span className="run-chip">{run.crew.name}</span>}
+      </div>
+    </button>
+  )
+}
+```
+
+- [ ] **Step 3: Write `ui/src/fleet/FleetView.tsx`**
+
+```tsx
+import { useEffect, useMemo, useState } from 'react'
+import { useRuns } from '../hooks/useRuns'
+import type { Run } from '../api/runs'
+import { isHistory, needsYou } from './staleness'
+import { RunCard } from './RunCard'
+import './fleet.css'
+
+type Filter = 'active' | 'needs-you' | 'all'
+
+/** Ticks once a minute so relative ages and freshness stay honest. */
+function useNow(): number {
+  const [now, setNow] = useState(() => Date.now())
+  useEffect(() => {
+    const id = window.setInterval(() => setNow(Date.now()), 60_000)
+    return () => window.clearInterval(id)
+  }, [])
+  return now
+}
+
+export function FleetView({ onOpen }: { onOpen?: (r: Run) => void }) {
+  const { runs, connected } = useRuns()
+  const now = useNow()
+  const [filter, setFilter] = useState<Filter>('active')
+
+  const attentionCount = useMemo(
+    () => runs.filter((r) => needsYou(r, now)).length,
+    [runs, now],
+  )
+
+  const visible = useMemo(() => {
+    const keep = runs.filter((r) => {
+      if (filter === 'needs-you') return needsYou(r, now)
+      if (filter === 'active') return !isHistory(r, now)
+      return true
+    })
+    // Anything asking for input first, then most recently active.
+    return keep.sort((a, b) => {
+      const an = needsYou(a, now) ? 1 : 0
+      const bn = needsYou(b, now) ? 1 : 0
+      if (an !== bn) return bn - an
+      return b.updated_at - a.updated_at
+    })
+  }, [runs, filter, now])
+
+  const groups = useMemo(() => {
+    const byHost = new Map<string, Run[]>()
+    for (const r of visible) {
+      const host = r.host || 'local'
+      const list = byHost.get(host)
+      if (list) list.push(r)
+      else byHost.set(host, [r])
+    }
+    return Array.from(byHost.entries())
+  }, [visible])
+
+  return (
+    <div className="fleet mocha">
+      <header className="fleet-nav">
+        <h1>Fleet</h1>
+        <span className={`fleet-badge${attentionCount === 0 ? ' quiet' : ''}`}>
+          {attentionCount > 0 ? `${attentionCount} needs you` : connected ? 'all quiet' : 'offline'}
+        </span>
+      </header>
+
+      <nav className="fleet-filters" aria-label="filter runs">
+        <button className={filter === 'active' ? 'on' : ''} onClick={() => setFilter('active')}>Active</button>
+        <button className={filter === 'needs-you' ? 'on' : ''} onClick={() => setFilter('needs-you')}>Needs you</button>
+        <button className={filter === 'all' ? 'on' : ''} onClick={() => setFilter('all')}>All</button>
+      </nav>
+
+      {visible.length === 0 && (
+        <div className="fleet-empty">
+          {connected ? 'No runs match this filter.' : 'Connecting to the run stream…'}
+        </div>
+      )}
+
+      {groups.map(([host, list]) => (
+        <section key={host}>
+          <div className="fleet-group">
+            <span className={host === 'local' ? 'host-local' : 'host-remote'}>{host}</span>
+            <span>{list.length}</span>
+          </div>
+          {list.map((r) => (
+            <RunCard key={r.id} run={r} now={now} onOpen={onOpen} />
+          ))}
+        </section>
+      ))}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Verify types and lint**
+
+Run: `cd ui && npx tsc -b && npx eslint . && npx vitest run`
+Expected: all clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ui/src/fleet/
+git commit -m "feat(ui): fleet view over /api/runs"
+```
+
+---
+
+### Task 5: The 4-tab shell, mounted at `#/fleet`
+
+Fleet is live; Crews, Workspace and Dispatch render a placeholder naming the milestone
+that fills them. Building the bar now means the shell can be held in a hand and judged
+before three more surfaces are built on top of it.
+
+**Files:**
+- Create: `ui/src/fleet/Shell.tsx`
+- Modify: `ui/src/fleet/fleet.css` (tab bar), `ui/src/App.tsx` (route)
+
+- [ ] **Step 1: Add the tab bar to `ui/src/fleet/fleet.css`**
+
+```css
+.shell { position: absolute; inset: 0; display: flex; flex-direction: column; background: var(--bg); }
+.shell-body { flex: 1; position: relative; overflow: hidden; }
+
+.shell-tabs {
+  display: flex; flex: none;
+  background: var(--bg-sunken); border-top: 1px solid var(--line);
+  padding-bottom: env(safe-area-inset-bottom);
+}
+.shell-tabs button {
+  flex: 1; min-height: var(--tap);
+  display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 2px;
+  border: 0; background: none; color: var(--text-faint);
+  font: inherit; font-size: 10px; cursor: pointer;
+}
+.shell-tabs button.on { color: var(--accent); font-weight: 700; }
+.shell-tabs .glyph { font-size: 15px; line-height: 1; }
+.shell-tabs .dot {
+  position: absolute; transform: translate(14px, -10px);
+  width: 6px; height: 6px; border-radius: 50%; background: var(--state-blocked);
+}
+
+.shell-placeholder {
+  position: absolute; inset: 0; display: flex; align-items: center; justify-content: center;
+  padding: 24px; text-align: center; color: var(--text-faint); font-size: 13px; line-height: 1.6;
+}
+```
+
+- [ ] **Step 2: Write `ui/src/fleet/Shell.tsx`**
+
+```tsx
+import { useMemo, useState } from 'react'
+import { useRuns } from '../hooks/useRuns'
+import { needsYou } from './staleness'
+import { FleetView } from './FleetView'
+import './fleet.css'
+
+type Tab = 'fleet' | 'crews' | 'workspace' | 'dispatch'
+
+const PLACEHOLDER: Record<Exclude<Tab, 'fleet'>, string> = {
+  crews: 'Crews arrives with the dispatcher milestone — crew grouping, tier and PR badges, and answering a blocked worker from here.',
+  workspace: 'Workspace arrives next — the tmux tree across every host, including panes that are not agents.',
+  dispatch: 'Dispatch arrives with the dispatcher milestone — pick a repo, task, tier and engine, and start work from your phone.',
+}
+
+export function Shell() {
+  const [tab, setTab] = useState<Tab>('fleet')
+  const { runs } = useRuns()
+  const attention = useMemo(() => {
+    const now = Date.now()
+    return runs.some((r) => needsYou(r, now))
+  }, [runs])
+
+  return (
+    <div className="shell mocha">
+      <div className="shell-body">
+        {tab === 'fleet' ? <FleetView /> : <div className="shell-placeholder">{PLACEHOLDER[tab]}</div>}
+      </div>
+
+      <nav className="shell-tabs" aria-label="sections">
+        <button className={tab === 'fleet' ? 'on' : ''} onClick={() => setTab('fleet')}>
+          <span className="glyph" aria-hidden>▤</span>
+          Fleet
+          {attention && tab !== 'fleet' && <span className="dot" />}
+        </button>
+        <button className={tab === 'crews' ? 'on' : ''} onClick={() => setTab('crews')}>
+          <span className="glyph" aria-hidden>◆</span>Crews
+        </button>
+        <button className={tab === 'workspace' ? 'on' : ''} onClick={() => setTab('workspace')}>
+          <span className="glyph" aria-hidden>▣</span>Workspace
+        </button>
+        <button className={tab === 'dispatch' ? 'on' : ''} onClick={() => setTab('dispatch')}>
+          <span className="glyph" aria-hidden>✦</span>Dispatch
+        </button>
+      </nav>
+    </div>
+  )
+}
+```
+
+Note `Shell` calls `useRuns()` for the badge dot while `FleetView` calls it again — two
+EventSource connections to the same endpoint. That is deliberate for now: sharing the
+store means lifting it to context, which belongs with the plan that makes this shell the
+default. If the duplicate connection shows up in testing as a real cost, say so rather
+than fixing it here.
+
+- [ ] **Step 3: Route `#/fleet` in `ui/src/App.tsx`**
+
+Add `'fleet'` to the `View` union, return `<Shell />` for it, and add a `#/fleet` case to
+`initialView()`. Add a third button to the existing `ViewSwitch` so the new shell is
+reachable. **Do not remove or restyle the existing agents/panes views** — they stay until
+a later plan retires them.
+
+- [ ] **Step 4: Verify**
+
+Run: `cd ui && npx tsc -b && npx eslint . && npx vitest run && npm run build`
+Expected: all clean, and the production build succeeds.
+
+- [ ] **Step 5: Check it against real data by hand**
+
+```bash
+just build && ./houston -addr 127.0.0.1:9095 &
+```
+
+Open `http://127.0.0.1:9095/#/fleet` once so the browser holds the auth cookie. Confirm,
+and report each: runs appear grouped by host; a run with a linked issue or PR shows those
+chips; the badge counts only recently-blocked runs; the "All" filter reveals finished
+runs that "Active" hides; and the existing `#/agents` and `#/panes` views still work.
+
+Kill your server afterwards. Do **not** run `tmux kill-server`, `tmux kill-session`, or
+any tmux command touching a server or session you did not create.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ui/src/fleet/Shell.tsx ui/src/fleet/fleet.css ui/src/App.tsx
+git commit -m "feat(ui): 4-tab shell with the fleet tab live"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec requirement | Task |
+|---|---|
+| Mocha token system | 1 |
+| One `useRuns()` store over the runs stream | 3 |
+| Mobile 4-tab shell — Fleet · Crews · Workspace · Dispatch | 5 |
+| Fleet grouped by host, filters, needs-you badge | 4 |
+| Desktop console shell | **out of scope** — a later plan |
+| Run detail with Activity/Terminal/Diff tabs | **out of scope** — the terminal plan |
+| `agents.css`'s `--ag-*` block removed | **out of scope** — the old views still use it |
+
+**Placeholder scan:** none. The three inert tabs render explanatory copy naming the
+milestone that fills them, which is content, not a stub.
+
+**Type consistency:** `Run`, `RunState`, `Caps`, `useRuns`, `applyEvent`, `FRESH_MS`,
+`isFresh`, `needsYou`, `isHistory`, `RunCard`, `FleetView`, `Shell` are spelled
+identically everywhere. Field names come from the Go `json:` tags verbatim — snake_case,
+not camelCase.
+
+**Two things a reviewer should push on.** First, `Shell` and `FleetView` each open their
+own `EventSource`; that is a deliberate deferral, not an oversight, but it is two
+connections per client and worth a second opinion. Second, `FRESH_MS` is one hour chosen
+from a single observation of real data — if a reviewer thinks the asymmetry is wrong
+(never hide `blocked`, but only badge it when fresh), that is the decision to challenge,
+because everything else in the view follows from it.

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -28,7 +28,8 @@
         "globals": "^16.5.0",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.48.0",
-        "vite": "^7.3.1"
+        "vite": "^7.3.1",
+        "vitest": "^5.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1416,6 +1417,24 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1776,6 +1795,44 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/mocker": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-5.0.0.tgz",
+      "integrity": "sha512-66PGTMIiVJP3t4a5yxU9qPtf7MdTBs8jmToMvy+HVflB3Yy13WJZTtPePdvU+wjRV02SKK5doLbSA6o9pwOmiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.31",
+        "@vitest/spy": "5.0.0",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^1.2.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-5.0.0.tgz",
+      "integrity": "sha512-uy+luWBAPw9XfthoHi5AkfHUnuPYEESjl0p/r+meoBnU8bxg5GDQ3Ey8MjcJ6sqahkL4PFyrvfMJJBw7LbU06g==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@xterm/addon-fit": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
@@ -1884,6 +1941,16 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1979,6 +2046,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -2090,6 +2167,13 @@
       "integrity": "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -2330,6 +2414,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2345,6 +2439,16 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -2716,6 +2820,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/magic-string": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.2.3.tgz",
+      "integrity": "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -2768,6 +2882,20 @@
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -2860,9 +2988,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.7.tgz",
+      "integrity": "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3046,6 +3174,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3055,6 +3190,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
@@ -3082,15 +3231,35 @@
         "node": ">=8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-6.1.4.tgz",
+      "integrity": "sha512-9APumHG7r4yOk4X4WlkmE71aZcv1gvin1czO3OQ1U9iJcFA5Ja/ygyb0vPOVHTthFozUYs8CLoLUlM8grb2lTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -3301,6 +3470,89 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-5.0.0.tgz",
+      "integrity": "sha512-gpsMNoRhMjMktVxPtstOH4/PJuPyovVaMDr4oDilXaGH1EcqM2OE96SoHT2VIQ6fTGtTjqmHDrEu2X9RQiXf8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/mocker": "5.0.0",
+        "chai": "^6.2.2",
+        "es-module-lexer": "^2.3.2",
+        "expect-type": "^1.4.0",
+        "magic-string": "^1.2.3",
+        "obug": "^2.1.4",
+        "picomatch": "^4.0.7",
+        "std-env": "^4.2.0",
+        "tinybench": "6.1.4",
+        "tinyexec": "1.3.0",
+        "tinyglobby": "^0.2.17",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^22.12.0 || ^24.0.0 || >=26.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "5.0.0",
+        "@vitest/browser-preview": "5.0.0",
+        "@vitest/browser-webdriverio": "^5.0.0-beta.5 || >=5.0.0",
+        "@vitest/coverage-istanbul": "5.0.0",
+        "@vitest/coverage-v8": "5.0.0",
+        "@vitest/ui": "5.0.0",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.4.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3315,6 +3567,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@xterm/addon-fit": "^0.11.0",
@@ -30,6 +31,7 @@
     "globals": "^16.5.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.48.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.1",
+    "vitest": "^5.0.0"
   }
 }

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -2,16 +2,19 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { Sidebar } from './components/Sidebar'
 import { TerminalArea } from './components/TerminalArea'
 import { AgentsView } from './components/agents/AgentsView'
+import { Shell } from './fleet/Shell'
 import { useIsDesktop } from './hooks/useMediaQuery'
 import { useLayout } from './hooks/useLayout'
 import { useSessionsStream } from './hooks/useSessionsStream'
 import { useAttentionNotifications } from './hooks/useAttentionNotifications'
 import './theme/tokens.css'
 
-type View = 'agents' | 'panes'
+type View = 'agents' | 'panes' | 'fleet'
 
 function initialView(): View {
-  return window.location.hash === '#/panes' ? 'panes' : 'agents'
+  if (window.location.hash === '#/panes') return 'panes'
+  if (window.location.hash === '#/fleet') return 'fleet'
+  return 'agents'
 }
 
 export default function App() {
@@ -25,26 +28,30 @@ export default function App() {
 
   const goAgents = () => { window.location.hash = '#/agents'; setView('agents') }
   const goPanes  = () => { window.location.hash = '#/panes';  setView('panes') }
+  const goFleet  = () => { window.location.hash = '#/fleet';  setView('fleet') }
 
+  if (view === 'fleet') {
+    return <Shell />
+  }
   if (view === 'agents') {
     return (
       <>
         <AgentsView />
-        <ViewSwitch current="agents" onAgents={goAgents} onPanes={goPanes} />
+        <ViewSwitch current="agents" onAgents={goAgents} onPanes={goPanes} onFleet={goFleet} />
       </>
     )
   }
   return (
     <>
       <PanesApp />
-      <ViewSwitch current="panes" onAgents={goAgents} onPanes={goPanes} />
+      <ViewSwitch current="panes" onAgents={goAgents} onPanes={goPanes} onFleet={goFleet} />
     </>
   )
 }
 
 function ViewSwitch({
-  current, onAgents, onPanes,
-}: { current: View; onAgents: () => void; onPanes: () => void }) {
+  current, onAgents, onPanes, onFleet,
+}: { current: View; onAgents: () => void; onPanes: () => void; onFleet: () => void }) {
   return (
     <div
       style={{
@@ -88,6 +95,18 @@ function ViewSwitch({
           fontWeight: 600,
         }}
       >Panes</button>
+      <button
+        onClick={onFleet}
+        style={{
+          appearance: 'none',
+          border: 'none',
+          padding: '8px 12px',
+          cursor: 'pointer',
+          background: current === 'fleet' ? 'rgba(255,255,255,0.06)' : 'transparent',
+          color: current === 'fleet' ? '#e4ebf3' : '#768391',
+          fontWeight: 600,
+        }}
+      >Fleet</button>
     </div>
   )
 }

--- a/ui/src/api/runs.ts
+++ b/ui/src/api/runs.ts
@@ -1,0 +1,98 @@
+// Mirror of runs.State (Go). Exactly one state means "a human is required".
+export type RunState =
+  | 'thinking'
+  | 'running'
+  | 'blocked'
+  | 'compacting'
+  | 'review'
+  | 'done'
+  | 'failed'
+  | 'idle'
+
+export interface TmuxRef {
+  session: string
+  window: number
+  pane_id: string
+}
+
+export interface IssueRef {
+  id: string
+  title?: string
+  url?: string
+  provider?: string
+}
+
+export interface PRRef {
+  number: string
+  state?: string
+  check_state?: string
+  mergeable?: string
+  draft?: boolean
+  url?: string
+}
+
+export interface CrewRef {
+  name: string
+  color?: string
+  tier?: string
+}
+
+export interface TrailChip {
+  tool: string
+  hint?: string
+  done: boolean
+  error?: boolean
+}
+
+export interface Activity {
+  tool?: string
+  hint?: string
+  message?: string
+  task?: string
+  trail?: TrailChip[]
+  preview?: string
+  turn?: number
+}
+
+export interface Question {
+  text: string
+  via: string // "pane" | "crew"
+}
+
+export interface Tokens {
+  input: number
+  output: number
+}
+
+export interface Caps {
+  terminal: boolean
+  reply: boolean
+  kill: boolean
+}
+
+// Mirror of runs.Run.
+//
+// A removal arrives as an ordinary `update` event carrying only `id` and
+// `removed: true` — every other field is empty, so consumers must check
+// `removed` before reading anything else.
+export interface Run {
+  id: string
+  host?: string
+  agent: string
+  state: RunState
+  repo?: string
+  branch?: string
+  worktree?: string
+  tmux?: TmuxRef
+  issue?: IssueRef
+  pr?: PRRef
+  crew?: CrewRef
+  activity: Activity
+  question?: Question
+  tokens: Tokens
+  since?: number
+  updated_at: number
+  stale?: boolean
+  caps: Caps
+  removed?: boolean
+}

--- a/ui/src/fleet/FleetView.tsx
+++ b/ui/src/fleet/FleetView.tsx
@@ -1,0 +1,90 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useRuns } from '../hooks/useRuns'
+import type { Run } from '../api/runs'
+import { isHistory, needsYou } from './staleness'
+import { RunCard } from './RunCard'
+import './fleet.css'
+
+type Filter = 'active' | 'needs-you' | 'all'
+
+/** Ticks once a minute so relative ages and freshness stay honest. */
+function useNow(): number {
+  const [now, setNow] = useState(() => Date.now())
+  useEffect(() => {
+    const id = window.setInterval(() => setNow(Date.now()), 60_000)
+    return () => window.clearInterval(id)
+  }, [])
+  return now
+}
+
+export function FleetView({ onOpen }: { onOpen?: (r: Run) => void }) {
+  const { runs, connected } = useRuns()
+  const now = useNow()
+  const [filter, setFilter] = useState<Filter>('active')
+
+  const attentionCount = useMemo(
+    () => runs.filter((r) => needsYou(r, now)).length,
+    [runs, now],
+  )
+
+  const visible = useMemo(() => {
+    const keep = runs.filter((r) => {
+      if (filter === 'needs-you') return needsYou(r, now)
+      if (filter === 'active') return !isHistory(r, now)
+      return true
+    })
+    // Anything asking for input first, then most recently active.
+    return keep.sort((a, b) => {
+      const an = needsYou(a, now) ? 1 : 0
+      const bn = needsYou(b, now) ? 1 : 0
+      if (an !== bn) return bn - an
+      return b.updated_at - a.updated_at
+    })
+  }, [runs, filter, now])
+
+  const groups = useMemo(() => {
+    const byHost = new Map<string, Run[]>()
+    for (const r of visible) {
+      const host = r.host || 'local'
+      const list = byHost.get(host)
+      if (list) list.push(r)
+      else byHost.set(host, [r])
+    }
+    return Array.from(byHost.entries())
+  }, [visible])
+
+  return (
+    <div className="fleet mocha">
+      <header className="fleet-nav">
+        <h1>Fleet</h1>
+        <span className={`fleet-badge${attentionCount === 0 ? ' quiet' : ''}`}>
+          {attentionCount > 0 ? `${attentionCount} needs you` : connected ? 'all quiet' : 'offline'}
+        </span>
+      </header>
+
+      <nav className="fleet-filters" aria-label="filter runs">
+        <button className={filter === 'active' ? 'on' : ''} onClick={() => setFilter('active')}>Active</button>
+        <button className={filter === 'needs-you' ? 'on' : ''} onClick={() => setFilter('needs-you')}>Needs you</button>
+        <button className={filter === 'all' ? 'on' : ''} onClick={() => setFilter('all')}>All</button>
+      </nav>
+
+      {visible.length === 0 && (
+        <div className="fleet-empty">
+          {connected ? 'No runs match this filter.' : 'Connecting to the run stream…'}
+        </div>
+      )}
+
+      {groups.map(([host, list]) => (
+        <section key={host}>
+          <div className="fleet-group">
+            <span className={host === 'local' ? 'host-local' : 'host-remote'}>{host}</span>
+            <span>{list.length}</span>
+          </div>
+          {list.map((r) => (
+            <RunCard key={r.id} run={r} now={now} onOpen={onOpen} />
+          ))}
+        </section>
+      ))}
+    </div>
+  )
+}

--- a/ui/src/fleet/FleetView.tsx
+++ b/ui/src/fleet/FleetView.tsx
@@ -1,25 +1,19 @@
-import { useEffect, useMemo, useState } from 'react'
-import { useRuns } from '../hooks/useRuns'
+import { useMemo, useState } from 'react'
 import type { Run } from '../api/runs'
-import { isHistory, needsYou } from './staleness'
+import { isFresh, isHistory, needsYou } from './staleness'
 import { RunCard } from './RunCard'
 import './fleet.css'
 
 type Filter = 'active' | 'needs-you' | 'all'
 
-/** Ticks once a minute so relative ages and freshness stay honest. */
-function useNow(): number {
-  const [now, setNow] = useState(() => Date.now())
-  useEffect(() => {
-    const id = window.setInterval(() => setNow(Date.now()), 60_000)
-    return () => window.clearInterval(id)
-  }, [])
-  return now
+interface FleetViewProps {
+  runs: Run[]
+  connected: boolean
+  now: number
+  onOpen?: (r: Run) => void
 }
 
-export function FleetView({ onOpen }: { onOpen?: (r: Run) => void }) {
-  const { runs, connected } = useRuns()
-  const now = useNow()
+export function FleetView({ runs, connected, now, onOpen }: FleetViewProps) {
   const [filter, setFilter] = useState<Filter>('active')
 
   const attentionCount = useMemo(
@@ -28,13 +22,24 @@ export function FleetView({ onOpen }: { onOpen?: (r: Run) => void }) {
   )
 
   const visible = useMemo(() => {
+    // Needs-you shows every blocked run, not just fresh ones — the badge
+    // and the sort answer "how many need me now", this filter answers
+    // "what asked for me at all".
     const keep = runs.filter((r) => {
-      if (filter === 'needs-you') return needsYou(r, now)
+      if (filter === 'needs-you') return r.state === 'blocked'
       if (filter === 'active') return !isHistory(r, now)
       return true
     })
-    // Anything asking for input first, then most recently active.
     return keep.sort((a, b) => {
+      if (filter === 'needs-you') {
+        const af = isFresh(a, now) ? 1 : 0
+        const bf = isFresh(b, now) ? 1 : 0
+        if (af !== bf) return bf - af
+        return b.updated_at - a.updated_at
+      }
+      // Anything asking for input first, then most recently active. Stale
+      // blocked runs deliberately stay out of this bucket — see RunCard's
+      // muted attention border for how they stay findable in place instead.
       const an = needsYou(a, now) ? 1 : 0
       const bn = needsYou(b, now) ? 1 : 0
       if (an !== bn) return bn - an
@@ -57,15 +62,29 @@ export function FleetView({ onOpen }: { onOpen?: (r: Run) => void }) {
     <div className="fleet mocha">
       <header className="fleet-nav">
         <h1>Fleet</h1>
-        <span className={`fleet-badge${attentionCount === 0 ? ' quiet' : ''}`}>
-          {attentionCount > 0 ? `${attentionCount} needs you` : connected ? 'all quiet' : 'offline'}
-        </span>
+        <div className="fleet-nav-actions">
+          <button
+            type="button"
+            className="fleet-classic"
+            aria-label="Switch to the classic view"
+            onClick={() => { window.location.hash = '#/agents' }}
+          >
+            Classic
+          </button>
+          <button
+            type="button"
+            className={`fleet-badge${attentionCount === 0 ? ' quiet' : ''}`}
+            onClick={() => setFilter('needs-you')}
+          >
+            {attentionCount > 0 ? `${attentionCount} needs you` : connected ? 'all quiet' : 'offline'}
+          </button>
+        </div>
       </header>
 
       <nav className="fleet-filters" aria-label="filter runs">
-        <button className={filter === 'active' ? 'on' : ''} onClick={() => setFilter('active')}>Active</button>
-        <button className={filter === 'needs-you' ? 'on' : ''} onClick={() => setFilter('needs-you')}>Needs you</button>
-        <button className={filter === 'all' ? 'on' : ''} onClick={() => setFilter('all')}>All</button>
+        <button aria-pressed={filter === 'active'} className={filter === 'active' ? 'on' : ''} onClick={() => setFilter('active')}>Active</button>
+        <button aria-pressed={filter === 'needs-you'} className={filter === 'needs-you' ? 'on' : ''} onClick={() => setFilter('needs-you')}>Needs you</button>
+        <button aria-pressed={filter === 'all'} className={filter === 'all' ? 'on' : ''} onClick={() => setFilter('all')}>All</button>
       </nav>
 
       {visible.length === 0 && (

--- a/ui/src/fleet/RunCard.tsx
+++ b/ui/src/fleet/RunCard.tsx
@@ -2,6 +2,7 @@ import type { Run } from '../api/runs'
 import { isFresh, isHistory, needsYou } from './staleness'
 
 function agoLabel(updatedAt: number, now: number): string {
+  if (!updatedAt) return '—'
   const s = Math.max(0, Math.floor(now / 1000 - updatedAt))
   if (s < 60) return `${s}s`
   const m = Math.floor(s / 60)
@@ -29,17 +30,23 @@ function nameLabel(run: Run): string {
 
 export function RunCard({ run, now, onOpen }: { run: Run; now: number; onOpen?: (r: Run) => void }) {
   const attention = needsYou(run, now)
+  // Stale blocked runs are never in the sort's attention bucket, but they
+  // still need a visible marker wherever they land — a muted version of the
+  // same border, not a whole new signal.
+  const staleBlocked = run.state === 'blocked' && !isFresh(run, now)
   const history = isHistory(run, now)
   const stale = !isFresh(run, now)
+
+  const attentionClass = attention ? ' attention' : staleBlocked ? ' attention muted' : ''
 
   return (
     <button
       type="button"
-      className={`run-card${attention ? ' attention' : ''}${history ? ' history' : ''}`}
+      className={`run-card${attentionClass}${history ? ' history' : ''}`}
       onClick={() => onOpen?.(run)}
     >
       <div className="run-head">
-        <span className="run-dot" style={{ background: `var(--state-${run.state})` }} />
+        <span className="run-dot" style={{ background: `var(--state-${run.state}, var(--text-faint))` }} />
         <span className="run-name">{nameLabel(run)}</span>
         <span className={`run-age${stale ? ' stale' : ''}`}>{agoLabel(run.updated_at, now)}</span>
       </div>

--- a/ui/src/fleet/RunCard.tsx
+++ b/ui/src/fleet/RunCard.tsx
@@ -1,0 +1,63 @@
+import type { Run } from '../api/runs'
+import { isFresh, isHistory, needsYou } from './staleness'
+
+function agoLabel(updatedAt: number, now: number): string {
+  const s = Math.max(0, Math.floor(now / 1000 - updatedAt))
+  if (s < 60) return `${s}s`
+  const m = Math.floor(s / 60)
+  if (m < 60) return `${m}m`
+  const h = Math.floor(m / 60)
+  if (h < 24) return `${h}h`
+  return `${Math.floor(h / 24)}d`
+}
+
+/** The one line describing what this run is doing right now. */
+function subtitle(run: Run): string {
+  const a = run.activity
+  if (run.state === 'blocked') return a.message || 'waiting on you'
+  if (a.tool) return a.hint ? `${a.tool} · ${a.hint}` : a.tool
+  if (a.task) return a.task
+  if (run.pr) return `PR #${run.pr.number}${run.pr.check_state ? ` · ${run.pr.check_state}` : ''}`
+  return run.state
+}
+
+/** repo/branch when both are present, otherwise whichever half exists. */
+function nameLabel(run: Run): string {
+  if (run.repo && run.branch) return `${run.repo}/${run.branch}`
+  return run.repo || run.branch || run.id
+}
+
+export function RunCard({ run, now, onOpen }: { run: Run; now: number; onOpen?: (r: Run) => void }) {
+  const attention = needsYou(run, now)
+  const history = isHistory(run, now)
+  const stale = !isFresh(run, now)
+
+  return (
+    <button
+      type="button"
+      className={`run-card${attention ? ' attention' : ''}${history ? ' history' : ''}`}
+      onClick={() => onOpen?.(run)}
+    >
+      <div className="run-head">
+        <span className="run-dot" style={{ background: `var(--state-${run.state})` }} />
+        <span className="run-name">{nameLabel(run)}</span>
+        <span className={`run-age${stale ? ' stale' : ''}`}>{agoLabel(run.updated_at, now)}</span>
+      </div>
+
+      <div className="run-sub">{subtitle(run)}</div>
+
+      {run.question && <div className="run-question">{run.question.text}</div>}
+
+      <div className="run-chips">
+        <span className="run-chip">{run.agent}</span>
+        {run.issue && <span className="run-chip issue">{run.issue.id}</span>}
+        {run.pr && (
+          <span className={`run-chip pr${run.pr.check_state === 'failure' ? ' failing' : ''}`}>
+            #{run.pr.number}
+          </span>
+        )}
+        {run.crew && <span className="run-chip">{run.crew.name}</span>}
+      </div>
+    </button>
+  )
+}

--- a/ui/src/fleet/Shell.tsx
+++ b/ui/src/fleet/Shell.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useRuns } from '../hooks/useRuns'
+import { needsYou } from './staleness'
+import { FleetView } from './FleetView'
+import './fleet.css'
+
+type Tab = 'fleet' | 'crews' | 'workspace' | 'dispatch'
+
+const PLACEHOLDER: Record<Exclude<Tab, 'fleet'>, string> = {
+  crews: 'Crews arrives with the dispatcher milestone — crew grouping, tier and PR badges, and answering a blocked worker from here.',
+  workspace: 'Workspace arrives next — the tmux tree across every host, including panes that are not agents.',
+  dispatch: 'Dispatch arrives with the dispatcher milestone — pick a repo, task, tier and engine, and start work from your phone.',
+}
+
+export function Shell() {
+  const [tab, setTab] = useState<Tab>('fleet')
+  const { runs } = useRuns()
+  const [now, setNow] = useState(() => Date.now())
+  useEffect(() => {
+    const id = window.setInterval(() => setNow(Date.now()), 60_000)
+    return () => window.clearInterval(id)
+  }, [])
+  const attention = useMemo(() => runs.some((r) => needsYou(r, now)), [runs, now])
+
+  return (
+    <div className="shell mocha">
+      <div className="shell-body">
+        {tab === 'fleet' ? <FleetView /> : <div className="shell-placeholder">{PLACEHOLDER[tab]}</div>}
+      </div>
+
+      <nav className="shell-tabs" aria-label="sections">
+        <button className={tab === 'fleet' ? 'on' : ''} onClick={() => setTab('fleet')}>
+          <span className="glyph" aria-hidden>▤</span>
+          Fleet
+          {attention && tab !== 'fleet' && <span className="dot" />}
+        </button>
+        <button className={tab === 'crews' ? 'on' : ''} onClick={() => setTab('crews')}>
+          <span className="glyph" aria-hidden>◆</span>Crews
+        </button>
+        <button className={tab === 'workspace' ? 'on' : ''} onClick={() => setTab('workspace')}>
+          <span className="glyph" aria-hidden>▣</span>Workspace
+        </button>
+        <button className={tab === 'dispatch' ? 'on' : ''} onClick={() => setTab('dispatch')}>
+          <span className="glyph" aria-hidden>✦</span>Dispatch
+        </button>
+      </nav>
+    </div>
+  )
+}

--- a/ui/src/fleet/Shell.tsx
+++ b/ui/src/fleet/Shell.tsx
@@ -1,7 +1,9 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useState } from 'react'
 import { useRuns } from '../hooks/useRuns'
 import { needsYou } from './staleness'
+import { useNow } from './useNow'
 import { FleetView } from './FleetView'
+import '../theme/mocha.css'
 import './fleet.css'
 
 type Tab = 'fleet' | 'crews' | 'workspace' | 'dispatch'
@@ -14,33 +16,34 @@ const PLACEHOLDER: Record<Exclude<Tab, 'fleet'>, string> = {
 
 export function Shell() {
   const [tab, setTab] = useState<Tab>('fleet')
-  const { runs } = useRuns()
-  const [now, setNow] = useState(() => Date.now())
-  useEffect(() => {
-    const id = window.setInterval(() => setNow(Date.now()), 60_000)
-    return () => window.clearInterval(id)
-  }, [])
-  const attention = useMemo(() => runs.some((r) => needsYou(r, now)), [runs, now])
+  const { runs, connected } = useRuns()
+  const now = useNow()
+  const attention = runs.some((r) => needsYou(r, now))
 
   return (
     <div className="shell mocha">
       <div className="shell-body">
-        {tab === 'fleet' ? <FleetView /> : <div className="shell-placeholder">{PLACEHOLDER[tab]}</div>}
+        {/* Kept mounted across tabs: switching tabs must not lose the chosen
+            filter or reopen the EventSource with a fresh snapshot. */}
+        <div hidden={tab !== 'fleet'}>
+          <FleetView runs={runs} connected={connected} now={now} />
+        </div>
+        {tab !== 'fleet' && <div className="shell-placeholder">{PLACEHOLDER[tab]}</div>}
       </div>
 
       <nav className="shell-tabs" aria-label="sections">
-        <button className={tab === 'fleet' ? 'on' : ''} onClick={() => setTab('fleet')}>
+        <button className={tab === 'fleet' ? 'on' : ''} aria-current={tab === 'fleet' ? 'true' : undefined} onClick={() => setTab('fleet')}>
           <span className="glyph" aria-hidden>▤</span>
           Fleet
-          {attention && tab !== 'fleet' && <span className="dot" />}
+          {attention && tab !== 'fleet' && <span className="dot" role="status" aria-label="runs need you" />}
         </button>
-        <button className={tab === 'crews' ? 'on' : ''} onClick={() => setTab('crews')}>
+        <button className={tab === 'crews' ? 'on' : ''} aria-current={tab === 'crews' ? 'true' : undefined} onClick={() => setTab('crews')}>
           <span className="glyph" aria-hidden>◆</span>Crews
         </button>
-        <button className={tab === 'workspace' ? 'on' : ''} onClick={() => setTab('workspace')}>
+        <button className={tab === 'workspace' ? 'on' : ''} aria-current={tab === 'workspace' ? 'true' : undefined} onClick={() => setTab('workspace')}>
           <span className="glyph" aria-hidden>▣</span>Workspace
         </button>
-        <button className={tab === 'dispatch' ? 'on' : ''} onClick={() => setTab('dispatch')}>
+        <button className={tab === 'dispatch' ? 'on' : ''} aria-current={tab === 'dispatch' ? 'true' : undefined} onClick={() => setTab('dispatch')}>
           <span className="glyph" aria-hidden>✦</span>Dispatch
         </button>
       </nav>

--- a/ui/src/fleet/fleet.css
+++ b/ui/src/fleet/fleet.css
@@ -22,21 +22,28 @@
   border-bottom: 1px solid var(--line);
 }
 .fleet-nav h1 { margin: 0; font-size: 16px; font-weight: 600; color: var(--text); }
+.fleet-nav-actions { display: flex; align-items: center; gap: 8px; }
+.fleet-classic {
+  min-height: var(--tap); padding: 0 8px; border: 0; background: none;
+  color: var(--text-faint); font: inherit; font-size: 12px; cursor: pointer;
+}
 .fleet-badge {
+  min-height: var(--tap); display: inline-flex; align-items: center;
   font-size: 12px; font-weight: 600; padding: 3px 10px; border-radius: 999px;
   background: color-mix(in srgb, var(--state-blocked) 22%, transparent);
   color: var(--state-blocked);
+  border: 0; font-family: inherit; cursor: pointer;
 }
-.fleet-badge.quiet { background: var(--ctp-surface0); color: var(--text-faint); }
+.fleet-badge.quiet { background: var(--fill); color: var(--text-faint); }
 
 .fleet-filters { display: flex; gap: 4px; padding: 10px 12px 4px; }
 .fleet-filters button {
-  flex: 1; min-height: 34px; border: 1px solid var(--line); border-radius: 8px;
+  flex: 1; min-height: var(--tap); border: 1px solid var(--line); border-radius: 8px;
   background: var(--bg-raised); color: var(--text-faint);
   font: inherit; font-size: 12.5px; cursor: pointer;
 }
 .fleet-filters button.on {
-  background: var(--ctp-surface0); color: var(--text); font-weight: 600;
+  background: var(--fill); color: var(--text); font-weight: 600;
   border-color: var(--line-strong);
 }
 
@@ -55,7 +62,9 @@
   min-height: var(--tap);
 }
 .run-card.attention { border-color: color-mix(in srgb, var(--state-blocked) 45%, var(--line)); }
+.run-card.attention.muted { border-color: color-mix(in srgb, var(--state-blocked) 22%, var(--line)); }
 .run-card.history { opacity: 0.55; }
+.run-card:active { background: var(--fill); transform: scale(0.995); }
 
 .run-head { display: flex; align-items: center; gap: 8px; margin-bottom: 5px; }
 .run-dot { width: 8px; height: 8px; border-radius: 50%; flex: none; }
@@ -72,19 +81,32 @@
 }
 .run-question {
   margin-top: 9px; padding: 9px 10px; border-radius: 8px;
-  background: var(--bg-sunken); color: var(--ctp-subtext1);
+  background: var(--bg-sunken); color: var(--text-strong);
   font-size: 13px; line-height: 1.45;
 }
 .run-chips { display: flex; flex-wrap: wrap; gap: 5px; margin-top: 8px; }
 .run-chip {
   font-size: 11px; padding: 2.5px 7px; border-radius: 5px;
-  background: var(--ctp-surface0); color: var(--text-dim);
+  background: var(--fill); color: var(--text-dim);
 }
 .run-chip.pr { background: color-mix(in srgb, var(--state-running) 18%, transparent); color: var(--state-running); }
 .run-chip.pr.failing { background: color-mix(in srgb, var(--state-blocked) 18%, transparent); color: var(--state-blocked); }
 .run-chip.issue { background: color-mix(in srgb, var(--accent) 18%, transparent); color: var(--accent); }
 
 .fleet-empty { padding: 40px 20px; text-align: center; color: var(--text-faint); font-size: 13px; }
+
+.run-card:focus-visible,
+.fleet-filters button:focus-visible,
+.shell-tabs button:focus-visible,
+.fleet-badge:focus-visible,
+.fleet-classic:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+/* Distinct from button.on's --fill so pressing the already-selected filter
+   still visibly registers. */
+.fleet-filters button:active { background: var(--line-strong); }
+.shell-tabs button:active { background: var(--fill); }
 
 .shell { position: absolute; inset: 0; display: flex; flex-direction: column; background: var(--bg); }
 .shell-body { flex: 1; position: relative; overflow: hidden; }
@@ -99,7 +121,7 @@
   flex: 1; min-height: var(--tap);
   display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 2px;
   border: 0; background: none; color: var(--text-faint);
-  font: inherit; font-size: 10px; cursor: pointer;
+  font: inherit; font-size: 11px; cursor: pointer;
 }
 .shell-tabs button.on { color: var(--accent); font-weight: 700; }
 .shell-tabs .glyph { font-size: 15px; line-height: 1; }

--- a/ui/src/fleet/fleet.css
+++ b/ui/src/fleet/fleet.css
@@ -85,3 +85,30 @@
 .run-chip.issue { background: color-mix(in srgb, var(--accent) 18%, transparent); color: var(--accent); }
 
 .fleet-empty { padding: 40px 20px; text-align: center; color: var(--text-faint); font-size: 13px; }
+
+.shell { position: absolute; inset: 0; display: flex; flex-direction: column; background: var(--bg); }
+.shell-body { flex: 1; position: relative; overflow: hidden; }
+
+.shell-tabs {
+  display: flex; flex: none;
+  background: var(--bg-sunken); border-top: 1px solid var(--line);
+  padding-bottom: env(safe-area-inset-bottom);
+}
+.shell-tabs button {
+  position: relative;
+  flex: 1; min-height: var(--tap);
+  display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 2px;
+  border: 0; background: none; color: var(--text-faint);
+  font: inherit; font-size: 10px; cursor: pointer;
+}
+.shell-tabs button.on { color: var(--accent); font-weight: 700; }
+.shell-tabs .glyph { font-size: 15px; line-height: 1; }
+.shell-tabs .dot {
+  position: absolute; transform: translate(14px, -10px);
+  width: 6px; height: 6px; border-radius: 50%; background: var(--state-blocked);
+}
+
+.shell-placeholder {
+  position: absolute; inset: 0; display: flex; align-items: center; justify-content: center;
+  padding: 24px; text-align: center; color: var(--text-faint); font-size: 13px; line-height: 1.6;
+}

--- a/ui/src/fleet/fleet.css
+++ b/ui/src/fleet/fleet.css
@@ -1,0 +1,87 @@
+.fleet {
+  position: absolute;
+  inset: 0;
+  overflow-y: auto;
+  background: var(--bg);
+  color: var(--text-dim);
+  font-family: var(--font-ui);
+  font-size: 14px;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.fleet-nav {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 14px;
+  background: color-mix(in srgb, var(--bg) 92%, transparent);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--line);
+}
+.fleet-nav h1 { margin: 0; font-size: 16px; font-weight: 600; color: var(--text); }
+.fleet-badge {
+  font-size: 12px; font-weight: 600; padding: 3px 10px; border-radius: 999px;
+  background: color-mix(in srgb, var(--state-blocked) 22%, transparent);
+  color: var(--state-blocked);
+}
+.fleet-badge.quiet { background: var(--ctp-surface0); color: var(--text-faint); }
+
+.fleet-filters { display: flex; gap: 4px; padding: 10px 12px 4px; }
+.fleet-filters button {
+  flex: 1; min-height: 34px; border: 1px solid var(--line); border-radius: 8px;
+  background: var(--bg-raised); color: var(--text-faint);
+  font: inherit; font-size: 12.5px; cursor: pointer;
+}
+.fleet-filters button.on {
+  background: var(--ctp-surface0); color: var(--text); font-weight: 600;
+  border-color: var(--line-strong);
+}
+
+.fleet-group {
+  display: flex; justify-content: space-between;
+  padding: 14px 14px 6px; font-size: 12px; font-weight: 600; color: var(--text-faint);
+}
+.fleet-group .host-local { color: var(--host-local); }
+.fleet-group .host-remote { color: var(--host-remote); }
+
+.run-card {
+  display: block; width: calc(100% - 20px); margin: 0 10px 8px;
+  padding: 11px 12px; border-radius: 10px; text-align: left;
+  background: var(--bg-raised); border: 1px solid var(--line);
+  color: inherit; font: inherit; cursor: pointer;
+  min-height: var(--tap);
+}
+.run-card.attention { border-color: color-mix(in srgb, var(--state-blocked) 45%, var(--line)); }
+.run-card.history { opacity: 0.55; }
+
+.run-head { display: flex; align-items: center; gap: 8px; margin-bottom: 5px; }
+.run-dot { width: 8px; height: 8px; border-radius: 50%; flex: none; }
+.run-name {
+  color: var(--text); font-size: 14px; font-weight: 600; letter-spacing: -0.01em;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.run-age { margin-left: auto; flex: none; font-size: 12px; color: var(--text-faint); }
+.run-age.stale { font-style: italic; }
+
+.run-sub {
+  font-family: var(--font-mono); font-size: 12px; color: var(--text-dim);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.run-question {
+  margin-top: 9px; padding: 9px 10px; border-radius: 8px;
+  background: var(--bg-sunken); color: var(--ctp-subtext1);
+  font-size: 13px; line-height: 1.45;
+}
+.run-chips { display: flex; flex-wrap: wrap; gap: 5px; margin-top: 8px; }
+.run-chip {
+  font-size: 11px; padding: 2.5px 7px; border-radius: 5px;
+  background: var(--ctp-surface0); color: var(--text-dim);
+}
+.run-chip.pr { background: color-mix(in srgb, var(--state-running) 18%, transparent); color: var(--state-running); }
+.run-chip.pr.failing { background: color-mix(in srgb, var(--state-blocked) 18%, transparent); color: var(--state-blocked); }
+.run-chip.issue { background: color-mix(in srgb, var(--accent) 18%, transparent); color: var(--accent); }
+
+.fleet-empty { padding: 40px 20px; text-align: center; color: var(--text-faint); font-size: 13px; }

--- a/ui/src/fleet/staleness.test.ts
+++ b/ui/src/fleet/staleness.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { FRESH_MS, isFresh, isHistory, needsYou } from './staleness'
+import type { Run } from '../api/runs'
+
+const now = 1_800_000_000_000 // fixed ms
+
+function run(p: Partial<Run>): Run {
+  return {
+    id: 'pane-1', agent: 'claude', state: 'idle',
+    activity: {}, tokens: { input: 0, output: 0 },
+    caps: { terminal: false, reply: false, kill: false },
+    updated_at: Math.floor(now / 1000),
+    ...p,
+  } as Run
+}
+
+const agoSec = (ms: number) => Math.floor((now - ms) / 1000)
+
+describe('staleness', () => {
+  it('counts a recently blocked run as needing you', () => {
+    expect(needsYou(run({ state: 'blocked' }), now)).toBe(true)
+  })
+
+  it('does not count a long-stale blocked run toward the badge', () => {
+    const old = run({ state: 'blocked', updated_at: agoSec(FRESH_MS + 60_000) })
+    expect(needsYou(old, now)).toBe(false)
+  })
+
+  it('never treats a blocked run as history, however old', () => {
+    // Hiding something that asked for input is the worse failure.
+    const old = run({ state: 'blocked', updated_at: agoSec(FRESH_MS * 10) })
+    expect(isHistory(old, now)).toBe(false)
+  })
+
+  it('treats a long-finished run as history', () => {
+    expect(isHistory(run({ state: 'done', updated_at: agoSec(FRESH_MS + 1) }), now)).toBe(true)
+    expect(isHistory(run({ state: 'failed', updated_at: agoSec(FRESH_MS + 1) }), now)).toBe(true)
+  })
+
+  it('keeps a just-finished run out of history so it does not vanish mid-glance', () => {
+    expect(isHistory(run({ state: 'done', updated_at: agoSec(1000) }), now)).toBe(false)
+  })
+
+  it('never treats a running or thinking run as history', () => {
+    for (const state of ['running', 'thinking', 'review', 'compacting'] as const) {
+      const old = run({ state, updated_at: agoSec(FRESH_MS * 5) })
+      expect(isHistory(old, now)).toBe(false)
+    }
+  })
+
+  it('reports freshness from updated_at', () => {
+    expect(isFresh(run({ updated_at: agoSec(1000) }), now)).toBe(true)
+    expect(isFresh(run({ updated_at: agoSec(FRESH_MS + 1) }), now)).toBe(false)
+  })
+})

--- a/ui/src/fleet/staleness.ts
+++ b/ui/src/fleet/staleness.ts
@@ -1,0 +1,36 @@
+import type { Run } from '../api/runs'
+
+/**
+ * How recently a run must have reported to count as fresh.
+ *
+ * Tuned against real data: a live server carried 22 finished-or-detached runs
+ * alongside 10 live ones, six of them still reporting `blocked` from up to five
+ * hours earlier. Move this if an hour proves wrong in practice — it is the only
+ * number that decides what the badge counts.
+ */
+export const FRESH_MS = 60 * 60 * 1000
+
+export function isFresh(run: Run, now: number): boolean {
+  if (!run.updated_at) return false
+  return now - run.updated_at * 1000 <= FRESH_MS
+}
+
+/**
+ * needsYou drives the badge and the sort. A run that asked for input long ago
+ * is almost always a session that ended while waiting, and counting it would
+ * leave the badge permanently lit — but see isHistory: it is still shown.
+ */
+export function needsYou(run: Run, now: number): boolean {
+  return run.state === 'blocked' && isFresh(run, now)
+}
+
+/**
+ * isHistory marks a run as foldable behind the "All" filter. Only terminal
+ * states qualify, and only once stale: a run that is blocked, running or
+ * thinking is never history however old it looks, because hiding something
+ * that is waiting on you is the worse failure.
+ */
+export function isHistory(run: Run, now: number): boolean {
+  if (run.state !== 'done' && run.state !== 'failed') return false
+  return !isFresh(run, now)
+}

--- a/ui/src/fleet/useNow.ts
+++ b/ui/src/fleet/useNow.ts
@@ -1,0 +1,11 @@
+import { useEffect, useState } from 'react'
+
+/** Ticks once a minute so relative ages and freshness stay honest. */
+export function useNow(): number {
+  const [now, setNow] = useState(() => Date.now())
+  useEffect(() => {
+    const id = window.setInterval(() => setNow(Date.now()), 60_000)
+    return () => window.clearInterval(id)
+  }, [])
+  return now
+}

--- a/ui/src/hooks/useRuns.test.ts
+++ b/ui/src/hooks/useRuns.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { applyEvent } from './useRuns'
+import type { Run } from '../api/runs'
+
+function run(id: string, p: Partial<Run> = {}): Run {
+  return {
+    id, agent: 'claude', state: 'running',
+    activity: {}, tokens: { input: 0, output: 0 },
+    caps: { terminal: true, reply: true, kill: true },
+    updated_at: 1000,
+    ...p,
+  } as Run
+}
+
+describe('applyEvent', () => {
+  it('adds an unseen run', () => {
+    const next = applyEvent(new Map(), run('pane-1'))
+    expect(next.get('pane-1')?.state).toBe('running')
+  })
+
+  it('replaces an existing run wholesale', () => {
+    const first = applyEvent(new Map(), run('pane-1', { state: 'running' }))
+    const next = applyEvent(first, run('pane-1', { state: 'blocked' }))
+    expect(next.get('pane-1')?.state).toBe('blocked')
+    expect(next.size).toBe(1)
+  })
+
+  it('deletes on a removal, which carries only id and removed', () => {
+    // The server sends Run{ID, Removed:true} with every other field empty, as
+    // an ordinary `update` — not a distinct event type.
+    const first = applyEvent(new Map(), run('pane-1'))
+    const next = applyEvent(first, { id: 'pane-1', removed: true } as Run)
+    expect(next.has('pane-1')).toBe(false)
+  })
+
+  it('ignores a removal for a run it never had', () => {
+    const next = applyEvent(new Map(), { id: 'ghost', removed: true } as Run)
+    expect(next.size).toBe(0)
+  })
+
+  it('does not mutate the map it was given', () => {
+    const first = applyEvent(new Map(), run('pane-1'))
+    applyEvent(first, run('pane-2'))
+    expect(first.size).toBe(1)
+  })
+})

--- a/ui/src/hooks/useRuns.ts
+++ b/ui/src/hooks/useRuns.ts
@@ -1,0 +1,60 @@
+import { useEffect, useState } from 'react'
+import type { Run } from '../api/runs'
+
+/**
+ * applyEvent folds one streamed Run into the map, returning a new map.
+ *
+ * A removal arrives as an ordinary update carrying only `id` and `removed`, so
+ * it must be checked before any other field is read.
+ */
+export function applyEvent(runs: Map<string, Run>, r: Run): Map<string, Run> {
+  const next = new Map(runs)
+  if (r.removed) {
+    next.delete(r.id)
+    return next
+  }
+  next.set(r.id, r)
+  return next
+}
+
+/**
+ * Subscribes to /api/runs/stream. The server sends one `snapshot` event on
+ * connect and one `update` per composed change; it also re-sends a full
+ * `snapshot` when it detects this subscriber missed an update, so a snapshot
+ * arriving mid-stream is a resync and replaces the map wholesale.
+ */
+export function useRuns() {
+  const [runs, setRuns] = useState<Map<string, Run>>(new Map())
+  const [connected, setConnected] = useState(false)
+
+  useEffect(() => {
+    const es = new EventSource('/api/runs/stream')
+
+    es.addEventListener('open', () => setConnected(true))
+
+    es.addEventListener('snapshot', (ev: MessageEvent<string>) => {
+      try {
+        const arr = JSON.parse(ev.data) as Run[]
+        setRuns(new Map(arr.map((r) => [r.id, r])))
+        setConnected(true)
+      } catch (e) {
+        console.error('runs snapshot parse failed', e)
+      }
+    })
+
+    es.addEventListener('update', (ev: MessageEvent<string>) => {
+      try {
+        const r = JSON.parse(ev.data) as Run
+        setRuns((prev) => applyEvent(prev, r))
+      } catch (e) {
+        console.error('runs update parse failed', e)
+      }
+    })
+
+    es.onerror = () => setConnected(false) // EventSource retries on its own
+
+    return () => es.close()
+  }, [])
+
+  return { runs: Array.from(runs.values()), connected }
+}

--- a/ui/src/theme/mocha.css
+++ b/ui/src/theme/mocha.css
@@ -1,0 +1,58 @@
+/*
+ * Catppuccin Mocha. Scoped to .mocha so it can coexist with the old views'
+ * tokens until those are deleted.
+ *
+ * Raw palette first, then semantic aliases. Components use only the semantic
+ * names — a component naming --ctp-mauve directly is a bug, because it pins a
+ * colour to a meaning it does not own.
+ */
+.mocha {
+  --ctp-base: #1e1e2e;
+  --ctp-mantle: #181825;
+  --ctp-crust: #11111b;
+  --ctp-surface0: #313244;
+  --ctp-surface1: #45475a;
+  --ctp-surface2: #585b70;
+  --ctp-overlay0: #6c7086;
+  --ctp-overlay1: #7f849c;
+  --ctp-overlay2: #9399b2;
+  --ctp-subtext0: #a6adc8;
+  --ctp-subtext1: #bac2de;
+  --ctp-text: #cdd6f4;
+  --ctp-green: #a6e3a1;
+  --ctp-red: #f38ba8;
+  --ctp-yellow: #f9e2af;
+  --ctp-peach: #fab387;
+  --ctp-blue: #89b4fa;
+  --ctp-mauve: #cba6f7;
+  --ctp-teal: #94e2d5;
+
+  --bg: var(--ctp-mantle);
+  --bg-raised: var(--ctp-base);
+  --bg-sunken: var(--ctp-crust);
+  --line: var(--ctp-surface0);
+  --line-strong: var(--ctp-surface1);
+  --text: var(--ctp-text);
+  --text-dim: var(--ctp-overlay2);
+  --text-faint: var(--ctp-overlay0);
+  --accent: var(--ctp-mauve);
+
+  /* One colour per run state. blocked is the only "needs you" colour and must
+     not be reused for anything else, or the badge stops meaning one thing. */
+  --state-blocked: var(--ctp-red);
+  --state-running: var(--ctp-green);
+  --state-thinking: var(--ctp-yellow);
+  --state-review: var(--ctp-blue);
+  --state-done: var(--ctp-overlay0);
+  --state-failed: var(--ctp-peach);
+  --state-idle: var(--ctp-overlay0);
+  --state-compacting: var(--ctp-teal);
+
+  --host-local: var(--ctp-blue);
+  --host-remote: var(--ctp-peach);
+
+  --font-ui: -apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', sans-serif;
+  --font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+
+  --tap: 44px; /* minimum touch target */
+}

--- a/ui/src/theme/mocha.css
+++ b/ui/src/theme/mocha.css
@@ -32,9 +32,14 @@
   --bg-sunken: var(--ctp-crust);
   --line: var(--ctp-surface0);
   --line-strong: var(--ctp-surface1);
+  --fill: var(--ctp-surface0);
   --text: var(--ctp-text);
+  --text-strong: var(--ctp-subtext1);
   --text-dim: var(--ctp-overlay2);
-  --text-faint: var(--ctp-overlay0);
+  /* overlay1, not overlay0 — overlay0 on the mantle ground is ~3.1:1, below
+     readable contrast for the 10-13px text (tab labels, ages, filters) that
+     use this token. */
+  --text-faint: var(--ctp-overlay1);
   --accent: var(--ctp-mauve);
 
   /* One colour per run state. blocked is the only "needs you" colour and must


### PR DESCRIPTION
Fourth of the #2 milestones, and the first that puts anything on screen: a Catppuccin
Mocha design system, a `useRuns()` store over `/api/runs/stream`, and the mobile 4-tab
shell with the Fleet tab live at `#/fleet`.

**Additive.** `#/agents` and `#/panes` are untouched and still work; Mocha tokens live
under a `.mocha` class alongside the existing `tokens.css`. Retiring the old views and
moving them onto `/api/runs` is a later plan.

Crews, Workspace and Dispatch render copy naming the milestone that fills them.

## ⚠️ Nothing here has been looked at

No browser was available in the build environment — no `$DISPLAY`, no `xvfb-run`, and
both browser automation tools failed to launch. Everything below marked confirmed is
curl JSON, built-CSS inspection or static analysis. **The rendered result is unverified.**

Six things only a phone settles, roughly in order of how likely they are to be wrong:

1. **Does it render in Mocha at all?** The stylesheet was inert until this branch's fix
   wave (see below), so nobody has ever seen the intended design.
2. **The attention dot's position.** `position: relative` makes its `translate(14px,-10px)`
   *meaningful*, not *correct* — it may sit on the glyph, off the tab, or clipped.
3. **`--text-faint` in daylight.** It carries filter labels, ages, group headers and every
   tab label. Lifted from ~3.1:1 to ~4.0:1 — a calculation, not an observation.
4. **Whether tapping feels alive.** The CSS now exists; only a thumb says whether the
   response reads as intentional.
5. **The tab bar on a notched phone** — does `env(safe-area-inset-bottom)` clear the home
   indicator, are 11px labels legible across four tabs.
6. **Is a stale blocked run distinguishable** from a fresh one? The muted border is a 22%
   red mix into `surface0` — a subtle 1px hue shift, the weakest fix in the branch.

Fastest check: run houston and open `#/fleet` on a phone. There are currently 8 blocked
runs in the data, 3 of them fresh — so the badge should read **3 needs you** while the
Needs-you filter shows all **8**.

## The freshness rule is the load-bearing decision

`/api/runs` returns everything the server knows, including finished and detached
sessions. Measured live: 21 runs, of which 8 reported `blocked` — and only 3 within the
hour. `blocked` is the single state meaning *a human is required*; it drives the badge,
the sort and future notifications. Counting stale ones leaves the badge permanently lit
and kills the signal the whole redesign exists for.

Age alone is the wrong discriminator, because an agent genuinely blocked for five hours
is exactly what you want to see. So the rule is deliberately **asymmetric**:

- **Nothing reporting `blocked` is ever hidden.** Hiding something that asked for input
  is the worse failure.
- **The badge counts only fresh blocked runs** — `FRESH_MS`, one hour, a named constant
  with the measurement in its comment. Move it in one line if an hour proves wrong.
- **The Needs-you filter shows *all* blocked runs**, fresh first. The badge answers *how
  many need me now*; the filter answers *what asked for me at all*.
- Terminal states fold behind "All" once stale; `running`, `thinking` and `review` never
  do, however old they look.

An earlier draft put stale blocked runs into the *sort* instead. That was rejected using
this branch's own numbers: 5 stale blocked runs on a ~5-card screen would have filled the
first screen with dead sessions and pushed every live agent below the fold — the mirror
failure, and worse.

## The design system was inert for the entire plan

`ui/src/theme/mocha.css` **was never imported anywhere**. Every `var(--state-blocked)`,
`var(--bg)`, `var(--text)` in the Fleet view resolved to nothing from the moment the
tokens were written. Confirmed: `git grep -c "mocha.css" 720700b -- ui/src/` returns
zero, and the built bundle had no `--ctp-*` declarations at all.

What let it through is worth recording, because every gate was green:

| Gate | Why it missed |
|---|---|
| `tsc` | CSS is not type-checked |
| `eslint` | no rule fires on an unimported stylesheet |
| `vitest` (12 tests) | covers predicates and a reducer; nothing rendered |
| whole-branch review | checked token *discipline* — that components use semantic aliases rather than raw `--ctp-*` — without asking whether the file declaring them was loaded |

It was caught by inspecting `ui/dist/assets/*.css` for actual declarations rather than
trusting that the build succeeded. **For CSS, a passing build proves nothing about
whether styles reach the page.**

## Other defects found in review

| Defect | Consequence |
|---|---|
| Zero `:focus`/`:active` rules alongside `-webkit-tap-highlight-color: transparent` | tapping produced no visual response at all — reads as a broken app |
| `.fleet-filters button` at 34px | below the project's own `--tap: 44px`, which everything else honoured |
| Four raw `--ctp-*` refs in `fleet.css` | the token rule was violated by the first component written against it, because no alias existed for "chip fill" or "strong text" |
| `--text-faint` at ~3.1:1 | carried every 10px tab label |
| Stale blocked kept but unfindable | no border, sorted below fresher runs, signalled only by an 8px dot |
| `FleetView` unmounted on tab switch | filter lost, plus a reconnect snapshot flash |
| No `aria-pressed`/`aria-current` | selected state existed only as a CSS class |

Three more were introduced **by the fix wave itself** and fixed in a follow-up pass:
`ViewSwitch` rendered alongside the shell covered the tab bar at `z-index: 300`, making
Workspace and Dispatch unreachable; making the badge a `<button>` created a new ~20px tap
target, reintroducing the defect the same commit was fixing; and `:active` on a selected
filter resolved to the same token as `.on`, so pressing it did nothing.

The `ViewSwitch` fix is structural rather than a z-index bump — raising the bar above 300
would have left the switch invisible *behind* an opaque bar, the same bug with a different
symptom. `ViewSwitch` now renders only for the two legacy views, and the shell gets a
`Classic` control in its header, keeping one bottom-anchored element per screen.

## Notes on the code

- **One `EventSource` for the shell's lifetime.** `useRuns()` lives in `Shell`, not
  `FleetView`, which is always mounted and hidden with `hidden`. The stream opens on
  `Shell` mount and closes only on leaving `#/fleet`; `hidden` affects rendering only and
  never runs effect cleanup. Stated explicitly so a future "cleanup" doesn't reintroduce a
  reconnect on every tab tap.
- **`vitest` is a new devDependency**, and the only dependency change. `ui/` had no test
  runner at all, so the freshness rule — the one number deciding whether the badge works —
  would otherwise ship untested. Runtime `dependencies` is byte-identical.
- **Removals ride inside `update`.** The server sends `Run{id, removed:true}` with every
  other field empty rather than a distinct event type, so `applyEvent` checks `removed`
  before reading anything else. A mid-stream `snapshot` is a resync and replaces the map
  wholesale — merging would resurrect deleted runs permanently.

## Follow-ups

- Desktop console shell; run detail with Activity/Terminal/Diff tabs; the mobile terminal.
- `useRuns()` has no lifecycle test (does unmount close the `EventSource`?) — needs a DOM
  test utility, a second devDependency.
- Multi-host grouping is unexercised: every run is currently host-less. It will matter when
  federation lands.
- No CI on this repo — #6.

https://claude.ai/code/session_01S3QQF9tpsskteWqRJN3Hn6
