### PR TITLE
fix(runs): name, date and key a session from its own transcript

### DIFF
--- a/hook/hook.go
+++ b/hook/hook.go
@@ -162,13 +162,20 @@ func truncate(s string, n int) string {
 // tmuxCoords returns (session, window, pane). Empty on any failure — hooks
 // can fire outside tmux.
 func tmuxCoords() (string, string, string) {
-	out, err := exec.Command("tmux", "display-message", "-p", "#S\t#I\t#P").Output()
-	if err != nil {
+	// $TMUX_PANE is the pane id ("%307") and is set per pane, so it is both the
+	// right namespace to correlate on — every other source keys on the pane id,
+	// never the index — and immune to which client tmux considers current.
+	pane := os.Getenv("TMUX_PANE")
+	if pane == "" {
 		return "", "", ""
 	}
-	parts := strings.SplitN(strings.TrimSpace(string(out)), "\t", 3)
-	for len(parts) < 3 {
+	out, err := exec.Command("tmux", "display-message", "-p", "-t", pane, "#S\t#I").Output()
+	if err != nil {
+		return "", "", pane
+	}
+	parts := strings.SplitN(strings.TrimSpace(string(out)), "\t", 2)
+	for len(parts) < 2 {
 		parts = append(parts, "")
 	}
-	return parts[0], parts[1], parts[2]
+	return parts[0], parts[1], pane
 }

--- a/hook/hook_test.go
+++ b/hook/hook_test.go
@@ -32,10 +32,10 @@ func dispatch(t *testing.T, stateDir string, event string, payload map[string]an
 func TestDispatchPreToolUseSetsToolRunning(t *testing.T) {
 	dir := t.TempDir()
 	got := dispatch(t, dir, EventPreToolUse, map[string]any{
-		"session_id":     "s1",
-		"tool_name":      "Edit",
-		"tool_input":     map[string]any{"file_path": "ui/src/App.tsx"},
-		"cwd":            "/tmp",
+		"session_id":      "s1",
+		"tool_name":       "Edit",
+		"tool_input":      map[string]any{"file_path": "ui/src/App.tsx"},
+		"cwd":             "/tmp",
 		"transcript_path": "/tmp/t.jsonl",
 	})
 	if got.State != StateToolRunning {
@@ -190,5 +190,28 @@ func TestToolInputHint(t *testing.T) {
 				t.Errorf("toolInputHint(%s) = %q, want %q", tc.in, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestTmuxCoordsReportsPaneIDNotIndex(t *testing.T) {
+	// Every source correlates on the tmux pane id (%17). "#P" is the pane
+	// *index* (1), which is not the same namespace and is not even unique —
+	// every session has a pane 1. The pane's own environment is authoritative.
+	t.Setenv("TMUX_PANE", "%307")
+
+	_, _, pane := tmuxCoords()
+
+	if pane != "%307" {
+		t.Errorf("pane = %q, want %%307 — a pane index here can never merge with the tmux layer", pane)
+	}
+}
+
+func TestTmuxCoordsEmptyOutsideTmux(t *testing.T) {
+	t.Setenv("TMUX_PANE", "")
+
+	session, window, pane := tmuxCoords()
+
+	if session != "" || window != "" || pane != "" {
+		t.Errorf("got (%q, %q, %q), want all empty outside tmux", session, window, pane)
 	}
 }

--- a/hook/state.go
+++ b/hook/state.go
@@ -42,6 +42,7 @@ type SessionState struct {
 	SessionID      string `json:"session_id"`
 	TranscriptPath string `json:"transcript_path,omitempty"`
 	CWD            string `json:"cwd,omitempty"`
+	GitBranch      string `json:"git_branch,omitempty"`
 
 	// tmux coordinates captured at hook time (may be empty if not under tmux).
 	TmuxSession string `json:"tmux_session,omitempty"`
@@ -49,15 +50,15 @@ type SessionState struct {
 	TmuxPane    string `json:"tmux_pane,omitempty"`
 
 	State         State  `json:"state"`
-	Tool          string `json:"tool,omitempty"`           // set by PreToolUse, cleared by PostToolUse
+	Tool          string `json:"tool,omitempty"` // set by PreToolUse, cleared by PostToolUse
 	ToolInputHint string `json:"tool_input_hint,omitempty"`
-	LastMessage   string `json:"last_message,omitempty"`   // populated by Notification
-	Reason        string `json:"reason,omitempty"`          // populated by SessionEnd
-	Source        string `json:"source,omitempty"`          // populated by SessionStart
+	LastMessage   string `json:"last_message,omitempty"` // populated by Notification
+	Reason        string `json:"reason,omitempty"`       // populated by SessionEnd
+	Source        string `json:"source,omitempty"`       // populated by SessionStart
 
 	Turn      int   `json:"turn,omitempty"`
-	Since     int64 `json:"since,omitempty"`      // unix-sec state entered
-	UpdatedAt int64 `json:"updated_at"`           // unix-sec last hook fired
+	Since     int64 `json:"since,omitempty"` // unix-sec state entered
+	UpdatedAt int64 `json:"updated_at"`      // unix-sec last hook fired
 	PID       int   `json:"pid,omitempty"`
 }
 

--- a/hub/discovery.go
+++ b/hub/discovery.go
@@ -64,6 +64,9 @@ func DiscoverClaudeSessions(projectsDir string, window time.Duration) ([]hook.Se
 			if err != nil {
 				continue
 			}
+			// mtime stays the pre-filter: it is free, and it only ever
+			// over-includes — synthesizeFromTranscript re-dates the session
+			// from its own events.
 			if info.ModTime().Before(cutoff) {
 				continue
 			}
@@ -91,12 +94,38 @@ func synthesizeFromTranscript(path string, info fs.FileInfo, cwd string) (hook.S
 		return hook.SessionState{}, false
 	}
 
+	// The transcript is the authority on its own session. The encoded directory
+	// name cannot be decoded (every "-" is either a separator or a literal), and
+	// mtime moves for reasons that are not session activity — a backup, a
+	// restore, a resume that rewrites the file. Both are fallbacks only.
+	var (
+		lastEvent time.Time
+		gitBranch string
+	)
+	for i := range events {
+		ev := &events[i]
+		if ev.Timestamp.After(lastEvent) {
+			lastEvent = ev.Timestamp
+		}
+		if ev.CWD != "" {
+			cwd = ev.CWD
+		}
+		if ev.GitBranch != "" {
+			gitBranch = ev.GitBranch
+		}
+	}
+	updated := info.ModTime()
+	if !lastEvent.IsZero() {
+		updated = lastEvent
+	}
+
 	state := hook.SessionState{
 		SessionID:      sessionID,
 		TranscriptPath: path,
 		CWD:            cwd,
-		UpdatedAt:      info.ModTime().Unix(),
-		Since:          info.ModTime().Unix(),
+		GitBranch:      gitBranch,
+		UpdatedAt:      updated.Unix(),
+		Since:          updated.Unix(),
 	}
 
 	var (
@@ -127,7 +156,7 @@ func synthesizeFromTranscript(path string, info fs.FileInfo, cwd string) (hook.S
 		}
 	}
 
-	age := time.Since(info.ModTime())
+	age := time.Since(updated)
 	switch {
 	case unmatchedTool != nil && age < 30*time.Second:
 		state.State = hook.StateToolRunning
@@ -141,9 +170,10 @@ func synthesizeFromTranscript(path string, info fs.FileInfo, cwd string) (hook.S
 	return state, true
 }
 
-// decodeProjectDirName reverses Claude's `-home-me-foo` path encoding.
-// Ambiguous for paths containing `-` — good enough for display until a hook
-// fire writes the real CWD.
+// decodeProjectDirName reverses Claude's `-home-me-foo` path encoding. It
+// cannot be done correctly: a "-" in the name is either a path separator or a
+// literal hyphen, so `-home-me-nix-amd-ai` decodes to `/home/me/nix/amd/ai`.
+// Only a transcript that carries no cwd of its own ever falls back to this.
 func decodeProjectDirName(name string) string {
 	if !strings.HasPrefix(name, "-") {
 		return name

--- a/hub/discovery_test.go
+++ b/hub/discovery_test.go
@@ -200,3 +200,65 @@ func TestHubHookStateWinsOverDiscovery(t *testing.T) {
 		t.Fatalf("hook state should win: %+v", snap)
 	}
 }
+
+func TestDiscoveryPrefersTranscriptCWDOverDirName(t *testing.T) {
+	// The encoded directory name cannot be decoded: every "-" is either a path
+	// separator or a literal hyphen, and nothing in the name says which. Every
+	// transcript record carries the real cwd, so read that instead.
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "-home-noams-git-nix-amd-ai")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	body := `{"type":"user","cwd":"/home/noams/git/nix-amd-ai","gitBranch":"main","message":{"role":"user","content":"hi"}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"which one?"}]}}
+`
+	if err := os.WriteFile(filepath.Join(projectDir, "sess-aaa.jsonl"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	got, err := DiscoverClaudeSessions(root, time.Hour)
+	if err != nil {
+		t.Fatalf("DiscoverClaudeSessions: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d sessions, want 1", len(got))
+	}
+	if got[0].CWD != "/home/noams/git/nix-amd-ai" {
+		t.Errorf("CWD = %q, want /home/noams/git/nix-amd-ai (decoding the dir name gives /home/noams/git/nix/amd/ai)", got[0].CWD)
+	}
+	if got[0].GitBranch != "main" {
+		t.Errorf("GitBranch = %q, want main", got[0].GitBranch)
+	}
+}
+
+func TestDiscoveryDatesSessionByLastEventNotMtime(t *testing.T) {
+	// mtime moves for reasons that are not session activity — a backup, a
+	// restore, a resume that rewrites the file. Only the events date the work.
+	lastEvent := time.Now().Add(-48 * time.Hour).UTC().Truncate(time.Second)
+	body := `{"type":"user","timestamp":"` + lastEvent.Add(-time.Minute).Format(time.RFC3339Nano) + `","message":{"role":"user","content":"hi"}}
+{"type":"assistant","timestamp":"` + lastEvent.Format(time.RFC3339Nano) + `","message":{"role":"assistant","content":[{"type":"text","text":"shall I proceed?"}]}}
+`
+	root := fakeProjectsDir(t, map[string]string{"sess-ghost.jsonl": body})
+	path := filepath.Join(root, "-home-me-project", "sess-ghost.jsonl")
+	now := time.Now()
+	if err := os.Chtimes(path, now, now); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	got, err := DiscoverClaudeSessions(root, time.Hour)
+	if err != nil {
+		t.Fatalf("DiscoverClaudeSessions: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d sessions, want 1 (a fresh mtime keeps it in the window)", len(got))
+	}
+	if got[0].UpdatedAt != lastEvent.Unix() {
+		t.Errorf("UpdatedAt = %d, want %d (the last event, not the mtime %d)", got[0].UpdatedAt, lastEvent.Unix(), now.Unix())
+	}
+	// The ghost this produces: a session that stopped two days ago still
+	// claiming a human is required, and counting toward the Fleet badge.
+	if got[0].State != hook.StateEnded {
+		t.Errorf("State = %q, want %q — a transcript two days cold is not waiting on anyone", got[0].State, hook.StateEnded)
+	}
+}

--- a/hub/hub.go
+++ b/hub/hub.go
@@ -28,6 +28,7 @@ type TrailChip struct {
 type SessionView struct {
 	SessionID      string      `json:"session_id"`
 	CWD            string      `json:"cwd,omitempty"`
+	GitBranch      string      `json:"git_branch,omitempty"`
 	TmuxSession    string      `json:"tmux_session,omitempty"`
 	TmuxWindow     string      `json:"tmux_window,omitempty"`
 	TmuxPane       string      `json:"tmux_pane,omitempty"`
@@ -405,6 +406,7 @@ func viewSignature(v SessionView) string {
 func mergeStateIntoView(v *SessionView, s hook.SessionState) {
 	v.SessionID = s.SessionID
 	v.CWD = s.CWD
+	v.GitBranch = s.GitBranch
 	v.TmuxSession = s.TmuxSession
 	v.TmuxWindow = s.TmuxWindow
 	v.TmuxPane = s.TmuxPane

--- a/hub/transcript.go
+++ b/hub/transcript.go
@@ -35,30 +35,34 @@ const (
 // Claude Code transcript. Not every field is populated for every event; the
 // UI consumer decides what's interesting.
 type TranscriptEvent struct {
-	Offset        int64     // byte offset of the line start in the file
-	Timestamp     time.Time // event timestamp (best effort)
-	Type          string    // "user" | "assistant" | "tool_use" | "tool_result" | "thinking" | "text"
-	Role          string    // for user/assistant messages
-	ToolName      string    // for tool_use / tool_result
-	ToolUseID     string    // links tool_use to tool_result
-	IsError       bool      // tool_result failure
-	Text          string    // plain text content (assistant text / thinking / tool inputs squashed)
-	InputTokens   int
-	OutputTokens  int
-	CacheReadTokens int
+	Offset           int64     // byte offset of the line start in the file
+	Timestamp        time.Time // event timestamp (best effort)
+	Type             string    // "user" | "assistant" | "tool_use" | "tool_result" | "thinking" | "text"
+	Role             string    // for user/assistant messages
+	ToolName         string    // for tool_use / tool_result
+	ToolUseID        string    // links tool_use to tool_result
+	IsError          bool      // tool_result failure
+	Text             string    // plain text content (assistant text / thinking / tool inputs squashed)
+	CWD              string    // working directory recorded on the record, if any
+	GitBranch        string    // git branch recorded on the record, if any
+	InputTokens      int
+	OutputTokens     int
+	CacheReadTokens  int
 	CacheWriteTokens int
 }
 
 // jsonlRecord is the on-disk envelope. Unmarshalled loosely — the schema
 // evolves and one new field shouldn't poison a whole transcript.
 type jsonlRecord struct {
-	Type      string           `json:"type"`
-	Timestamp string           `json:"timestamp"`
-	Message   *anthropicMsg    `json:"message,omitempty"`
-	ToolName  string           `json:"tool_name,omitempty"`
-	ToolInput json.RawMessage  `json:"tool_input,omitempty"`
-	ToolUseID string           `json:"tool_use_id,omitempty"`
-	IsError   bool             `json:"is_error,omitempty"`
+	Type      string          `json:"type"`
+	Timestamp string          `json:"timestamp"`
+	CWD       string          `json:"cwd,omitempty"`
+	GitBranch string          `json:"gitBranch,omitempty"`
+	Message   *anthropicMsg   `json:"message,omitempty"`
+	ToolName  string          `json:"tool_name,omitempty"`
+	ToolInput json.RawMessage `json:"tool_input,omitempty"`
+	ToolUseID string          `json:"tool_use_id,omitempty"`
+	IsError   bool            `json:"is_error,omitempty"`
 }
 
 type anthropicMsg struct {
@@ -68,15 +72,15 @@ type anthropicMsg struct {
 }
 
 type contentBlock struct {
-	Type       string          `json:"type"`
-	Text       string          `json:"text,omitempty"`
-	Thinking   string          `json:"thinking,omitempty"`
-	ID         string          `json:"id,omitempty"`
-	Name       string          `json:"name,omitempty"`
-	Input      json.RawMessage `json:"input,omitempty"`
-	ToolUseID  string          `json:"tool_use_id,omitempty"`
-	IsError    bool            `json:"is_error,omitempty"`
-	Content    json.RawMessage `json:"content,omitempty"` // tool_result body
+	Type      string          `json:"type"`
+	Text      string          `json:"text,omitempty"`
+	Thinking  string          `json:"thinking,omitempty"`
+	ID        string          `json:"id,omitempty"`
+	Name      string          `json:"name,omitempty"`
+	Input     json.RawMessage `json:"input,omitempty"`
+	ToolUseID string          `json:"tool_use_id,omitempty"`
+	IsError   bool            `json:"is_error,omitempty"`
+	Content   json.RawMessage `json:"content,omitempty"` // tool_result body
 }
 
 type usage struct {
@@ -130,7 +134,7 @@ func parseLine(line string, offset int64) []TranscriptEvent {
 		return nil
 	}
 	ts, _ := time.Parse(time.RFC3339Nano, rec.Timestamp)
-	base := TranscriptEvent{Offset: offset, Timestamp: ts, Type: rec.Type}
+	base := TranscriptEvent{Offset: offset, Timestamp: ts, Type: rec.Type, CWD: rec.CWD, GitBranch: rec.GitBranch}
 
 	// Top-level tool_use / tool_result rows (some schema variants).
 	if rec.ToolName != "" {

--- a/runs/hooksource.go
+++ b/runs/hooksource.go
@@ -2,7 +2,9 @@ package runs
 
 import (
 	"context"
+	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/noamsto/houston/hub"
@@ -87,9 +89,12 @@ func (s *HookSource) Run(ctx context.Context, out chan<- Delta) error {
 // deltas can also produce; a headless session falls back to its own id and
 // simply never correlates with them.
 func runFromSessionView(v hub.SessionView) (string, Run) {
+	repo, branch := repoAndBranch(v.CWD, v.GitBranch)
 	r := Run{
 		Agent:     "claude",
 		State:     FromHookState(v.State),
+		Repo:      repo,
+		Branch:    branch,
 		Worktree:  v.CWD,
 		UpdatedAt: v.UpdatedAt,
 		Since:     v.Since,
@@ -120,4 +125,21 @@ func runFromSessionView(v hub.SessionView) (string, Run) {
 		r.Question = &Question{Text: v.LastMessage, Via: "pane"}
 	}
 	return key, r
+}
+
+// repoAndBranch names a run that has no tmux layer to inherit a name from.
+// Without it the card falls back to the raw session id.
+//
+// Worktree-per-branch is this project's mandated topology, so the leaf
+// directory is usually the branch rather than the repo — recognisably so,
+// because worktrunk names the directory after the branch with "/" flattened.
+func repoAndBranch(cwd, gitBranch string) (string, string) {
+	if cwd == "" {
+		return "", gitBranch
+	}
+	repo := filepath.Base(cwd)
+	if gitBranch != "" && repo == strings.ReplaceAll(gitBranch, "/", "-") {
+		repo = filepath.Base(filepath.Dir(cwd))
+	}
+	return repo, gitBranch
 }

--- a/runs/hooksource_test.go
+++ b/runs/hooksource_test.go
@@ -65,3 +65,36 @@ func TestRunFromSessionViewCarriesQuestionWhenBlocked(t *testing.T) {
 		t.Errorf("Question.Via = %q, want pane", r.Question.Via)
 	}
 }
+
+func TestRunFromSessionViewNamesTheRepo(t *testing.T) {
+	_, r := runFromSessionView(hub.SessionView{
+		SessionID: "abc-123",
+		CWD:       "/home/noams/git/nix-amd-ai",
+		GitBranch: "main",
+	})
+
+	if r.Repo != "nix-amd-ai" {
+		t.Errorf("Repo = %q, want nix-amd-ai — without it the card falls back to the raw session id", r.Repo)
+	}
+	if r.Branch != "main" {
+		t.Errorf("Branch = %q, want main", r.Branch)
+	}
+}
+
+func TestRunFromSessionViewNamesTheRepoFromAWorktree(t *testing.T) {
+	// Worktree-per-branch is this project's mandated topology, so the leaf
+	// directory is the branch, not the repo. It is recognisable as such:
+	// worktrunk names the directory after the branch with "/" flattened.
+	_, r := runFromSessionView(hub.SessionView{
+		SessionID: "abc-123",
+		CWD:       "/home/noams/Data/git/.worktrees/git/houston/fix-build-guard-ui-dist",
+		GitBranch: "fix/build-guard-ui-dist",
+	})
+
+	if r.Repo != "houston" {
+		t.Errorf("Repo = %q, want houston — the leaf directory is the branch", r.Repo)
+	}
+	if r.Branch != "fix/build-guard-ui-dist" {
+		t.Errorf("Branch = %q, want fix/build-guard-ui-dist", r.Branch)
+	}
+}


### PR DESCRIPTION
Found by rendering `#/fleet` on a phone over the tailnet — the first time #8 has ever been looked at. Three defects, one screen.

Closes #10.

## What was wrong

**`tmuxCoords` recorded a pane index, not a pane id.** `hook/hook.go` asked tmux for `#P` (`1`) while `runs/tmuxsource.go:132` keys every run on `p.PaneID` (`%17`). The design authority says *"correlation key is the tmux pane id"*; `tmuxsource` honours it, the hook did not, so a hook-born run and its tmux layer could never merge. `1` is not unique either — every session has a pane 1, so two unrelated runs could collide onto one key.

It also called `display-message` without `-t`, resolving against the *current client's* pane. The new test caught this live: run from the houston worktree, it reported `nix-amd-ai:1`.

**Discovery dated sessions by mtime.** mtime moves for reasons that are not session activity. Session `d413541f` had a last event of `2026-09-06T19:57Z` and an mtime of today — rendered as "23m", `blocked`, and counted in the "needs you" badge. The freshness rule was correct; it was being fed a timestamp that did not mean what it claimed.

**Discovery rebuilt cwd from the directory name.** `decodeProjectDirName` replaces every `-` with `/`, which cannot be right: `nix-amd-ai` → `/home/noams/git/nix/amd/ai`. `hooksource` then set `Worktree` but never `Repo`/`Branch`, so `nameLabel()` fell through to the raw `sess-<uuid>`.

Every transcript record already carries `cwd`, `gitBranch` and `timestamp`.

## Verified against the live server

| | before | after |
|---|---|---|
| UUID-named cards | 12 | **0** |
| the Sep-6 nix-rpi session | `blocked`, 23m, in the badge | `nix-rpi/main`, `done`, 45h, in history |
| blocked runs / in badge | 8 / 3 | 5 / 2 |

Worktree sessions name correctly too: `lazytmux/feat/320-relay-sixel-and-osc-1337-graphics`. The leaf directory is the branch under worktree-per-branch, and it is recognisable as such because worktrunk names it after the branch with `/` flattened.

## Tests

Four new tests, each confirmed to bite by mutating the fix back:

- `TestTmuxCoordsReportsPaneIDNotIndex` — failed with `pane = "1"` before the fix
- `TestTmuxCoordsEmptyOutsideTmux` — reported another window's coordinates before the fix
- `TestDiscoveryDatesSessionByLastEventNotMtime` — reverting to mtime gives `State = "waiting"` for a two-day-cold transcript
- `TestDiscoveryPrefersTranscriptCWDOverDirName` — ignoring the record cwd gives `/home/noams/git/nix/amd/ai`
- `TestRunFromSessionViewNamesTheRepo` / `...FromAWorktree` — dropping the worktree rule names the repo `fix-build-guard-ui-dist`

Full suite green; `golangci-lint` reports the same 7 pre-existing issues as `main`, none new.

## Not in this PR

Live panes still appear twice (once from tmux, once from discovery). This PR makes the merge *possible* by fixing the key, but the hooks layer has never fired on this machine — `~/.local/state/houston/claude/` is empty, so discovery, designed as a startup bootstrap, is doing all the work permanently. Installing the hooks is a nix-config change (they belong in the read-only `--settings` overlay, not `settings.json`), so it is left as a separate step.

The struct realignments in `transcript.go`/`state.go` are gofmt acting on the blocks that gained a field, not hand-editing.

https://claude.ai/code/session_016Kh5rgwBKAD68QmVqDQEQw