### PR TITLE
fix(nix): make the flake package build from a clean checkout

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
             pname = "houston-ui";
             version = "0.1.0";
             src = ./ui;
-            npmDepsHash = "sha256-VbXiUUSVVP3F+a9H3l4DlVD9wC35v9rBXwY9a1tAKHo=";
+            npmDepsHash = "sha256-NyflCfn5AlUeWGWXniENFt80ZXAZjejHXyZ/Ly1GGcA=";
             buildPhase = "npm run build";
             installPhase = "cp -r dist $out";
             dontNpmInstall = true;
@@ -50,7 +50,10 @@
             pname = "houston";
             version = "0.1.0";
             src = pkgs.lib.cleanSource ./.;
-            vendorHash = "sha256-0Qxw+MUYVgzgWB8vi3HBYtVXSq/btfh4ZfV/m1chNrA=";
+            vendorHash = "sha256-ArYCbm+rj0VYQV58tiVyYPXGfgiW45hfc+wFGQuQy3U=";
+
+            # tmux/control_integration_test.go drives a real server.
+            nativeCheckInputs = [pkgs.tmux];
 
             preBuild = ''
               mkdir -p ui/dist


### PR DESCRIPTION
Blocks wiring houston's hooks into nix-config, which needs `inputs.houston.packages.<system>.default` to build.

`nix build github:noamsto/houston#default` failed three ways against a clean fetch of `main`:

1. `npmDepsHash` stale — `sha256-VbXi…` → `sha256-Nyfl…`
2. `vendorHash` stale — `sha256-0Qxw…` → `sha256-ArYC…`
3. `checkPhase` ran `tmux/control_integration_test.go` with no `tmux` on PATH:
   ```
   --- FAIL: TestControlClientIntegration
       failed to create test session: exec: "tmux": executable file not found in $PATH
   ```

Fixed the two hashes and added `nativeCheckInputs = [pkgs.tmux]` so those tests actually run in the sandbox rather than being skipped or removed. All 12 packages now pass inside the build.

Nothing had noticed because there is no CI (#6), and a local `nix build` happily reuses the store path from whenever the hashes last matched — which is why this only surfaced when another flake fetched it fresh.

Refs #6.