### PR TITLE
fix(server): make the Host-allowlist test hermetic

### DIFF
--- a/server/hosts.go
+++ b/server/hosts.go
@@ -24,16 +24,20 @@ type hostGate struct {
 // domain genuinely does resolve to our address, so a lookup would validate the
 // attacker's own claim.
 func deriveHosts(extra []string, allowedOrigins []string) *hostGate {
-	g := &hostGate{hosts: map[string]struct{}{}}
+	return newHostGate(selfKnownHosts(), extra, allowedOrigins)
+}
 
-	for _, h := range []string{"localhost", "127.0.0.1", "::1"} {
-		g.add(h)
-	}
+// selfKnownHosts asks the machine what it knows about itself: its hostname
+// and its Tailscale addresses, reverse-resolved to their MagicDNS names.
+// Isolated from newHostGate so tests can supply a fixed host list instead of
+// depending on ambient machine/network state.
+func selfKnownHosts() []string {
+	var out []string
 	if hn, err := os.Hostname(); err == nil {
-		g.add(hn)
+		out = append(out, hn)
 	}
 	for _, ip := range tailnetAddrs() {
-		g.add(ip)
+		out = append(out, ip)
 		// Reverse lookup is safe here: the input is our own bound address,
 		// not anything a client sent. Bounded so a dead resolver (e.g. a
 		// laptop waking on a flaky network) can't hang startup — a timeout
@@ -44,9 +48,25 @@ func deriveHosts(extra []string, allowedOrigins []string) *hostGate {
 		cancel()
 		if err == nil {
 			for _, n := range names {
-				g.add(strings.TrimSuffix(n, "."))
+				out = append(out, strings.TrimSuffix(n, "."))
 			}
 		}
+	}
+	return out
+}
+
+// newHostGate builds the allowlist from explicit inputs, with zero ambient
+// machine or network dependency: loopback literals, the given self-known
+// hosts (what the machine reports about itself, in production), the
+// hostnames of allowedOrigins, and any extra hosts (e.g. from -hostname).
+func newHostGate(selfKnown []string, extra []string, allowedOrigins []string) *hostGate {
+	g := &hostGate{hosts: map[string]struct{}{}}
+
+	for _, h := range []string{"localhost", "127.0.0.1", "::1"} {
+		g.add(h)
+	}
+	for _, h := range selfKnown {
+		g.add(h)
 	}
 	for _, o := range allowedOrigins {
 		if u, err := url.Parse(o); err == nil && u.Hostname() != "" {

--- a/server/hosts_test.go
+++ b/server/hosts_test.go
@@ -10,7 +10,7 @@ import (
 
 // If this fails, a rebound page can obtain the real token by fetching "/".
 func TestUnknownHostGetsNoCookieAndIsRefused(t *testing.T) {
-	g := deriveHosts(nil, nil)
+	g := newHostGate([]string{"houston-host"}, nil, nil)
 	a := &authGate{token: "secret", enabled: true}
 
 	handler := g.middleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -34,12 +34,21 @@ func TestUnknownHostGetsNoCookieAndIsRefused(t *testing.T) {
 // Exercises the real Handler() rather than a hand-built chain: the bug this
 // guards against was in the wiring, not the gate — the SPA handler sat outside
 // the host gate and issued the real token to any Host that asked.
+//
+// The allowlist is swapped for a fixed one after New() (both in package
+// server, so the unexported field is reachable), so the assertion — an
+// unrecognised Host gets 421 and no cookie — holds against a fixed, injected
+// allowlist with zero dependence on os.Hostname(), DNS, or a Tailscale
+// interface being present. (New() still probes those ambient sources during
+// construction, same as any production startup; only their result is
+// discarded here, not the probing itself.)
 func TestHandlerRefusesUnknownHostEndToEnd(t *testing.T) {
 	dir := t.TempDir()
 	s, err := New(Config{StatusDir: dir, AuthEnabled: true, UIFS: fstest.MapFS{}})
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
+	s.hosts = newHostGate([]string{"houston-host"}, nil, nil)
 
 	req := httptest.NewRequest("GET", "http://evil.example/", nil)
 	req.Host = "evil.example"
@@ -74,7 +83,7 @@ func TestDeriveHostsIncludesSelfKnowledge(t *testing.T) {
 }
 
 func TestAllowsStripsPortAndIsCaseInsensitive(t *testing.T) {
-	g := deriveHosts(nil, nil)
+	g := newHostGate(nil, nil, nil)
 
 	if !g.allows("127.0.0.1:9090") {
 		t.Error("allows(\"127.0.0.1:9090\") = false, want true — the port must be stripped")


### PR DESCRIPTION
## Summary

`TestHandlerRefusesUnknownHostEndToEnd` flipped pass/fail depending on which
nixpkgs the flake built under, because `deriveHosts` read ambient machine
state (`os.Hostname()`, the Tailscale address, its reverse DNS) directly.
The test result was a property of the build environment, not of the code.

- Split `deriveHosts` into `selfKnownHosts()` (ambient reads, production
  only) and `newHostGate(selfKnown, extra, allowedOrigins)` (pure
  construction from explicit inputs, zero ambient dependency).
- `TestUnknownHostGetsNoCookieAndIsRefused` and
  `TestHandlerRefusesUnknownHostEndToEnd` now build their allowlist via
  `newHostGate` with a fixed, injected host list — the end-to-end test still
  exercises the real `Handler()` wiring (auth → origin → host-gate → mux →
  SPA), it just swaps the unexported `s.hosts` field for a fixed gate after
  `New()` so the *data* is hermetic, not the wiring.
- Verified the regression tests actually bite: temporarily made `allows`
  always return `true`, confirmed both host tests failed, then reverted.

## Scope

Touched only `server/hosts.go` and `server/hosts_test.go`, per the task's
scope boundary (`.github/workflows/`, `server/agents_test.go`,
`server/server.go`, `tmux/`, `runs/`, `ui/` are owned by other concurrent
workers).

## Plan

Plan: task doc (provided)

Closes #13

## Test plan
- [x] `go test ./server/...` passes
- [x] `go vet ./server/...` passes
- [x] Breaking the Host check makes the new tests fail (verified, then reverted)
- [x] go-reviewer pass: approved (one comment-drift nit, fixed)

https://claude.ai/code/session_019AKPEn367J1MyqiAUrMyYZ