### PR TITLE
feat(ci): add CI — build, vet, test, lint, format and race gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,20 +21,15 @@ jobs:
 
       - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
 
-      - name: Debug tmux
-        run: |
-          nix develop -c tmux -V
-          nix develop -c id
-          nix develop -c bash -c 'echo "TMUX_TMPDIR=$TMUX_TMPDIR TERM=$TERM"; ls -la /tmp | head -20'
-          nix develop -c tmux new-session -d -s ci-probe -x 80 -y 24
-          echo "new-session exit: $?"
-          nix develop -c tmux kill-session -t ci-probe || true
-
       - run: nix develop -c just build
 
       - run: nix develop -c go vet ./...
 
-      - run: nix develop -c go test ./...
+      # -p 1: tmux's integration tests spawn a real tmux server under a 5s
+      # timeout (tmux/client.go); GitHub runners' limited CPU can starve that
+      # spawn past it when packages run in parallel (reproduced here as a
+      # flake). Serializing removes the contention at negligible wall-clock cost.
+      - run: nix develop -c go test -p 1 ./...
 
       - name: Check gofmt
         run: nix develop -c bash -c 'out=$(gofmt -l .); [ -z "$out" ] || { echo "$out"; exit 1; }'
@@ -57,4 +52,4 @@ jobs:
 
       - run: nix develop -c just build
 
-      - run: nix develop -c go test -race ./...
+      - run: nix develop -c go test -race -p 1 ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,14 @@ jobs:
 
       - run: nix develop -c go vet ./...
 
-      # -p 1: tmux's integration tests spawn a real tmux server under a 5s
-      # timeout (tmux/client.go); GitHub runners' limited CPU can starve that
-      # spawn past it when packages run in parallel (reproduced here as a
-      # flake). Serializing removes the contention at negligible wall-clock cost.
-      - run: nix develop -c go test -p 1 ./...
+      # tmux's server auto-exits when its last session is killed. Each
+      # integration test creates and kills its own session, so on a runner
+      # with no other tmux activity the next `new-session` can race a dying
+      # server ("server exited unexpectedly" — reproduced on an isolated
+      # socket). A session outliving the test run keeps the server up.
+      - run: nix develop -c tmux new-session -d -s ci-keepalive
+
+      - run: nix develop -c go test ./...
 
       - name: Check gofmt
         run: nix develop -c bash -c 'out=$(gofmt -l .); [ -z "$out" ] || { echo "$out"; exit 1; }'
@@ -52,4 +55,8 @@ jobs:
 
       - run: nix develop -c just build
 
-      - run: nix develop -c go test -race -p 1 ./...
+      # See the "checks" job for why: keeps tmux's shared default server
+      # alive across the whole test run.
+      - run: nix develop -c tmux new-session -d -s ci-keepalive
+
+      - run: nix develop -c go test -race ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,15 @@ jobs:
 
       - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
 
+      - name: Debug tmux
+        run: |
+          nix develop -c tmux -V
+          nix develop -c id
+          nix develop -c bash -c 'echo "TMUX_TMPDIR=$TMUX_TMPDIR TERM=$TERM"; ls -la /tmp | head -20'
+          nix develop -c tmux new-session -d -s ci-probe -x 80 -y 24
+          echo "new-session exit: $?"
+          nix develop -c tmux kill-session -t ci-probe || true
+
       - run: nix develop -c just build
 
       - run: nix develop -c go vet ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+
+      - run: nix develop -c just build
+
+      - run: nix develop -c go vet ./...
+
+      - run: nix develop -c go test ./...
+
+      - name: Check gofmt
+        run: nix develop -c bash -c 'out=$(gofmt -l .); [ -z "$out" ] || { echo "$out"; exit 1; }'
+
+      - run: nix develop -c golangci-lint run
+
+      - name: Frontend lint
+        run: nix develop -c bash -c 'cd ui && npx eslint .'
+
+      - name: Frontend types
+        run: nix develop -c bash -c 'cd ui && npx tsc -b'
+
+  race:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+
+      - run: nix develop -c just build
+
+      - run: nix develop -c go test -race ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,7 @@
+# Restores golangci-lint v1's default EXC0001 errcheck exclusions
+# (dropped when this repo's config moved to v2 schema).
+version: "2"
+linters:
+  exclusions:
+    presets:
+      - std-error-handling

--- a/agents/agent.go
+++ b/agents/agent.go
@@ -14,7 +14,7 @@ const (
 
 // AgentState wraps parser.Result with agent metadata.
 type AgentState struct {
-	Agent  AgentType    `json:"agent"`
+	Agent  AgentType     `json:"agent"`
 	Result parser.Result `json:"result"`
 }
 

--- a/agents/amp/detect.go
+++ b/agents/amp/detect.go
@@ -13,8 +13,8 @@ var boxStatusPattern = regexp.MustCompile(`╭─.*─╮`)
 func DetectFromOutput(output string) bool {
 	// Amp-specific markers (high confidence)
 	ampMarkers := []string{
-		"Cogitated for",           // Amp thinking indicator
-		"Baked for",               // Amp thinking variant
+		"Cogitated for",             // Amp thinking indicator
+		"Baked for",                 // Amp thinking variant
 		"Running PostToolUse hooks", // Amp hook indicator
 	}
 	for _, marker := range ampMarkers {

--- a/agents/amp/state.go
+++ b/agents/amp/state.go
@@ -41,11 +41,11 @@ type WorkspaceTree struct {
 
 // Message represents a thread message.
 type Message struct {
-	Role      string        `json:"role"`
-	MessageID int           `json:"messageId"`
-	Content   []any `json:"content"`
-	State     MessageState  `json:"state"`
-	Usage     Usage         `json:"usage"`
+	Role      string       `json:"role"`
+	MessageID int          `json:"messageId"`
+	Content   []any        `json:"content"`
+	State     MessageState `json:"state"`
+	Usage     Usage        `json:"usage"`
 }
 
 // MessageState represents the state of a message.

--- a/agents/claude/state.go
+++ b/agents/claude/state.go
@@ -15,16 +15,16 @@ import (
 
 // Message represents a single entry in the JSONL log.
 type Message struct {
-	Type       string    `json:"type"` // "user", "assistant", "file-history-snapshot", "summary"
-	UUID       string    `json:"uuid"`
-	ParentUUID string    `json:"parentUuid"`
-	SessionID  string    `json:"sessionId"`
-	Timestamp  time.Time `json:"timestamp"`
-	CWD        string    `json:"cwd"`
-	GitBranch  string    `json:"gitBranch"`
-	Todos      []Todo    `json:"todos"`
+	Type       string         `json:"type"` // "user", "assistant", "file-history-snapshot", "summary"
+	UUID       string         `json:"uuid"`
+	ParentUUID string         `json:"parentUuid"`
+	SessionID  string         `json:"sessionId"`
+	Timestamp  time.Time      `json:"timestamp"`
+	CWD        string         `json:"cwd"`
+	GitBranch  string         `json:"gitBranch"`
+	Todos      []Todo         `json:"todos"`
 	Message    MessageContent `json:"message"`
-	Summary    string `json:"summary"`
+	Summary    string         `json:"summary"`
 }
 
 // MessageContent represents the content of a user or assistant message.

--- a/agents/registry.go
+++ b/agents/registry.go
@@ -12,7 +12,7 @@ const detectionTTL = 15 * time.Second
 
 type cachedDetection struct {
 	agentType AgentType
-	command   string    // pane_current_command when detected
+	command   string // pane_current_command when detected
 	expiresAt time.Time
 }
 

--- a/docs/superpowers/plans/2026-09-08-ci-gates.md
+++ b/docs/superpowers/plans/2026-09-08-ci-gates.md
@@ -1,0 +1,210 @@
+# Plan: Add CI (build, vet, test, lint, format, race gates) — closes #6
+
+## Context established during research
+
+- Repo has **no** `.github/workflows/` at all.
+- `flake.nix` pins the toolchain (go 1.25.5, golangci-lint 2.8.0, node 24, tmux) via
+  `devShells.default` and defines pre-commit hooks for golangci-lint, eslint, tsc.
+- `go build`/`go vet`/`go test` all fail today with
+  `embed.go:5:12: pattern ui/dist: no matching files found` unless `ui/dist` exists
+  first (the `//go:embed ui/dist` directive). `just build` guards this by running
+  `npm install --prefix ui` + `npm run build --prefix ui` before `go build`. Any CI
+  step that runs bare `go vet`/`go test`/`go build` needs the same UI-build step
+  first, not just the literal `just build` invocation named in the issue.
+- Confirmed against the real toolchain (nix-provided go1.25.5 / golangci-lint 2.8.0,
+  the same ones `nix develop` would give CI):
+  - `gofmt -l .` on `main` (HEAD `a8d083e`) lists **12** files, not the 4 named in
+    the task doc: the 4 named (`server/server.go`, `tmux/client.go`,
+    `tmux/control.go`, `tmux/escape.go`) plus 8 more (`agents/agent.go`,
+    `agents/amp/detect.go`, `agents/amp/state.go`, `agents/claude/state.go`,
+    `agents/registry.go`, `opencode/client.go`, `parser/message_parser.go`,
+    `parser/parser.go`). None of the 8 extra files fall inside this task's
+    protected boundary (`runs/`, `ui/src/fleet/`, `server/hosts.go`,
+    `server/hosts_test.go`) or any other worker's named files — the discrepancy is
+    a toolchain-version fact, not a merge hazard. **Deviation from the task doc's
+    literal "gofmt-only edits to the four files named above":** formatting only 4
+    of the 12 flagged files would leave `gofmt -l .` non-empty and the format gate
+    red on arrival — exactly what the task's own prerequisite section says a gate
+    must never be. Format all 12; call this out explicitly in the PR body.
+  - `go test -race ./...` fails with a real data race in
+    `server/agents_test.go:90`'s `TestAgentsStreamEmitsSnapshotAndUpdate`: the test
+    goroutine polls `rec.Body.String()` while `handleAgentsStream` concurrently
+    writes to the same `httptest.ResponseRecorder` from another goroutine.
+    Confirmed goroutine IDs/stacks in `-race` output.
+  - `golangci-lint run` fails today on `main`, unrelated to the two named
+    blockers. Its default output is truncated by golangci-lint's `max-same-issues:
+    3` default — `golangci-lint run --max-same-issues=0 --max-issues-per-linter=0`
+    shows the real count: **24** `errcheck` findings (unchecked
+    `fmt.Fprintf`/`Fprintln` return values) spread across `hook/doctor.go` (21),
+    `main.go` (1), `server/agents.go` (1), `server/runs_api.go` (1), plus the 1
+    `staticcheck` S1011 already found (`hub/transcript.go:116`). `server/runs_api.go`
+    is not on the protected list verbatim, but it's clearly part of the concurrent
+    `runs/` workstream (PR #7's "Run model ... `/api/runs`"), so hand-editing it is
+    exactly the kind of file this task should stay out of even though the literal
+    string isn't in the boundary list.
+    **Fix: a `.golangci.yml` restoring the `std-error-handling` exclusion preset**
+    (confirmed empirically: adding
+    `linters.exclusions.presets: [std-error-handling]` under `version: "2"` drops
+    the errcheck count from 24 to 0, leaving only the 1 genuine staticcheck issue).
+    This is v1's implicit default behavior for exactly this pattern
+    (v1's `EXC0001` errcheck exclusion — unchecked `fmt.Fprint*`, `.*Close`,
+    `.*Flush`, `os.Remove(All)?`, `os.(Un)?Setenv` — not just `Fprint*`), lost
+    because golangci-lint v2 requires
+    opting in. It's a **new file**, squarely CI configuration (this task's own
+    remit), and touches zero existing source files outside this task's declared
+    scope — strictly safer than hand-editing 24 call sites across 4 files, one of
+    which belongs to another worker. Only the 1 remaining `staticcheck` fix in
+    `hub/transcript.go` (outside the protected boundary) is still needed.
+  - `eslint` / `tsc -b` in `ui/` are clean today (confirmed via `npm run build`,
+    which runs `tsc -b && vite build`).
+
+## Job layout decision
+
+Two jobs, both `runs-on: ubuntu-latest`, nix-based (`nix develop -c ...`), each
+with `timeout-minutes: 15` (`checks`) / `20` (`race`, since `-race` and the tmux
+integration test are slower) so a hung tmux server can't wedge the runner.
+Triggered on:
+```yaml
+on:
+  pull_request:
+  push:
+    branches: [main]
+```
+This gates every PR and acts as a safety net on direct pushes to `main`, without
+double-running the same commit (PR event covers feature branches; push covers only
+`main`, i.e. post-merge).
+
+1. **`checks`** — build, vet, test, format, lint, frontend lint, frontend types.
+   One job because these are fast (seconds each) and all need the same
+   `ui/dist` + `nix develop` setup; splitting them would triplicate that setup
+   cost for no parallelism benefit on a repo this size. Steps, in order (fail
+   fast on the cheapest/most-informative first):
+   - checkout
+   - install nix (`DeterminateSystems/nix-installer-action`, pinned to a released
+     tag). **No cache action** — `DeterminateSystems/magic-nix-cache-action` was
+     sunset (superseded by `flakehub-cache-action`, which needs
+     `id-token: write` + FlakeHub account linkage — more moving parts than this
+     task needs). The acceptance bar is "gates run and are green", not "gates are
+     fast"; a plain `nix-installer-action` with no cache is simpler and has one
+     fewer thing that can silently break the build. Revisit caching later if CI
+     minutes become a real cost.
+   - `nix develop -c just build` (builds `ui/dist` + the go binary — covers the
+     Build gate and produces `ui/dist` for every subsequent step)
+   - `nix develop -c go vet ./...`
+   - `nix develop -c go test ./...`
+   - `nix develop -c bash -c 'out=$(gofmt -l .); [ -z "$out" ] || { echo "$out"; exit 1; }'`
+     (format gate — prints the offending files on failure instead of a bare
+     nonzero exit)
+   - `nix develop -c golangci-lint run`
+   - `nix develop -c bash -c 'cd ui && npx eslint .'`
+   - `nix develop -c bash -c 'cd ui && npx tsc -b'` (redundant with the `tsc -b`
+     inside `just build`'s `npm run build`, but kept as an explicit, independently
+     named gate per the issue's table — harmless no-op when the build already
+     ran)
+2. **`race`** — separate job, same nix setup, only:
+   - `nix develop -c just build` (needs `ui/dist` too, since it's a full package
+     compile)
+   - `nix develop -c go test -race ./...`
+   Kept separate as a design choice (not attributed to the state-of-play doc,
+   which doesn't actually recommend this): `-race` instruments every memory
+   access and is materially slower, and `tmux/control_integration_test.go` spins
+   up a real tmux server — isolating it means a slow or hung race run doesn't
+   block the fast `checks` feedback loop. Runs in parallel with `checks` (no
+   `needs:`), both required for merge (branch protection is a human follow-up,
+   out of scope here — the PR's green checks are the proof). Add
+   `timeout-minutes` and a `concurrency` group with `cancel-in-progress: true` to
+   both jobs so a hung tmux server (the integration test `t.Fatalf`s if
+   `new-session` fails, and only skips under `-short`, which we don't pass)
+   can't wedge the runner indefinitely.
+
+`tmux` is already in `devShells.default`'s `buildInputs`, so `nix develop -c`
+provides it for the integration test noted in the issue — no extra runner setup
+needed.
+
+## Steps
+
+- [ ] **Step 1: gofmt the flagged files** — re-run `gofmt -l .` immediately before
+  fixing anything (three other workers are landing concurrently, so the exact
+  file list from research time — 12 files: the 4 named
+  (`server/server.go`, `tmux/client.go`, `tmux/control.go`, `tmux/escape.go`)
+  plus 8 discovered (`agents/agent.go`, `agents/amp/detect.go`,
+  `agents/amp/state.go`, `agents/claude/state.go`, `agents/registry.go`,
+  `opencode/client.go`, `parser/message_parser.go`, `parser/parser.go`) — is a
+  snapshot, not a guarantee). `gofmt -w` on whatever the fresh list contains,
+  *unless* a file on it now falls inside the protected boundary (`runs/`,
+  `ui/src/fleet/`, `server/hosts.go`, `server/hosts_test.go`) — skip and flag
+  those instead of touching them. Verify `gofmt -l .` is empty afterward.
+  Whitespace-only; no behavior change.
+
+- [ ] **Step 2: fix the `server/agents_test.go` data race** — replace the raw
+  `httptest.NewRecorder()` used by `TestAgentsStreamEmitsSnapshotAndUpdate` with a
+  small test-local `syncRecorder` type using an **unexported named field, never
+  embedded** — `type syncRecorder struct { mu sync.Mutex; rec *httptest.ResponseRecorder }`
+  — so every stale `.Body`/`.Header()` access becomes a compile error instead of
+  silently staying promoted through an embedded field. Implement
+  `http.ResponseWriter` (`Header`, `Write`, `WriteHeader`) and `http.Flusher`
+  (`Flush`) by locking `mu` and delegating to `rec`, plus mutex-guarded `body()`
+  and `header()` accessors. Update **all five** call sites in the test that
+  currently touch the recorder directly: `rec.Body.String()` at lines 99, 108,
+  122, 138 → `rec.body()`, and `rec.Header().Get(...)` at line 133 → `rec.header().Get(...)`.
+  Use it only in this one test — the other three tests in the file read the
+  recorder synchronously after the handler returns and have no race. Keep it
+  minimal: no redesign of the test's assertions or control flow, per the task's
+  explicit instruction (`/api/agents` is slated for deletion later).
+
+- [ ] **Step 3: fix the pre-existing golangci-lint issues** — add
+  `.golangci.yml` at the repo root:
+  ```yaml
+  version: "2"
+  linters:
+    exclusions:
+      presets:
+        - std-error-handling
+  ```
+  (empirically confirmed: this drops the errcheck count from 24 to 0, restoring
+  v1's default `EXC0001` errcheck exclusion (broader than just `fmt.Fprint*` —
+  see above), without touching
+  `hook/doctor.go`, `main.go`, `server/agents.go`, or `server/runs_api.go` — the
+  last of which belongs to the concurrent `runs/` worker). Then fix the one
+  remaining real issue: `hub/transcript.go:116`, replace
+  `for _, ev := range parseLine(trimmed, pos) { events = append(events, ev) }`
+  with `events = append(events, parseLine(trimmed, pos)...)`. Confirm
+  `golangci-lint run` is clean afterward (re-run with `--max-same-issues=0
+  --max-issues-per-linter=0` too, so truncation can't hide a straggler).
+
+- [ ] **Step 4: add `.github/workflows/ci.yml`** — implement the two-job layout
+  above. Confirm the YAML is valid (`yamllint`/`actionlint` if available, or at
+  minimum a careful read) before pushing, since the only real proof is the PR's
+  own checks running green.
+
+- [ ] **Step 5: run the full local gate matrix once, in the dev shell** —
+  `just build`, `go vet ./...`, `go test ./...`, `gofmt -l .` (expect empty),
+  `golangci-lint run`, `cd ui && npx eslint .`, `cd ui && npx tsc -b`,
+  `go test -race ./...`. All must be green before pushing — this is also the
+  worker protocol's fast deterministic gate.
+
+- [ ] **Step 6: push and open the PR**, verify the two new checks actually run
+  and go green on the PR (not just "the YAML looks right"), per the acceptance
+  criteria. Document in the PR body: the gofmt-scope deviation (4 named → all
+  currently-flagged files), the third (lint) prerequisite and the `.golangci.yml`
+  fix, the one-line `hub/transcript.go` change, and that frontend `vitest` tests (`ui/src/hooks/useRuns.test.ts`,
+  `ui/src/fleet/staleness.test.ts`) are **not** gated — they're outside the
+  issue's stated gate table, and one lives under `ui/src/fleet/`, another
+  worker's territory, so adding it here would be scope creep on top of scope
+  creep. Note it as a known gap for a follow-up.
+
+## Acceptance criteria (from task doc)
+
+- [ ] Every gate in the table (build, vet, test, format, lint, frontend lint,
+  frontend types, race) is green on the PR, or deliberately deferred with a
+  stated reason in the PR body.
+- [ ] `gofmt -l .` is empty.
+- [ ] `go test -race ./...` passes.
+- [ ] The PR's own checks are the proof the workflow runs — not just correct YAML.
+
+## Explicitly out of scope
+
+`runs/`, `ui/src/fleet/`, `server/hosts.go`, `server/hosts_test.go` (three other
+concurrent workers own these). Branch protection rules (human follow-up, not
+achievable from a worker session). Deploy/release automation (explicitly out of
+scope in the issue).

--- a/hub/transcript.go
+++ b/hub/transcript.go
@@ -113,9 +113,7 @@ func ReadTranscriptFrom(path string, byteOffset int64) ([]TranscriptEvent, int64
 		n := int64(len(line))
 		trimmed := strings.TrimSpace(string(line))
 		if trimmed != "" {
-			for _, ev := range parseLine(trimmed, pos) {
-				events = append(events, ev)
-			}
+			events = append(events, parseLine(trimmed, pos)...)
 		}
 		pos += n
 		if err == io.EOF {

--- a/opencode/client.go
+++ b/opencode/client.go
@@ -270,7 +270,7 @@ func (c *Client) SubscribeEvents(ctx context.Context) (<-chan Event, error) {
 
 			line, err := reader.ReadString('\n')
 			if err != nil {
-					return
+				return
 			}
 
 			line = strings.TrimSpace(line)

--- a/parser/message_parser.go
+++ b/parser/message_parser.go
@@ -56,8 +56,8 @@ func (t MessageType) String() string {
 // Message represents a single message in the conversation
 type Message struct {
 	Type       MessageType
-	Content    string            // Clean content (colors stripped for matching)
-	RawContent string            // Original with ANSI colors (for display)
+	Content    string // Clean content (colors stripped for matching)
+	RawContent string // Original with ANSI colors (for display)
 	Timestamp  time.Time
 	Metadata   map[string]string // tool name, activity, line numbers, etc.
 }
@@ -95,9 +95,9 @@ type ConversationState struct {
 // MessageParser parses agent output into structured messages
 type MessageParser struct {
 	config       ParserConfig
-	buffer       []string          // Raw output lines with ANSI colors
+	buffer       []string // Raw output lines with ANSI colors
 	state        ConversationState
-	seenMessages map[int]bool      // Track processed lines
+	seenMessages map[int]bool // Track processed lines
 }
 
 // NewMessageParser creates a new parser with the given configuration
@@ -180,8 +180,8 @@ func (s *ConversationState) ToLegacyResult() Result {
 		// Has a question but not multiple choice
 		resultType = TypeQuestion
 	} else if s.CurrentState == StateThinking ||
-	          s.CurrentState == StateResponding ||
-	          s.CurrentState == StateRunningTool {
+		s.CurrentState == StateResponding ||
+		s.CurrentState == StateRunningTool {
 		// Agent is actively working
 		resultType = TypeWorking
 	}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -72,8 +72,8 @@ type Result struct {
 	Question     string     `json:"question,omitempty"`
 	Choices      []string   `json:"choices,omitempty"`
 	ErrorSnippet string     `json:"error_snippet,omitempty"`
-	Activity     string     `json:"activity,omitempty"`     // What Claude is currently doing (for TypeWorking)
-	Suggestion   string     `json:"suggestion,omitempty"`   // Prompt suggestion from Claude Code subagent
+	Activity     string     `json:"activity,omitempty"`   // What Claude is currently doing (for TypeWorking)
+	Suggestion   string     `json:"suggestion,omitempty"` // Prompt suggestion from Claude Code subagent
 }
 
 var (
@@ -84,7 +84,7 @@ var (
 	// Error patterns - look for actual error messages, not just code containing "error"
 	// Requires colon after error keyword to avoid matching code/comments
 	// Matches: "Error: message" or "error: message" but not "// handle error" or "errorCount"
-	errorPattern = regexp.MustCompile(`(?mi)^(?:error|failed|fatal|panic):\s+(.+)`)
+	errorPattern    = regexp.MustCompile(`(?mi)^(?:error|failed|fatal|panic):\s+(.+)`)
 	approvalPattern = regexp.MustCompile(`(?i)(proceed|continue|look right|does this|should i)\?`)
 
 	// Claude Code working/activity patterns
@@ -155,7 +155,6 @@ func Parse(output string) Result {
 			}
 		}
 	}
-
 
 	// Check for approval/confirmation question
 	if approvalPattern.MatchString(text) {

--- a/server/agents_test.go
+++ b/server/agents_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -75,11 +76,60 @@ func TestAgentsSnapshotReflectsHookState(t *testing.T) {
 	}
 }
 
+// syncRecorder wraps httptest.ResponseRecorder with a mutex so a handler
+// writing concurrently with a test goroutine reading the body doesn't race.
+// The recorder is unexported (not embedded) so any stray direct
+// .Body/.Header() access fails to compile instead of silently working.
+type syncRecorder struct {
+	mu  sync.Mutex
+	rec *httptest.ResponseRecorder
+}
+
+func newSyncRecorder() *syncRecorder {
+	return &syncRecorder{rec: httptest.NewRecorder()}
+}
+
+func (s *syncRecorder) Header() http.Header {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.rec.Header()
+}
+
+func (s *syncRecorder) Write(b []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.rec.Write(b)
+}
+
+func (s *syncRecorder) WriteHeader(code int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.rec.WriteHeader(code)
+}
+
+func (s *syncRecorder) Flush() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.rec.Flush()
+}
+
+func (s *syncRecorder) body() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.rec.Body.String()
+}
+
+func (s *syncRecorder) header() http.Header {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.rec.Header()
+}
+
 func TestAgentsStreamEmitsSnapshotAndUpdate(t *testing.T) {
 	dir := t.TempDir()
 	s := newTestServer(t, dir)
 
-	rec := httptest.NewRecorder()
+	rec := newSyncRecorder()
 
 	// Kick the SSE handler off in a goroutine and cancel it when we're done.
 	ctx, cancel := context.WithCancel(context.Background())
@@ -96,7 +146,7 @@ func TestAgentsStreamEmitsSnapshotAndUpdate(t *testing.T) {
 	waitForBody := func(substr string, timeout time.Duration) bool {
 		deadline := time.Now().Add(timeout)
 		for time.Now().Before(deadline) {
-			if strings.Contains(rec.Body.String(), substr) {
+			if strings.Contains(rec.body(), substr) {
 				return true
 			}
 			time.Sleep(25 * time.Millisecond)
@@ -105,7 +155,7 @@ func TestAgentsStreamEmitsSnapshotAndUpdate(t *testing.T) {
 	}
 
 	if !waitForBody("event: snapshot", time.Second) {
-		t.Fatalf("snapshot event never sent\n%s", rec.Body.String())
+		t.Fatalf("snapshot event never sent\n%s", rec.body())
 	}
 
 	// Write a state file — the hub should broadcast an update.
@@ -119,7 +169,7 @@ func TestAgentsStreamEmitsSnapshotAndUpdate(t *testing.T) {
 	}
 
 	if !waitForBody("event: update", 2*time.Second) {
-		t.Errorf("update event never sent\n%s", rec.Body.String())
+		t.Errorf("update event never sent\n%s", rec.body())
 	}
 
 	cancel()
@@ -130,12 +180,12 @@ func TestAgentsStreamEmitsSnapshotAndUpdate(t *testing.T) {
 	}
 
 	// Content-Type sanity.
-	if got := rec.Header().Get("Content-Type"); got != "text/event-stream" {
+	if got := rec.header().Get("Content-Type"); got != "text/event-stream" {
 		t.Errorf("Content-Type = %q", got)
 	}
 
 	// Parse the SSE stream and assert the update payload deserializes cleanly.
-	r := bufio.NewReader(strings.NewReader(rec.Body.String()))
+	r := bufio.NewReader(strings.NewReader(rec.body()))
 	var lastData string
 	var lastEvent string
 	for {

--- a/server/runs_api_test.go
+++ b/server/runs_api_test.go
@@ -48,7 +48,7 @@ func TestRunsStreamDeliversARemoval(t *testing.T) {
 	reg.Apply(runs.Delta{Source: "hooks", Key: "%1", Run: runs.Run{Agent: "claude", State: runs.StateRunning}})
 
 	s := &Server{runs: reg}
-	rec := httptest.NewRecorder()
+	rec := newSyncRecorder()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -63,7 +63,7 @@ func TestRunsStreamDeliversARemoval(t *testing.T) {
 	waitForBody := func(substr string, timeout time.Duration) bool {
 		deadline := time.Now().Add(timeout)
 		for time.Now().Before(deadline) {
-			if strings.Contains(rec.Body.String(), substr) {
+			if strings.Contains(rec.body(), substr) {
 				return true
 			}
 			time.Sleep(25 * time.Millisecond)
@@ -72,7 +72,7 @@ func TestRunsStreamDeliversARemoval(t *testing.T) {
 	}
 
 	if !waitForBody("event: snapshot", time.Second) {
-		t.Fatalf("snapshot event never sent\n%s", rec.Body.String())
+		t.Fatalf("snapshot event never sent\n%s", rec.body())
 	}
 
 	// The run's only agent-bearing layer leaves — the registry must report it
@@ -80,7 +80,7 @@ func TestRunsStreamDeliversARemoval(t *testing.T) {
 	reg.Apply(runs.Delta{Source: "hooks", Key: "%1", Gone: true})
 
 	if !waitForBody(`"removed":true`, 2*time.Second) {
-		t.Fatalf("removal never reached the client\n%s", rec.Body.String())
+		t.Fatalf("removal never reached the client\n%s", rec.body())
 	}
 
 	cancel()

--- a/server/server.go
+++ b/server/server.go
@@ -770,7 +770,6 @@ func parsePaneTarget(path string) (tmux.Pane, error) {
 	return tmux.Pane{Session: session, Window: window, Index: pane}, nil
 }
 
-
 func (s *Server) handlePaneSend(w http.ResponseWriter, r *http.Request, pane tmux.Pane) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)

--- a/tmux/client.go
+++ b/tmux/client.go
@@ -232,12 +232,12 @@ func (c *Client) ListPanes(session string, window int) ([]PaneInfo, error) {
 // CaptureResult holds the captured pane output and detected mode
 type CaptureResult struct {
 	Output     string `json:"output"`
-	CursorX    int    `json:"cursor_x"`     // 0-indexed cursor column in visible area
-	CursorY    int    `json:"cursor_y"`     // 0-indexed cursor row in visible area
-	PaneWidth  int    `json:"pane_width"`   // visible columns in the pane
-	PaneHeight int    `json:"pane_height"`  // visible rows in the pane
-	Mode       string `json:"mode"`         // "insert", "normal", or ""
-	StatusLine string `json:"status_line"`  // Full status line with ANSI colors intact
+	CursorX    int    `json:"cursor_x"`    // 0-indexed cursor column in visible area
+	CursorY    int    `json:"cursor_y"`    // 0-indexed cursor row in visible area
+	PaneWidth  int    `json:"pane_width"`  // visible columns in the pane
+	PaneHeight int    `json:"pane_height"` // visible rows in the pane
+	Mode       string `json:"mode"`        // "insert", "normal", or ""
+	StatusLine string `json:"status_line"` // Full status line with ANSI colors intact
 }
 
 func (c *Client) CapturePane(p Pane, lines int) (string, error) {
@@ -286,10 +286,6 @@ func (c *Client) CapturePaneWithMode(p Pane, lines int) (CaptureResult, error) {
 		StatusLine: "", // Agent-specific; set by caller
 	}, nil
 }
-
-
-
-
 
 // GetPaneID returns the tmux pane ID (e.g. "%42") for a given pane target.
 func (c *Client) GetPaneID(p Pane) (string, error) {

--- a/tmux/control.go
+++ b/tmux/control.go
@@ -9,7 +9,7 @@ import (
 type ControlEventType int
 
 const (
-	EventOutput          ControlEventType = iota
+	EventOutput ControlEventType = iota
 	EventBegin
 	EventEnd
 	EventError

--- a/tmux/escape.go
+++ b/tmux/escape.go
@@ -19,7 +19,7 @@ func UnescapeOctal(s string) string {
 		if s[i] == '\\' && i+3 < len(s) {
 			d1, d2, d3 := s[i+1], s[i+2], s[i+3]
 			if d1 >= '0' && d1 <= '3' && d2 >= '0' && d2 <= '7' && d3 >= '0' && d3 <= '7' {
-				val := (d1-'0')*64 + (d2-'0')*8 + (d3-'0')
+				val := (d1-'0')*64 + (d2-'0')*8 + (d3 - '0')
 				buf = append(buf, val)
 				i += 3
 				continue


### PR DESCRIPTION
Closes #6

## What this adds

`.github/workflows/ci.yml` — two independent jobs (nix-based, using the toolchain `flake.nix` already pins):

- **`checks`** — `just build` (produces `ui/dist`, needed by `//go:embed ui/dist`), `go vet ./...`, a keep-alive tmux session (see below), `go test ./...`, `gofmt -l .` (empty), `golangci-lint run`, frontend `eslint`, frontend `tsc -b`.
- **`race`** — `just build` + keep-alive session + `go test -race ./...`, kept separate since `-race` and the tmux integration tests are slower and shouldn't gate the fast feedback loop.

Triggered on `pull_request` (any branch) + `push` to `main` (post-merge safety net), with a `concurrency` group to cancel superseded runs, `permissions: contents: read`, and `DeterminateSystems/nix-installer-action` pinned to a commit SHA (not a mutable tag).

## Three pre-existing blockers cleared (all confirmed against the actual pinned toolchain — go 1.25.5, golangci-lint 2.8.0 — the same one CI runs)

1. **`gofmt -l .`** — flagged **12** files against the nix-pinned gofmt, not the 4 originally named in the issue: the 4 named (`server/server.go`, `tmux/client.go`, `tmux/control.go`, `tmux/escape.go`) plus 8 more (`agents/agent.go`, `agents/amp/detect.go`, `agents/amp/state.go`, `agents/claude/state.go`, `agents/registry.go`, `opencode/client.go`, `parser/message_parser.go`, `parser/parser.go`). Formatted all 12 — leaving 8 unformatted would leave the format gate red on arrival. None of the 8 extra files touch this repo's other in-flight work (`runs/`, `ui/src/fleet/`, `server/hosts.go`, `server/hosts_test.go`). All whitespace-only (verified with `git diff -w`).

2. **`go test -race ./...`** had **two** instances of the same bug, not one: `server/agents_test.go:90` (named in the issue) and an identical pattern in `server/runs_api_test.go` — both spawn an SSE handler in a goroutine that writes to an `httptest.ResponseRecorder` while the test polls the recorder's body concurrently. Fixed both with a shared `syncRecorder` test helper (mutex-guarded, unexported named field so stale direct `.Body`/`.Header()` access is a compile error, not a silent race).

3. **`golangci-lint run`** failed with 24 pre-existing `errcheck` findings (unchecked `fmt.Fprintf`/`Fprintln` returns across `hook/doctor.go`, `main.go`, `server/agents.go`, `server/runs_api.go` — the default `--max-same-issues` cap was hiding the true count behind what looked like 6) plus one real `staticcheck` S1011 in `hub/transcript.go`. Rather than hand-editing 24 call sites across 4 files — one of which (`server/runs_api.go`) is part of another in-flight workstream — added `.golangci.yml` restoring golangci-lint v1's default `std-error-handling` exclusion preset (empirically verified: 24 → 0), and fixed the one genuine staticcheck finding by hand.

## Deliberate policy choice: `.golangci.yml`

`.golangci.yml` isn't just a `gofmt`-style bugfix — it's a policy call, flagged explicitly so a reviewer doesn't have to infer it from the diff: **all future code in this repo also gets the `std-error-handling` exclusion** (unchecked `fmt.Fprint*`, `.*Close`, `.*Flush`, `os.Remove(All)?`, `os.(Un)?Setenv`), not just the 24 grandfathered call sites. This restores golangci-lint v1's default behavior (lost when the config moved to v2 schema) rather than introducing a new, stricter policy — but it's still a real, repo-wide relaxation and worth a second pair of eyes.

## CI was red on the first three pushes — root cause and fix

`TestControlManagerGetClient`, a real tmux integration test, failed on both jobs with `failed to create test session: exit status 1`. Two wrong turns before the real cause:

- First guess (wrong): tmux unavailable on the runner. Disproved by a diagnostic step — nix's devShell provides tmux fine, and a standalone `tmux new-session -d` in the same job exited 0.
- Second guess (wrong): CPU contention from `go test`'s per-package parallelism starving the tmux server spawn past its 5s command timeout. Disproved by the failure timing itself — it failed in **0.02s**, nowhere near a 5s timeout, so `-p 1` (serializing packages) didn't fix it either.
- **Actual root cause**, confirmed by reproducing on an isolated tmux socket locally: tmux's server auto-exits when its last session is killed (`exit-empty`). Each integration test creates and kills its own session; on a runner with no other tmux activity, the shared default server dies between tests, and the next test's `new-session` call races the dying server instead of starting fresh (`"server exited unexpectedly"`). This never reproduces on a dev machine because the person/agent running the tests is themselves inside a tmux session, which keeps the server's session count above zero throughout. Fix: start a session that outlives the whole test run before `go test` in both jobs.

## Known gap

Frontend `vitest` tests (`ui/src/hooks/useRuns.test.ts`, `ui/src/fleet/staleness.test.ts`) are not gated — outside this issue's stated gate table, and one lives under `ui/src/fleet/`, another workstream's territory. Follow-up: #23.

## Proof

This PR's own checks are the proof — see the `checks` and `race` jobs on this PR.

## Plan

Full plan and research notes: `docs/superpowers/plans/2026-09-08-ci-gates.md`.

https://claude.ai/code/session_01HEGyVviGuDHN2Ab4CGz5Mo
