### PR TITLE
fix(runs): derive Caps at composition time, evict finished crew runs

### DIFF
--- a/docs/superpowers/plans/2026-09-08-derive-caps-and-evict-finished-runs.md
+++ b/docs/superpowers/plans/2026-09-08-derive-caps-and-evict-finished-runs.md
@@ -1,0 +1,259 @@
+# Derive Caps at composition time and evict finished runs
+
+Closes #14. Scope: `runs/` only.
+
+## Defect 1 — Caps derived at composition time
+
+**Authoritative signal.** `TmuxSource` polls `ListPaneOptions` every tick (2s
+default) and emits `Gone` the instant a pane disappears from that poll — so the
+presence of a `"tmux"` entry in `composeLocked`'s `bySource` map for a key is
+ground truth for "a live pane exists right now." `HookSource` cannot answer
+this: it asserts `Caps` from a `TmuxPane` ref cached in hook state that
+survives the pane's death until the whole hub session ends.
+
+**Derivation rule**, computed in `composeLocked` from `bySource` (which
+sources are currently present for this key), not from any `Caps` field a
+source publishes:
+
+- `Terminal` = `"tmux"` layer present.
+- `Kill` = `"tmux"` layer present. There is no "crew kill" — killing requires
+  a pane.
+- `Reply` = `"tmux"` layer present **or** `"crew"` layer present. The `Caps`
+  doc comment already says "pane keys or `crew reply`" — a crew-managed run
+  can take a `crew reply` over the bus with no pane at all, and the `"crew"`
+  layer only exists for git-crew-bus-tracked branches, which is exactly
+  crew-reply-capable.
+
+This makes `Caps` layer-presence-derived, not OR-accumulated. Once derived
+this way, no source needs to assert `Caps` on its own `Delta.Run` at all —
+`hooksource.go`'s and `tmuxsource.go`'s per-layer `Caps` assignments become
+dead fields that nothing reads. Delete them rather than leave them as
+misleading dead weight (per repo convention: delete, don't preserve).
+
+### Steps
+
+- [ ] **Step 1: prove the bug** — add `TestCapsTerminalStaysTrueAfterTmuxLayerGoesGone`
+  and `TestCapsReplyRequiresLayerNotJustFlag` to `runs/registry_test.go`
+  against the **current** code. Run `go test ./runs/... -run TestCaps` and
+  confirm both fail (red) — capture the failure output.
+  - Test (a): `Apply` a `"tmux"` delta (`Run{Agent:"claude"}`) and a `"hooks"`
+    delta whose `Run.Caps = Caps{Terminal:true,Reply:true,Kill:true}` on the
+    same key (mirrors what `hooksource.go` sets today for a pane-backed
+    session). Assert `Snapshot()[0].Caps.Terminal` is true. Then `Apply` a
+    `"tmux"` `Gone` for that key. Assert the run is still listed (hooks layer
+    survives) but `Caps.Terminal` and `Caps.Kill` are now **false** — this is
+    the part that fails against current `mergeInto`, which keeps ORing the
+    hooks layer's stale `true`.
+  - Test (b): `Apply` only a `"crew"` delta on key `"branch/fix/1"`
+    (`Run{Agent:"claude", State: StateBlocked}`, no `Caps` set — matches what
+    `crewsource.go` publishes today). Assert `Caps.Reply` is **true** and
+    `Caps.Terminal`/`Caps.Kill` are false. Fails today because nothing ever
+    sets `Reply` true for a crew-only key.
+  **Note on test (a):** give the `"hooks"` delta `Agent: "claude"` too (not
+  just the tmux delta) — `listed()` is `r.Agent != ""`, so without it the run
+  is unlisted after `tmux` goes `Gone` and `Snapshot()` has nothing to assert
+  on.
+- [ ] **Step 1b: prove the broadcast half of the bug.** Add
+  `TestCapsTransitionIsBroadcast` to `runs/registry_test.go`: `Subscribe()`,
+  `Apply` a `"tmux"` delta and a `"hooks"` delta on the same key — both
+  carrying `Agent: "claude"`, and **deliberately no** `Issue`/`PR`/`Crew`/
+  `Activity.Task` on either, so no field other than `Caps` differs across the
+  transition — drain the resulting broadcast, then `Apply` the `"tmux"`
+  `Gone`. Assert a `Run` arrives on the subscriber channel with
+  `Caps.Terminal == false`. This must fail against current code even after
+  Step 2's `composeLocked` change alone, because `runSignature` doesn't
+  include `Caps` yet — nothing about this transition changes the signature,
+  so `Apply` never re-broadcasts and the subscriber sees nothing. That gap is
+  exactly acceptance criterion 1's "and that transition is broadcast to
+  subscribers."
+- [ ] **Step 2: implement the derivation.** In `runs/registry.go`:
+  - Add `func deriveCaps(bySource map[string]Run) Caps` next to
+    `composeLocked`, implementing the three rules above by checking key
+    presence in `bySource` (`_, hasTmux := bySource["tmux"]`, same for
+    `"crew"`).
+  - In `composeLocked`, after the merge loop, set `out.Caps =
+    deriveCaps(bySource)` (overwriting whatever the loop produced).
+  - Delete the `Caps` block from `mergeInto` (the three `if src.Caps.X`
+    lines) — `Caps` is no longer a merged field.
+  - In `runs/hooksource.go`, delete the `r.Caps = Caps{...}` line in
+    `runFromSessionView`.
+  - In `runs/tmuxsource.go`, delete the `Caps: Caps{...}` field from the
+    `Run{}` literal in `deltasFromTmux`.
+  - **In `runSignature` (registry.go:188-218), add `Caps` to the hashed
+    fields** (e.g. `b.WriteByte('|')` then the three bools formatted). Without
+    this, Step 1b's test stays red even after everything else is fixed —
+    `Caps` derives correctly but a change in it alone never triggers a
+    broadcast, which is precisely acceptance criterion 1's second half.
+  - Note for later readers: after this, a composed run can carry a non-nil
+    `Tmux` ref (from `hooksource.go`'s cached ref) alongside
+    `Caps.Terminal == false` — that's intended, `Caps` is the affordance
+    signal per the design doc, not `Tmux != nil`. Leave a short comment near
+    `deriveCaps` saying so, so the run-detail work (plan A) doesn't branch on
+    `run.Tmux` by mistake.
+- [ ] **Step 3: fix the fallout in existing tests.**
+  - `runs/registry_test.go`: `TestMergeIntoCoversEveryField` iterates every
+    `Run` field via reflection and fails if `mergeInto` leaves it zero. Add a
+    `case "Caps": continue` alongside the existing `"ID"`/`"Removed"` cases,
+    with a one-line comment: derived in `composeLocked`, not merged.
+  - `runs/hooksource_test.go`: `TestRunFromSessionViewKeysOnPane` (asserts
+    `r.Caps.Terminal`/`r.Caps.Reply` are true) and
+    `TestRunFromSessionViewFallsBackToSessionID` (asserts `r.Caps.Terminal` is
+    false) both test a field `runFromSessionView` no longer sets. Delete
+    those specific assertions (leave the rest of each test — `Tmux`,
+    `Agent`, key shape — intact). Caps behavior is now covered by the
+    registry-level tests from Steps 1/1b.
+- [ ] **Step 4: confirm green, then confirm the regression bites.** Run
+  `go test ./runs/...` — everything green, including the new tests. Then
+  temporarily re-introduce the `Caps` OR block in `mergeInto` (or comment out
+  the `out.Caps = deriveCaps(...)` line) **and** revert the `runSignature`
+  addition, and re-run `go test ./runs/... -run TestCaps` to confirm all three
+  new tests go red again. Revert back to the fix.
+
+## Defect 2 — evict finished crew-sourced runs
+
+**Rule.** Eviction is **state-based**, gated on the bus's own terminal status
+(`Run.State == StateDone || Run.State == StateFailed` — `FromCrewState` already
+maps `"done"`/`"failed"`/`"exited"` to these), **not** time-based on inactivity.
+A purely-quiet-but-still-`StateBlocked` run (waiting hours for a human) must
+never be evicted just because time passed — that's an explicit acceptance
+requirement, and a plain "no message in N minutes" rule would violate it.
+
+State-based with zero delay has its own problem: it would yank the "done" card
+out from under a human looking at it the instant the worker posts done. So:
+evict a terminal-state branch only once `now - Run.UpdatedAt` (already
+populated from the status record's `ts`) exceeds a grace period. Pick **10
+minutes** — long enough that a human glancing at Fleet right after a finish
+still sees it, short enough that the measured-live "10 of 21 runs were history"
+problem actually clears out during a normal session. (The hub's parallel
+precedent keeps ended sessions 24h; crew-sourced runs don't need that long
+because the PR/branch itself persists elsewhere — Fleet is not the only record
+of a finished run.)
+
+A terminal-state record with a missing/zero `ts` (the bus is shell-written;
+`deltasFromCrewLog` already tolerates torn lines) must not be treated as
+"infinitely old" — guard `UpdatedAt == 0` as not-yet-eligible, or a malformed
+line evicts a run instantly, bypassing the grace period entirely. A branch
+with only a `dispatch` record and no `status` record yet has `State == ""`
+and `UpdatedAt == 0` — falls under the same guard, never evicted, which is
+correct (nothing to evict). `StateReview` (`pr_open`) is deliberately **not**
+evicted under this rule — a human may still act on an open PR — so the
+"~10 of 21 were history" figure is expected to include some `review`-state
+runs that this change does not touch; that's a scope choice, not a gap.
+
+**Shape.** `CrewSource.Run()` currently loops `s.scan()` every tick and always
+emits `Delta{Run: r}` per branch — never `Gone`. `scan()` (`crewsource.go:63`)
+returns **nil** when `ListWindowOptions()` errors, indistinguishable from "no
+branches" — so naively diffing against `nil` would emit `Gone` for every
+crew-sourced run on one transient tmux hiccup, then have them reappear next
+tick. `TmuxSource.Run` already guards exactly this
+(`tmuxsource.go:53-55`: "A transient tmux error is not evidence that every
+pane vanished: skip the tick entirely rather than emitting `Gone` for
+everything seen") — `CrewSource` needs the same guard. Change `scan()`'s
+signature to report success:
+
+```go
+// scan returns ok=false when ListWindowOptions failed — a transient tmux
+// error, not evidence every crew-sourced branch vanished. The caller must
+// skip the tick entirely rather than diff against an empty map.
+func (s *CrewSource) scan() (branches map[string]Run, ok bool)
+```
+
+Extract a pure, directly testable tick function (mirrors the existing
+seen-map `Gone`-diffing pattern already used by `TmuxSource.Run` and
+`HookSource.Run`, and mirrors how `deltasFromCrewLog`/`deltasFromTmux` are
+already pure functions tested without goroutines or channels):
+
+```go
+// tickCrewDeltas computes this cycle's deltas from the branches scan()
+// currently sees, evicting anything whose bus status has been terminal for
+// longer than crewEvictionGrace. seen is the previous tick's emitted key set;
+// it returns the deltas to send and the new seen set.
+func tickCrewDeltas(current map[string]Run, seen map[string]bool, now time.Time) ([]Delta, map[string]bool)
+```
+
+### Steps
+
+- [ ] **Step 1: extract current behavior verbatim (no behavior change).**
+  Add `tickCrewDeltas` to `runs/crewsource.go` as a faithful transcription of
+  today's loop body (`crewsource.go:47-54`): for each `branch, r` in
+  `current`, emit `Delta{Source:"crew", Key:"branch/"+branch, Run:r}` and add
+  the key to the new seen set — **no eviction logic yet, no `Gone` emitted
+  for anything**. Change `CrewSource.Run()` to call this instead of its
+  inline loop, with `scan()` still returning a single map (defer the `ok`
+  signature change to Step 2b). This step changes no behavior; it only makes
+  the loop unit-testable. Run `go test ./runs/...` — everything still green,
+  same as before this step.
+- [ ] **Step 2: prove the bug** — add `TestTickCrewDeltasEvictsFinishedRunsAfterGrace`
+  to `runs/crewsource_test.go` against the extraction from Step 1: a branch
+  `StateDone` with `UpdatedAt` 30 minutes in the past, present in both
+  `current` and the incoming `seen` set. Assert the returned deltas contain
+  exactly one delta with `Gone == true`, `Key == "branch/fix/412"`, **and
+  `Source == "crew"` checked explicitly** (not a whole-struct compare) — and
+  that the key is absent from the returned seen set. The explicit `Source`
+  check matters: `Registry.Apply` deletes `r.layers[d.Key][d.Source]`, so a
+  delta with an empty `Source` deletes nothing and eviction would silently
+  no-op end to end while every test here still passed. **Confirm this
+  fails** against the Step-1 extraction — it does, for the real reason:
+  today's shape has no eviction concept at all, so it re-emits the branch
+  and never produces `Gone`. This is the actual defect-2 proof, not a
+  stand-in.
+- [ ] **Step 2b: implement eviction.**
+  - Add `const crewEvictionGrace = 10 * time.Minute` and
+    `func crewRunFinished(r Run, now time.Time) bool`: `false` if
+    `r.State` is not `StateDone`/`StateFailed`, `false` if `r.UpdatedAt == 0`
+    (malformed or dispatch-only record — never treat as eligible), otherwise
+    `now.Sub(time.Unix(r.UpdatedAt, 0)) > crewEvictionGrace`. Spell the
+    `time.Unix` conversion out explicitly — `Run.UpdatedAt` is unix
+    **seconds** (`crewsource.go:207`, `rec.TS / 1000`), so comparing it
+    directly against a `time.Duration` or against `now.Unix()` without the
+    conversion is the kind of off-by-1000× bug that would still pass every
+    test in this plan if written wrong.
+  - Update `tickCrewDeltas` to skip (no emit, not added to the new seen set)
+    any branch where `crewRunFinished(r, now)`; for every key in the old
+    `seen` not present in the new seen set (whether skipped for that reason
+    or simply absent from `current`), emit
+    `Delta{Source:"crew", Key:key, Gone:true}`.
+  - Change `scan()` to `(map[string]Run, bool)` per the signature above
+    (`ok=false` on `ListWindowOptions` error). In `CrewSource.Run()`, when
+    `ok` is false, skip the tick entirely — do not call `tickCrewDeltas`, do
+    not touch `seen`, matching `tmuxsource.go:53-55`'s guard exactly.
+- [ ] **Step 3: finish the regression tests.** Alongside the eviction test,
+  add:
+  - `TestTickCrewDeltasKeepsFreshlyFinishedRuns` — `StateDone`,
+    `UpdatedAt` a minute ago → still emitted, not evicted.
+  - `TestTickCrewDeltasNeverEvictsAQuietBlockedRun` — `StateBlocked`,
+    `UpdatedAt` 24h ago → still emitted, never evicted. This is the test that
+    directly encodes the "don't evict a human's blocked run" acceptance
+    requirement.
+  - `TestTickCrewDeltasKeepsADispatchedRunWithNoStatusYet` — a branch with
+    only a `dispatch`-shaped `Run{}` (`State == ""`, `UpdatedAt == 0`) → still
+    emitted, never evicted (guards the `UpdatedAt == 0` short-circuit against
+    a future refactor of `crewRunFinished`).
+  - A scan-failure test at the `CrewSource.Run()` level, or at minimum a
+    comment at the `ok` check in `Run()` citing the same rationale as
+    `tmuxsource.go:53`, if driving `Run()` itself proves impractical without
+    a fake tmux client (`CrewSource.client` is the concrete `*tmux.Client`,
+    unlike `TmuxSource`'s `lister` interface — do not introduce a new
+    interface seam for this task; a well-placed comment plus the `ok`-based
+    early-return is sufficient given the scope boundary).
+  Run `go test ./runs/...` and confirm all green.
+- [ ] **Step 4: confirm the regression bites.** Two separate mutations, since
+  one alone doesn't bite both new tests:
+  - Temporarily make `crewRunFinished` always return `false` → re-run →
+    confirm `TestTickCrewDeltasEvictsFinishedRunsAfterGrace` goes red (the
+    freshly-finished test stays green under this mutation — it asserts a
+    fresh `StateDone` run is *not* evicted, which is exactly what
+    always-`false` produces; that's expected, not a failure). Revert.
+  - Temporarily set `crewEvictionGrace = 0` → re-run → confirm
+    `TestTickCrewDeltasKeepsFreshlyFinishedRuns` goes red. Revert.
+  - Quiet-blocked and dispatch-only tests stay green under both mutations —
+    expected, not a failure; they exercise the state/UpdatedAt guards, not
+    the grace threshold.
+
+## Final verification
+
+- [ ] `go test ./runs/...`, `go vet ./...`, `gofmt -l runs/` all clean.
+- [ ] Skim `docs/superpowers/2026-09-08-state-of-play.md` "Decisions already
+  made" once more — confirm nothing here changes the `tmux → crew → hooks`
+  precedence order (it doesn't: that order still governs every other field;
+  `Caps` is simply no longer a field the merge loop touches at all).

--- a/runs/crewsource.go
+++ b/runs/crewsource.go
@@ -44,12 +44,21 @@ func (s *CrewSource) Run(ctx context.Context, out chan<- Delta) error {
 	t := time.NewTicker(s.every)
 	defer t.Stop()
 
+	seen := map[string]bool{}
 	for {
-		for branch, r := range s.scan() {
-			select {
-			case out <- Delta{Source: s.Name(), Key: "branch/" + branch, Run: r}:
-			case <-ctx.Done():
-				return ctx.Err()
+		current, ok := s.scan()
+		// A transient tmux error is not evidence that every crew-sourced
+		// branch vanished: skip the tick entirely rather than diffing
+		// against an empty map and emitting Gone for everything seen.
+		if ok {
+			deltas, newSeen := tickCrewDeltas(current, seen, time.Now())
+			seen = newSeen
+			for _, d := range deltas {
+				select {
+				case out <- d:
+				case <-ctx.Done():
+					return ctx.Err()
+				}
 			}
 		}
 		select {
@@ -60,11 +69,59 @@ func (s *CrewSource) Run(ctx context.Context, out chan<- Delta) error {
 	}
 }
 
-func (s *CrewSource) scan() map[string]Run {
+// crewEvictionGrace is how long a terminal-state run stays visible after its
+// last status update before CrewSource evicts it. Zero delay would yank the
+// "done" card out from under a human looking at it the instant a worker
+// posts done; 10 minutes is long enough to avoid that while still clearing
+// finished runs out during a normal session.
+const crewEvictionGrace = 10 * time.Minute
+
+// crewRunFinished reports whether r's bus status has been terminal for
+// longer than crewEvictionGrace. UpdatedAt == 0 covers both a malformed
+// status record and a dispatch-only branch with no status yet — neither is
+// eligible, since treating a zero timestamp as "infinitely old" would evict
+// instantly and bypass the grace period entirely.
+func crewRunFinished(r Run, now time.Time) bool {
+	if r.State != StateDone && r.State != StateFailed {
+		return false
+	}
+	if r.UpdatedAt == 0 {
+		return false
+	}
+	return now.Sub(time.Unix(r.UpdatedAt, 0)) > crewEvictionGrace
+}
+
+// tickCrewDeltas computes this cycle's deltas from the branches scan()
+// currently sees, evicting anything whose bus status has been terminal for
+// longer than crewEvictionGrace. seen is the previous tick's emitted key
+// set; it returns the deltas to send and the new seen set.
+func tickCrewDeltas(current map[string]Run, seen map[string]bool, now time.Time) ([]Delta, map[string]bool) {
+	var deltas []Delta
+	newSeen := map[string]bool{}
+	for branch, r := range current {
+		if crewRunFinished(r, now) {
+			continue
+		}
+		key := "branch/" + branch
+		deltas = append(deltas, Delta{Source: "crew", Key: key, Run: r})
+		newSeen[key] = true
+	}
+	for key := range seen {
+		if !newSeen[key] {
+			deltas = append(deltas, Delta{Source: "crew", Key: key, Gone: true})
+		}
+	}
+	return deltas, newSeen
+}
+
+// scan returns ok=false when ListWindowOptions failed — a transient tmux
+// error, not evidence every crew-sourced branch vanished. The caller must
+// skip the tick entirely rather than diff against an empty map.
+func (s *CrewSource) scan() (branches map[string]Run, ok bool) {
 	wins, err := s.client.ListWindowOptions()
 	if err != nil {
 		slog.Debug("crew source: list window options", "error", err)
-		return nil
+		return nil, false
 	}
 
 	roots := map[string]bool{}
@@ -78,7 +135,7 @@ func (s *CrewSource) scan() map[string]Run {
 	for repo := range roots {
 		rootList = append(rootList, repo)
 	}
-	return s.scanRoots(rootList)
+	return s.scanRoots(rootList), true
 }
 
 // scanRoots reads every root's crew bus and folds it into the latest state per

--- a/runs/crewsource_test.go
+++ b/runs/crewsource_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 const crewFixture = `{"ts":1000,"crew_id":"c1","kind":"dispatch","branch":"fix/412","title":"fix the ws drop","tier":"standard","engine":"claude","model":"sonnet","session":"houston"}
@@ -100,6 +101,83 @@ func TestScanFindsBusFromInsideAWorktree(t *testing.T) {
 	}
 	if r.State != StateBlocked || r.Question == nil {
 		t.Fatalf("got %+v, want a blocked run carrying its question", r)
+	}
+}
+
+func TestTickCrewDeltasEvictsFinishedRunsAfterGrace(t *testing.T) {
+	now := time.Now()
+	current := map[string]Run{
+		"fix/412": {Branch: "fix/412", State: StateDone, UpdatedAt: now.Add(-30 * time.Minute).Unix()},
+	}
+	seen := map[string]bool{"branch/fix/412": true}
+
+	deltas, newSeen := tickCrewDeltas(current, seen, now)
+
+	var gone []Delta
+	for _, d := range deltas {
+		if d.Gone {
+			gone = append(gone, d)
+		}
+	}
+	if len(gone) != 1 {
+		t.Fatalf("got %d Gone deltas, want exactly 1: %+v", len(gone), deltas)
+	}
+	if gone[0].Key != "branch/fix/412" {
+		t.Errorf("Gone delta Key = %q, want branch/fix/412", gone[0].Key)
+	}
+	if gone[0].Source != "crew" {
+		t.Errorf("Gone delta Source = %q, want crew — Registry.Apply deletes r.layers[key][Source], so an empty Source silently no-ops eviction", gone[0].Source)
+	}
+	if newSeen["branch/fix/412"] {
+		t.Error("branch/fix/412 still present in the new seen set, want evicted")
+	}
+}
+
+func TestTickCrewDeltasKeepsFreshlyFinishedRuns(t *testing.T) {
+	now := time.Now()
+	current := map[string]Run{
+		"fix/412": {Branch: "fix/412", State: StateDone, UpdatedAt: now.Add(-1 * time.Minute).Unix()},
+	}
+
+	deltas, newSeen := tickCrewDeltas(current, map[string]bool{}, now)
+
+	if len(deltas) != 1 || deltas[0].Gone {
+		t.Fatalf("deltas = %+v, want one non-Gone delta for a freshly finished run", deltas)
+	}
+	if !newSeen["branch/fix/412"] {
+		t.Error("branch/fix/412 missing from the new seen set, want present")
+	}
+}
+
+func TestTickCrewDeltasNeverEvictsAQuietBlockedRun(t *testing.T) {
+	now := time.Now()
+	current := map[string]Run{
+		"fix/412": {Branch: "fix/412", State: StateBlocked, UpdatedAt: now.Add(-24 * time.Hour).Unix()},
+	}
+
+	deltas, newSeen := tickCrewDeltas(current, map[string]bool{}, now)
+
+	if len(deltas) != 1 || deltas[0].Gone {
+		t.Fatalf("deltas = %+v, want one non-Gone delta — a quiet blocked run must never be evicted", deltas)
+	}
+	if !newSeen["branch/fix/412"] {
+		t.Error("branch/fix/412 missing from the new seen set, want present")
+	}
+}
+
+func TestTickCrewDeltasKeepsADispatchedRunWithNoStatusYet(t *testing.T) {
+	now := time.Now()
+	current := map[string]Run{
+		"fix/412": {Branch: "fix/412"},
+	}
+
+	deltas, newSeen := tickCrewDeltas(current, map[string]bool{}, now)
+
+	if len(deltas) != 1 || deltas[0].Gone {
+		t.Fatalf("deltas = %+v, want one non-Gone delta — a dispatch-only run has nothing to evict", deltas)
+	}
+	if !newSeen["branch/fix/412"] {
+		t.Error("branch/fix/412 missing from the new seen set, want present")
 	}
 }
 

--- a/runs/hooksource.go
+++ b/runs/hooksource.go
@@ -118,7 +118,6 @@ func runFromSessionView(v hub.SessionView) (string, Run) {
 		key = v.TmuxPane
 		win, _ := strconv.Atoi(v.TmuxWindow)
 		r.Tmux = &TmuxRef{Session: v.TmuxSession, Window: win, PaneID: v.TmuxPane}
-		r.Caps = Caps{Terminal: true, Reply: true, Kill: true}
 	}
 
 	if r.State == StateBlocked && v.LastMessage != "" {

--- a/runs/hooksource_test.go
+++ b/runs/hooksource_test.go
@@ -29,9 +29,6 @@ func TestRunFromSessionViewKeysOnPane(t *testing.T) {
 	if r.Agent != "claude" {
 		t.Errorf("Agent = %q, want claude", r.Agent)
 	}
-	if !r.Caps.Terminal || !r.Caps.Reply {
-		t.Errorf("Caps = %+v, want terminal and reply for a pane-backed run", r.Caps)
-	}
 }
 
 func TestRunFromSessionViewFallsBackToSessionID(t *testing.T) {
@@ -42,9 +39,6 @@ func TestRunFromSessionViewFallsBackToSessionID(t *testing.T) {
 	}
 	if r.Tmux != nil {
 		t.Errorf("TmuxRef = %+v, want nil without a pane", r.Tmux)
-	}
-	if r.Caps.Terminal {
-		t.Error("Caps.Terminal is true without a pane — there is nothing to attach to")
 	}
 }
 

--- a/runs/registry.go
+++ b/runs/registry.go
@@ -158,7 +158,26 @@ func (r *Registry) composeLocked(key string) (Run, bool) {
 		mergeInto(&out, bySource[name])
 	}
 	out.ID = idFor(key)
+	out.Caps = deriveCaps(bySource)
 	return out, true
+}
+
+// deriveCaps derives Caps from which layers are present for a key, not from
+// any Caps field a source publishes — only TmuxSource's poll is ground truth
+// for "a live pane exists right now," since it diffs against a fresh
+// ListPaneOptions call every tick and emits Gone the instant a pane
+// disappears, whereas HookSource asserts from a cached ref that can outlive
+// the pane it names. A composed run can still carry a non-nil Tmux ref
+// (hooksource.go's cached ref) alongside Caps.Terminal == false — that's
+// intended: Caps is the affordance signal, not Tmux != nil.
+func deriveCaps(bySource map[string]Run) Caps {
+	_, hasTmux := bySource["tmux"]
+	_, hasCrew := bySource["crew"]
+	return Caps{
+		Terminal: hasTmux,
+		Kill:     hasTmux,
+		Reply:    hasTmux || hasCrew,
+	}
 }
 
 // idFor derives a URL-path-safe Run.ID from a source's correlation key. The
@@ -214,6 +233,16 @@ func runSignature(r Run) string {
 	}
 	b.WriteByte('|')
 	b.WriteString(r.Activity.Tool + "," + r.Activity.Hint + "," + r.Activity.Message + "," + r.Activity.Task + "," + r.Activity.Preview)
+	b.WriteByte('|')
+	if r.Caps.Terminal {
+		b.WriteByte('T')
+	}
+	if r.Caps.Reply {
+		b.WriteByte('R')
+	}
+	if r.Caps.Kill {
+		b.WriteByte('K')
+	}
 	return b.String()
 }
 
@@ -288,15 +317,6 @@ func mergeInto(dst *Run, src Run) {
 	}
 	if src.Stale {
 		dst.Stale = true
-	}
-	if src.Caps.Terminal {
-		dst.Caps.Terminal = true
-	}
-	if src.Caps.Reply {
-		dst.Caps.Reply = true
-	}
-	if src.Caps.Kill {
-		dst.Caps.Kill = true
 	}
 }
 

--- a/runs/registry_test.go
+++ b/runs/registry_test.go
@@ -291,10 +291,87 @@ func TestMergeIntoCoversEveryField(t *testing.T) {
 			continue // set by composeLocked from the key, deliberately not merged
 		case "Removed":
 			continue // set only by the registry when broadcasting a removal, never by a source
+		case "Caps":
+			continue // derived in composeLocked from layer presence, not merged
 		}
 		if v.Field(i).IsZero() {
 			t.Errorf("mergeInto drops %s — it will never reach the API", tp.Field(i).Name)
 		}
+	}
+}
+
+func TestCapsTerminalGoesFalseAfterTmuxLayerGoesGone(t *testing.T) {
+	r := NewRegistry(DefaultOrder)
+	r.Apply(Delta{Source: "tmux", Key: "%1", Run: Run{Agent: "claude"}})
+	// Mirrors what hooksource.go sets today for a pane-backed session.
+	r.Apply(Delta{Source: "hooks", Key: "%1", Run: Run{
+		Agent: "claude",
+		Caps:  Caps{Terminal: true, Reply: true, Kill: true},
+	}})
+
+	if got := r.Snapshot(); len(got) != 1 || !got[0].Caps.Terminal {
+		t.Fatalf("Caps.Terminal = %+v, want true while the tmux layer is present", got)
+	}
+
+	r.Apply(Delta{Source: "tmux", Key: "%1", Gone: true})
+
+	got := r.Snapshot()
+	if len(got) != 1 {
+		t.Fatalf("%d runs after the tmux layer left, want 1 — the hooks layer survives", len(got))
+	}
+	if got[0].Caps.Terminal || got[0].Caps.Kill {
+		t.Errorf("Caps = %+v, want Terminal and Kill false once the tmux layer is gone", got[0].Caps)
+	}
+}
+
+func TestCapsReplyRequiresLayerNotJustFlag(t *testing.T) {
+	r := NewRegistry(DefaultOrder)
+	// Matches what crewsource.go publishes today: no Caps set on the delta.
+	r.Apply(Delta{Source: "crew", Key: "branch/fix/1", Run: Run{Agent: "claude", State: StateBlocked}})
+
+	got := r.Snapshot()
+	if len(got) != 1 {
+		t.Fatalf("%d runs, want 1", len(got))
+	}
+	if !got[0].Caps.Reply {
+		t.Error("Caps.Reply = false, want true — a crew layer can take a crew reply with no pane")
+	}
+	if got[0].Caps.Terminal || got[0].Caps.Kill {
+		t.Errorf("Caps = %+v, want Terminal and Kill false with no tmux layer", got[0].Caps)
+	}
+}
+
+func TestCapsTransitionIsBroadcast(t *testing.T) {
+	r := NewRegistry(DefaultOrder)
+	sub := r.Subscribe()
+	defer r.Unsubscribe(sub)
+
+	r.Apply(Delta{Source: "tmux", Key: "%1", Run: Run{Agent: "claude"}})
+	r.Apply(Delta{Source: "hooks", Key: "%1", Run: Run{
+		Agent: "claude",
+		Caps:  Caps{Terminal: true, Reply: true, Kill: true},
+	}})
+
+	// Drain whatever setup broadcasts fired (house style: non-blocking
+	// select/default, see TestRemovalFiresOnlyOnTheListedToUnlistedEdge).
+drain:
+	for {
+		select {
+		case <-sub:
+		default:
+			break drain
+		}
+	}
+
+	r.Apply(Delta{Source: "tmux", Key: "%1", Gone: true})
+
+	select {
+	case run := <-sub:
+		if run.Caps.Terminal {
+			t.Fatalf("got %+v, want Caps.Terminal false once the tmux layer is gone", run)
+		}
+	default:
+		t.Fatal("no broadcast when the tmux layer went gone — Caps must be part of the change signature")
 	}
 }
 

--- a/runs/tmuxsource.go
+++ b/runs/tmuxsource.go
@@ -105,7 +105,6 @@ func deltasFromTmux(wins []tmux.WindowOptions, panes []tmux.PaneOptions) []Delta
 			Worktree:  w.GitRoot,
 			Tmux:      &TmuxRef{Session: w.Session, Window: w.Window, PaneID: p.PaneID},
 			Activity:  Activity{Task: firstNonEmpty(p.ClaudeTask, w.Task)},
-			Caps:      Caps{Terminal: true, Reply: true, Kill: true},
 		}
 		// A pane is an agent run only once lazytmux reports a claude_status for
 		// it — an empty status means a shell, build or htop, and the enrichment


### PR DESCRIPTION
## Summary

Fixes two defects in the run registry documented in `docs/superpowers/2026-09-08-state-of-play.md` ("Known defects and follow-ups", items 1 and 2), per the binding design in `docs/superpowers/specs/2026-09-07-houston-overhaul-design.md`.

**Defect 1 — `Caps` staleness.** `mergeInto` OR-accumulated `Caps.Terminal`/`Reply`/`Kill` across layers and never cleared them, so once the hooks layer asserted `Terminal: true` from a cached `TmuxPane` ref, it stayed true even after the actual tmux pane died (the UI would offer an attach button for a dead pane). Fixed by deriving `Caps` in `composeLocked` from which layers are currently present for a key, rather than merging a bool field:
- `Terminal`/`Kill` = the `tmux` layer is present (only `TmuxSource`'s poll against a live `ListPaneOptions` is ground truth for "a pane exists right now"; there's no "crew kill").
- `Reply` = `tmux` layer present **or** `crew` layer present (a crew-managed run can take a `crew reply` over the bus with no pane at all).

`Caps` was also missing from `runSignature`, so even a correctly-derived `Terminal: false` would never have reached subscribers — added it there too, so the transition actually broadcasts.

**Defect 2 — nothing evicts finished runs.** `CrewSource` read an append-only bus log and never emitted `Gone`, so branches accumulated forever (measured live: 21 runs, ~10 history). Eviction is **state-based** on the bus's own terminal status (`done`/`failed`), not time-based on inactivity — a quiet-but-still-blocked run waiting on a human is never evicted just because time passed. A 10-minute grace period after the terminal status avoids yanking a "done" card out from under someone looking at it.

## Plan

See `docs/superpowers/plans/2026-09-08-derive-caps-and-evict-finished-runs.md` for the full plan (drafted and adversarially reviewed twice via `plan-critic` before implementation).

## Testing

Each defect has a regression test written and confirmed red against the unfixed code, then confirmed green after the fix, then confirmed red again after temporarily reverting the fix:
- `TestCapsTerminalGoesFalseAfterTmuxLayerGoesGone`, `TestCapsReplyRequiresLayerNotJustFlag`, `TestCapsTransitionIsBroadcast` (registry.go)
- `TestTickCrewDeltasEvictsFinishedRunsAfterGrace`, `TestTickCrewDeltasKeepsFreshlyFinishedRuns`, `TestTickCrewDeltasNeverEvictsAQuietBlockedRun`, `TestTickCrewDeltasKeepsADispatchedRunWithNoStatusYet` (crewsource.go)

`go test ./runs/...`, `go vet ./...`, and `gofmt -l runs/` are all clean.

Closes #14

https://claude.ai/code/session_01WvqjGccZVHswc7a3rHNbJ7