### PR TITLE
fix(ui): make the Mocha fleet shell notch-safe and AA-contrast-safe

### DIFF
--- a/docs/superpowers/plans/2026-09-08-verify-and-fix-mocha-fleet-shell.md
+++ b/docs/superpowers/plans/2026-09-08-verify-and-fix-mocha-fleet-shell.md
@@ -1,0 +1,195 @@
+# Verify and fix the Mocha fleet shell (#15)
+
+## Context
+
+`#/fleet` (PR #8) was built with no browser available, so its rendered result
+was never seen. This plan implements the fixes found by an actual browser
+verification pass (headless Firefox, mobile viewport 320/390/428px, against
+live production run data) of the six checks flagged in
+`docs/superpowers/2026-09-08-state-of-play.md` and `WORKER_TASK.md`.
+
+**Revision 1** (after `plan-critic`, verdict `revise`, 6 blocking findings —
+all independently re-verified against the actual code before incorporating):
+the original draft under-scoped the contrast fix (missed `.fleet-badge.quiet`
+on `--fill`, a worse surface than `--bg-raised`; wrongly cited `.fleet-classic`
+as failing when it doesn't; missed `.run-age`, which does), under-scoped the
+safe-area fix (bottom-only; `viewport-fit=cover` affects all four edges, and
+`.fleet-nav`'s sticky header would start rendering under the status bar/notch
+without a matching top inset), didn't flag that `viewport-fit=cover` in
+`ui/index.html` is global and the classic `/agents` `/panes` view has zero
+safe-area handling of its own, and the `:active` step as drafted would have
+shipped a real CSS specificity bug. All fixed below.
+
+**Revision 1 re-review** (verdict `accept`, with 3 implementation-time items
+and non-blocking notes, all adopted): the attention-dot and desktop-viewport
+evidence gaps were already covered by screenshots taken during verification
+(non-Fleet-tab screenshot for the dot; 1440×900 for desktop) — just needed to
+land in the PR body. Two real adoptions: `.fleet` itself (not just its header
+and tab bar) needs left/right safe-area insets for landscape/cutout devices;
+and `.fleet-badge.quiet`'s fix is better done by swapping its **background**
+from `--fill` to `--bg-raised` (keeping `color: var(--text-faint)`, now
+overlay2 after Step 3 → 5.81:1) rather than bumping its *text* to
+`--text-strong`, which would have made the "all quiet" badge render louder
+than the "N needs you" badge it replaces — the opposite of "quiet". Also
+adopted: `.run-chip`'s `--text-dim` on `--fill` has the identical 4.45:1
+near-miss as `.fleet-badge.quiet` did; fixed by bumping its `color` to
+`--text-strong` (a background swap doesn't work there — chips sit inside a
+`.run-card` whose own background is already `--bg-raised`, so swapping the
+chip to the same tone would make it blend invisibly into the card, losing
+the pill affordance).
+
+## Findings driving this plan
+
+1. Renders in Mocha — confirmed working, no fix.
+2. Attention dot position — confirmed fine at 320/390/428px, no fix.
+3. **`--text-faint` legibility — real defect, wider than first drafted.**
+   Exact WCAG contrast (sRGB relative luminance, computed and reconfirmed):
+
+   | surface | `--ctp-overlay1` (current) | `--ctp-overlay2` (candidate) |
+   |---|---|---|
+   | `--bg` (mantle, `.fleet-classic`'s effective ground) | 4.75:1 ✅ | 6.22:1 |
+   | `--bg-raised` (base — `.fleet-filters button`, `.run-age`) | 4.44:1 ❌ | 5.81:1 ✅ |
+   | `--bg-sunken` (crust) | 5.07:1 ✅ | 6.64:1 |
+   | `--fill`/`--line` (surface0 — **`.fleet-badge.quiet`**) | 3.40:1 ❌ | **4.45:1 ❌ (still fails, by 0.05)** |
+
+   So bumping the token alone fixes `.fleet-filters button` and `.run-age`,
+   but **not** `.fleet-badge.quiet` — the "all quiet" badge, which is the
+   default state whenever nothing needs attention (`FleetView.tsx` renders it
+   when `attentionCount === 0`), so it's a commonly-seen surface. `.fleet-classic`
+   was misdiagnosed in the first draft — it already passes (`background: none`
+   inside `.fleet-nav`, which composites to `--bg`), so it needs no change.
+4. Tap feedback — confirmed present on the primary surfaces (`run-card`,
+   filter buttons, tab bar). Minor gap: `.fleet-classic` / `.fleet-badge`
+   have no `:active` state, only `:focus-visible`.
+5. **Notched-phone tab bar — real defect, and the direct fix is incomplete
+   on its own.** `ui/index.html`'s viewport meta tag has no
+   `viewport-fit=cover`, so **every** `env(safe-area-inset-*)` in the app
+   resolves to `0px` regardless of device — confirmed by `rg` that the one
+   `env()` in the whole repo is `fleet.css:117`'s
+   `padding-bottom: env(safe-area-inset-bottom)` on `.shell-tabs`.
+   Adding `viewport-fit=cover` extends the layout into *all four* safe
+   areas, not just the bottom: without a matching top inset,
+   `.fleet-nav` (`position: sticky; top: 0`, the "Fleet" header) would start
+   rendering under the status bar/notch — trading a dead bottom pad for a
+   live top overlap. Also: `viewport-fit=cover` is a single global
+   `index.html` meta tag — it will affect the classic `/agents` `/panes`
+   view too (`App.tsx:174`, `height: '100dvh'`), which has **zero**
+   safe-area handling anywhere. That view is out of this task's declared
+   scope (`ui/src/fleet/` and `ui/src/theme/` only) and slated for deletion
+   in plan D, so this plan fixes the new shell fully and documents the old
+   view's exposure rather than silently expanding scope into `App.tsx` /
+   `MobileInputBar.tsx`.
+6. Stale-vs-fresh distinguishability — confirmed working and matches the
+   oracle, verified against live data (badge counted 4 fresh, "Needs you"
+   filter showed 8 total including 1h/2h/7h-old blocked runs); border color
+   difference (~53 RGB euclidean distance) confirmed visible in screenshots.
+
+## Steps
+
+- [ ] **Step 1: `viewport-fit=cover`** — add it to the `<meta
+  name="viewport">` `content` attribute in `ui/index.html` (append to the
+  existing `width=device-width, initial-scale=1.0, maximum-scale=1,
+  user-scalable=no` string). Only line that changes in this file.
+
+- [ ] **Step 2: full safe-area coverage for the new shell**, in
+  `ui/src/fleet/fleet.css`:
+  - `.fleet-nav` (currently `padding: 12px 14px;`, `position: sticky; top:
+    0`): change to inset-aware padding so the sticky header cannot render
+    under a notch/status bar or side cutout:
+    `padding: calc(12px + env(safe-area-inset-top)) calc(14px +
+    env(safe-area-inset-right)) 12px calc(14px + env(safe-area-inset-left));`
+  - `.shell-tabs` (currently only `padding-bottom:
+    env(safe-area-inset-bottom);`): add `padding-left:
+    env(safe-area-inset-left); padding-right: env(safe-area-inset-right);`
+    for landscape/rounded-corner devices.
+  - `.fleet` itself (`position: absolute; inset: 0`, the scrolling container
+    whose `.run-card`s carry only `margin: 0 10px`): add `padding-left:
+    env(safe-area-inset-left); padding-right: env(safe-area-inset-right);`
+    so cards don't clip under a landscape cutout — the header and tab bar
+    alone don't cover the scrolling content between them.
+
+- [ ] **Step 3: fix `--text-faint` contrast**, in `ui/src/theme/mocha.css`:
+  - Change `--text-faint: var(--ctp-overlay1);` to
+    `--text-faint: var(--ctp-overlay2);`.
+  - Rewrite the comment above it with the real, re-verified numbers: overlay1
+    fails AA (4.5:1) on `--bg-raised` (4.44:1); overlay2 clears every
+    background the token is actually used on (`--bg`/`--bg-raised`/
+    `--bg-sunken`, 5.81-6.64:1). Do not mention `--fill` in this comment —
+    after Step 4 swaps `.fleet-badge.quiet` to a `--bg-raised` background
+    instead of a text-color fix, no `--text-faint` consumer sits on `--fill`
+    any more, so the token alone genuinely covers everywhere it's used.
+  - Leave `--text-dim` alone even though it becomes the same literal value as
+    `--text-faint` — they stay distinct semantic aliases for distinct roles
+    (dim = subtitle text, faint = chrome labels), per the file's own stated
+    convention.
+
+- [ ] **Step 4: fix the surfaces the token bump doesn't reach**, in
+  `ui/src/fleet/fleet.css`:
+  - `.fleet-badge.quiet`: change `background` from `var(--fill)` to
+    `var(--bg-raised)` (keep `color: var(--text-faint)`, which is overlay2 →
+    5.81:1 after Step 3). A background swap, not a text-color swap, so the
+    "all quiet" state stays visually quieter than the red "N needs you"
+    badge it replaces.
+  - `.run-chip`: change `color` from `var(--text-dim)` to
+    `var(--text-strong)` (measured 7.10:1 on `--fill`; `--text-dim` is
+    overlay2, same 4.45:1 near-miss as the badge had). Background stays
+    `var(--fill)` here — chips sit inside `.run-card`, whose own background
+    is already `--bg-raised`, so swapping the chip to that same tone would
+    make it blend into the card instead of reading as a pill.
+
+- [ ] **Step 5: `:active` feedback for the two header buttons**, in
+  `ui/src/fleet/fleet.css` — add `.fleet-classic:active, .fleet-badge:active
+  { opacity: 0.7; }` near the existing `:active` rules. Use `opacity`, not a
+  `background` swap: `.fleet-badge.quiet` and default `.fleet-badge` share
+  selector specificity with a plain `:active` background rule, and source
+  order would make pressing the "all quiet" badge flash the wrong tint
+  (color-neutral `opacity` sidesteps that entirely and works identically for
+  both badge states).
+
+- [ ] **Step 6: rebuild and re-verify in the browser** — `cd ui && npm run
+  build`, restart `just dev` if needed, reload the app in the already-running
+  headless Firefox session at 390×844, and capture **after** screenshots for:
+  - `.fleet-filters` unselected buttons and `.run-age` (contrast fix)
+  - the "all quiet" `.fleet-badge` state (needs the badge count to be 0, or
+    inspect via devtools computed-style if live data has no quiet moment)
+  - `.fleet-nav` header padding is unchanged in a non-notched viewport (a
+    `calc(12px + 0px)` should render pixel-identical to before — confirms the
+    inset addition doesn't regress the common case)
+  - Note honestly in the PR body that the actual notch overlap can't be
+    shown in a plain browser viewport without device emulation with inset
+    values — cite the `viewport-fit=cover` + `env()` addition and the known
+    iOS Safari behavior rather than presenting a screenshot that can't exist
+  - pressing (or CSS-inspecting) `.fleet-classic` / `.fleet-badge` to confirm
+    the new `:active` opacity rule applies
+
+- [ ] **Step 7: verification gate** — `cd ui && npx tsc -b`, `npx eslint .`,
+  and `npm run build` must all pass. Then, because the entire reason this
+  task exists is that a previous session's CSS change silently failed to
+  ship:
+  - grep the rebuilt `ui/dist/assets/*.css` for the literal string
+    `--text-faint:` followed by `var(--ctp-overlay2)` — Vite does not
+    resolve custom-property indirection, so the bundle keeps the `var()`
+    reference, not a hex value; grepping for a hex string would false-negative.
+  - grep the rebuilt `ui/dist/index.html` for `viewport-fit=cover`.
+
+- [ ] **Step 8: PR body** — write up all six checks with evidence (screenshots
+  for the visual ones, the contrast numbers and the live-badge-vs-filter
+  counts for the numeric ones), before/after screenshots for every visual
+  change, a note on the classic-view safe-area exposure (Finding 5) with a
+  filed follow-up GitHub issue reference, and `Closes #15`.
+
+## Explicitly not doing
+
+- Not touching `.github/workflows/`, `server/`, `tmux/`, `runs/` (owned by
+  concurrent workers).
+- Not touching `App.tsx`, `MobileInputBar.tsx`, or any other classic-view
+  file to backfill safe-area handling there — out of declared scope
+  (`ui/src/fleet/` and `ui/src/theme/` only) and that view is slated for
+  deletion in plan D. Filing a GitHub issue instead, per the task's own
+  "too large to fix in scope" clause.
+- Not building the desktop shell (confirmed not broken; separate later plan).
+- Not starting the run detail view or mobile terminal rework (separate plan
+  A, per `docs/superpowers/2026-09-08-state-of-play.md`).
+- Not touching the attention-dot position, `--state-*` tokens, or the
+  fresh/stale staleness logic in `staleness.ts` — all independently verified
+  correct via live-data testing in a real browser.

--- a/ui/index.html
+++ b/ui/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1, user-scalable=no" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1, user-scalable=no, viewport-fit=cover" />
     <title>houston</title>
   </head>
   <body>

--- a/ui/src/fleet/fleet.css
+++ b/ui/src/fleet/fleet.css
@@ -7,6 +7,13 @@
   font-family: var(--font-ui);
   font-size: 14px;
   -webkit-tap-highlight-color: transparent;
+  /* Insets the run-card list; as a side effect also insets .fleet-nav's
+     content since it's a child. .fleet-nav's own background/border-bottom
+     are NOT full-bleed like .shell-tabs' — on a landscape/cutout device
+     they stop short of the true edge. Accepted: --bg and the nav's
+     92%-mix of --bg are nearly identical, so the delta is a border line. */
+  padding-left: env(safe-area-inset-left);
+  padding-right: env(safe-area-inset-right);
 }
 
 .fleet-nav {
@@ -16,7 +23,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 12px 14px;
+  padding: calc(12px + env(safe-area-inset-top)) 14px 12px;
   background: color-mix(in srgb, var(--bg) 92%, transparent);
   backdrop-filter: blur(12px);
   border-bottom: 1px solid var(--line);
@@ -34,7 +41,7 @@
   color: var(--state-blocked);
   border: 0; font-family: inherit; cursor: pointer;
 }
-.fleet-badge.quiet { background: var(--fill); color: var(--text-faint); }
+.fleet-badge.quiet { background: var(--bg-raised); color: var(--text-faint); }
 
 .fleet-filters { display: flex; gap: 4px; padding: 10px 12px 4px; }
 .fleet-filters button {
@@ -87,7 +94,7 @@
 .run-chips { display: flex; flex-wrap: wrap; gap: 5px; margin-top: 8px; }
 .run-chip {
   font-size: 11px; padding: 2.5px 7px; border-radius: 5px;
-  background: var(--fill); color: var(--text-dim);
+  background: var(--fill); color: var(--text-strong);
 }
 .run-chip.pr { background: color-mix(in srgb, var(--state-running) 18%, transparent); color: var(--state-running); }
 .run-chip.pr.failing { background: color-mix(in srgb, var(--state-blocked) 18%, transparent); color: var(--state-blocked); }
@@ -107,6 +114,11 @@
    still visibly registers. */
 .fleet-filters button:active { background: var(--line-strong); }
 .shell-tabs button:active { background: var(--fill); }
+/* opacity, not a background swap — .fleet-badge has a .quiet variant with
+   its own background, and a background :active rule would need to fight
+   that variant's specificity instead of just dimming either state. */
+.fleet-classic:active,
+.fleet-badge:active { opacity: 0.7; }
 
 .shell { position: absolute; inset: 0; display: flex; flex-direction: column; background: var(--bg); }
 .shell-body { flex: 1; position: relative; overflow: hidden; }
@@ -115,6 +127,8 @@
   display: flex; flex: none;
   background: var(--bg-sunken); border-top: 1px solid var(--line);
   padding-bottom: env(safe-area-inset-bottom);
+  padding-left: env(safe-area-inset-left);
+  padding-right: env(safe-area-inset-right);
 }
 .shell-tabs button {
   position: relative;

--- a/ui/src/theme/mocha.css
+++ b/ui/src/theme/mocha.css
@@ -36,10 +36,17 @@
   --text: var(--ctp-text);
   --text-strong: var(--ctp-subtext1);
   --text-dim: var(--ctp-overlay2);
-  /* overlay1, not overlay0 — overlay0 on the mantle ground is ~3.1:1, below
-     readable contrast for the 10-13px text (tab labels, ages, filters) that
-     use this token. */
-  --text-faint: var(--ctp-overlay1);
+  /* overlay2, not overlay1 or overlay0 — this token carries the smallest
+     text in the shell (tab labels, ages, filters), on whichever of --bg /
+     --bg-raised / --bg-sunken happens to be under it at rest, so it needs
+     headroom on the worst case, not just the best one. Measured (WCAG,
+     sRGB): overlay0 is 3.36-3.59:1 across those three, overlay1 is
+     4.44-5.07:1 (fails AA's 4.5:1 on --bg-raised), overlay2 is 5.81-6.64:1
+     on all three — clears AA on every resting background this token sits
+     on. (A couple of :active press states swap their background to --fill,
+     where overlay2 is still under 4.5:1 — untouched here since that's a
+     sub-200ms tap flash, not sustained reading.) */
+  --text-faint: var(--ctp-overlay2);
   --accent: var(--ctp-mauve);
 
   /* One colour per run state. blocked is the only "needs you" colour and must


### PR DESCRIPTION
## What this is

PR #8 shipped the Mocha fleet shell without a browser ever available — no
`$DISPLAY`, no automation. This session had `playwright`/`firefox-devtools`
MCP available and used it: ran `just dev`, opened `#/fleet` in a real
headless Firefox at mobile viewport (390×844, also spot-checked at 320×844
and 428×926) against this session's own **live production data** (the
dispatcher's actual running fleet, visible in the screenshots below), and
checked all six risks flagged in
`docs/superpowers/2026-09-08-state-of-play.md`.

**Screenshots:** GitHub's PR body can't embed local images here — this
repo's `.gitignore` explicitly excludes `*.png`/`*.jpeg` under a
`# Screenshots` comment, and `gh`'s CLI tooling has no supported path for
inline binary PR-body attachments (`gh gist create` rejects binary files
outright). All before/after screenshots were sent to you directly instead.

## The six checks

**1. Does it render in Mocha at all?**
Yes. `grep`ped the *built* bundle (not just the source import) — `ui/dist/assets/*.css`
contains the full `.mocha{...}` ruleset and every `--ctp-*` declaration.
Screenshot: `fleet-mobile-before.png`. No fix needed.

**2. The attention dot's position (`translate(14px,-10px)`, an admitted guess)**
Fine as shipped — no fix. Verified by switching to a non-Fleet tab (with a
fresh blocked run present) at 320px, 390px, and 428px viewport widths; the
dot renders consistently near the top-right of the Fleet tab's icon at all
three, because the tab button's content is centered by flexbox regardless of
button width, so the dot's absolute-position basis doesn't drift. Screenshot:
`attention-dot-before.png` (captured on the Crews tab, dot visible on Fleet).

**3. `--text-faint` legibility — real defect, fixed**
Computed exact WCAG contrast (sRGB relative luminance) for every background
the token is actually used against:

| surface | old (`--ctp-overlay1`) | new (`--ctp-overlay2`) |
|---|---|---|
| `--bg` (mantle) | 4.75:1 ✅ | 6.22:1 |
| `--bg-raised` (base — `.fleet-filters button`, `.run-age`) | **4.44:1 ❌** | 5.81:1 ✅ |
| `--bg-sunken` (crust) | 5.07:1 ✅ | 6.64:1 |
| `--fill` (surface0 — `.fleet-badge.quiet`, `.run-chip`) | 3.40:1 ❌ | 4.45:1 ❌ (still fails — fixed separately, see below) |

`--text-faint` was 4.44:1 on `--bg-raised` — just under WCAG AA's 4.5:1 for
normal text. Bumped the token to `--ctp-overlay2` (clears every background it
actually sits on at rest). The one background the token bump *doesn't* reach
(`--fill`) got two targeted fixes instead of pushing the shared token even
further (which would have muddied every other use of it):
- `.fleet-badge.quiet` (the "all quiet" badge): swapped its **background**
  from `--fill` to `--bg-raised`, not its text color — a text-color fix would
  have made the "all quiet" state render *louder* than the red "N needs you"
  badge it replaces.
- `.run-chip` (agent/issue labels): swapped its **color** to `--text-strong`
  (background swap doesn't work there — chips sit inside a `.run-card` whose
  own background is already `--bg-raised`, so matching that tone would make
  the chip blend invisibly into the card).

Screenshots: `fleet-mobile-before.png` vs `fleet-mobile-after.png` (filter
buttons and chip labels visibly brighter in the after shot).

**4. Does tapping feel alive?**
Mostly yes already — `.run-card:active`, `.fleet-filters button:active`, and
`.shell-tabs button:active` all had real `:active` rules. Real gap: the two
header buttons (`.fleet-classic`, `.fleet-badge`) had none, only
`:focus-visible`. Added `.fleet-classic:active, .fleet-badge:active { opacity:
0.7; }` — opacity rather than a background swap, because `.fleet-badge` has a
`.quiet` variant with its own background and a background `:active` rule
would need to win a specificity fight against it instead of just dimming
either state uniformly.

**5. The tab bar on a notched phone — real defect, fixed**
`ui/index.html`'s viewport meta tag had no `viewport-fit=cover`, so **every**
`env(safe-area-inset-*)` in the app silently resolved to `0px` regardless of
device — confirmed the only `env()` in the whole repo pre-fix was
`.shell-tabs`'s `padding-bottom`. Added `viewport-fit=cover`, plus matching
top/left/right insets (not just the pre-existing bottom one) to `.fleet-nav`
(the sticky header — without this it would start rendering under the status
bar/notch) and `.fleet` itself (the scrolling run-card list, for
landscape/cutout devices).

Can't screenshot an actual notch without device emulation, so the evidence
here is code-level: an independent subagent confirmed the rebuilt
`ui/dist/index.html` contains `viewport-fit=cover` and `ui/dist/assets/*.css`
has 6 `env(safe-area-inset-*)` usages across `.fleet`/`.fleet-nav`/`.shell-tabs`
(up from 1 before). Regression check: `header-regression-after.png` shows the
header's spacing is pixel-identical to before in this non-notched viewport
(`calc(12px + env(...))` correctly evaluates to `12px` when the inset is 0).

11px tab labels were also checked at mobile viewport and read fine — no
defect there.

*Known gap, filed separately, not fixed here:* `viewport-fit=cover` is a
single global meta tag — it also affects the classic `/agents`/`/panes`
view, which has **zero** safe-area handling of its own (`App.tsx`,
`MobileInputBar.tsx`). That's outside this task's declared scope
(`ui/src/fleet/` and `ui/src/theme/` only) and that view is slated for
deletion once plans A–C land. Filed as #18.

**6. Is a stale blocked run visually distinguishable from a fresh one?**
Yes, already correct — no fix needed, and it matches the oracle exactly.
Verified against **live data**: the header badge showed "4 needs you" (fresh
blocked runs only, via `needsYou()`/`isFresh()` in `staleness.ts`,
`FRESH_MS = 1h`), while the "Needs you" filter showed **8** runs total,
including ones blocked for 1h/2h/7h — the asymmetric rule from the design doc
(nothing blocked is ever hidden, only fresh ones count toward the badge).
`RunCard.tsx`'s muted-vs-bright attention border (`color-mix` at 45% vs 22%)
is a real, visible ~53-RGB-euclidean-distance difference, confirmed in a
side-by-side crop of a 4m-old vs 1h-old blocked card. Screenshot:
`needs-you-stale-vs-fresh-before.png`.

## Desktop viewport

Checked at 1440×900 — not broken, just not optimized (cards and the tab bar
stretch full-width), which is expected since the desktop shell is a separate
later plan. Screenshots: `desktop-check.png` / `desktop-after.png` (identical
— none of this PR's fixes change anything visible at this width, since every
`env()` inset resolves to `0` on a non-cutout device).

## Review

- `plan-critic` (fresh context): 1 revision round, `revise` → `accept`. Six
  blocking findings on the first pass, all independently re-verified against
  the code before incorporating (see the plan doc's revision history).
- `typescript-reviewer` (fresh context, independent of the plan/implementation
  context): **approve**, 2 findings (MEDIUM, LOW), both addressed —
  `.fleet-nav`'s chrome-bar edge-bleed tradeoff on landscape/cutout devices is
  now documented with a code comment rather than fixed with extra CSS
  (accepted, low visual impact — `--bg` and the nav's 92%-mix of `--bg` are
  nearly identical); the `mocha.css` token comment's "clears AA everywhere"
  claim was corrected to scope to resting backgrounds (a couple of `:active`
  states transiently use `--fill`, where overlay2 is still under 4.5:1 — a
  sub-200ms tap flash, not sustained reading, so left as-is).
- Independent test-runner (fresh context): confirmed `tsc -b`, `eslint .`,
  and `npm run build` all pass, and separately grepped the *rebuilt* bundle
  for both fixes (this task exists because a previous session's CSS change
  silently never shipped) — `--text-faint: var(--ctp-overlay2)` and
  `viewport-fit=cover` both confirmed present in `ui/dist`.

## Scope

Touched only `ui/index.html`, `ui/src/fleet/fleet.css`,
`ui/src/theme/mocha.css` — per the task boundary
(`.github/workflows/`, `server/`, `tmux/`, `runs/` untouched, owned by
concurrent workers). Did not start the run detail view or mobile terminal
rework (separate plan A). Did not build the desktop shell (separate plan C).

Closes #15

https://claude.ai/code/session_01L1SNSNzrF9FQRFNbkJH6Q8
