### PR TITLE
test(ui): add a DOM test utility and cover useRuns() lifecycle

### DIFF
--- a/docs/superpowers/plans/2026-09-08-dom-test-utility-useruns-lifecycle.md
+++ b/docs/superpowers/plans/2026-09-08-dom-test-utility-useruns-lifecycle.md
@@ -1,0 +1,190 @@
+# Plan: DOM test utility and useRuns() lifecycle coverage
+
+Closes #21.
+
+## Context
+
+`useRuns()` (`ui/src/hooks/useRuns.ts`) is the store the new fleet shell reads from.
+It has no lifecycle test today because the repo's vitest setup has no DOM — existing
+tests (`ui/src/fleet/staleness.test.ts`, `ui/src/hooks/useRuns.test.ts`) only exercise
+pure functions (`applyEvent`). The open question: does unmounting the hook close the
+`EventSource`? Reading the current source, the effect's cleanup already calls
+`es.close()` (`useRuns.ts:56`) — so no leak is expected, but nothing proves it, and the
+task explicitly asks us to prove the test bites by deleting that cleanup and watching
+the test go red.
+
+## Approach
+
+1. **DOM test utility: `happy-dom` + `@testing-library/react`.** Both jsdom and happy-dom
+   work for this use; happy-dom is the smaller footprint (no bundled native
+   dependencies, faster startup), so it wins per the task's tie-break instruction. We
+   install a fake `EventSource` regardless of which DOM library is picked — even if the
+   installed happy-dom version ships a native one, the test needs deterministic control
+   over connection lifecycle and event delivery that only a fake gives, so don't repeat
+   an "neither has EventSource" claim in the README/PR body without checking.
+   `@testing-library/react` gives `render`/`act`/`cleanup` for hook lifecycle testing
+   without hand-rolling a test harness component.
+2. **Add dependencies first.** Add `happy-dom` and `@testing-library/react` to
+   `ui/package.json` devDependencies (not `@testing-library/dom` explicitly — it's a
+   `peerDependency` of `@testing-library/react`, not a direct dependency; npm installs
+   it automatically, and adding an unused explicit devDep would contradict the "smaller
+   footprint" rationale — add it explicitly only if `npm install` or a lint rule
+   complains it's missing). Do not add `jsdom`. Run `npm install` in `ui/` now, before
+   writing any code that imports these packages (steps 4–6 below need them on disk to
+   typecheck/run) — `ui/package-lock.json` regenerates; it gets committed in step 9.
+3. **Wire into vitest.** `ui/vite.config.ts` is type-checked as part of
+   `tsconfig.node.json` (`"include": ["vite.config.ts"]`, `"types": ["node"]`, strict) —
+   Vite's `UserConfig` has no `test` property, so adding one under the current
+   `import { defineConfig } from 'vite'` fails `npx tsc -b` with an excess-property
+   error. Change the import to `import { defineConfig } from 'vitest/config'` (it
+   re-exports Vite's `defineConfig` with the `test` property merged in via module
+   augmentation) before adding the `test` block: `environment: 'happy-dom'`,
+   `globals: false` (keep explicit imports, matching existing test style). No
+   `setupFiles`/global `afterEach` — see step 5's explicit `cleanup` call instead. This
+   applies `happy-dom` globally, including to the two existing pure-logic suites
+   (`staleness.test.ts`, `useRuns.test.ts`); harmless, so don't scope it per-file.
+4. **Reusable fake `EventSource` helper** — new file `ui/src/testing/fakeEventSource.ts`.
+   Not inline in the test file per the task's explicit instruction (the future run-detail
+   view will reuse it for its own SSE hook). Shape:
+   - A class implementing enough of the `EventSource` surface for `useRuns()`:
+     `addEventListener`, `removeEventListener`, `close`, `onerror`, `readyState`, a
+     public `url` field captured from the constructor arg (needed for the "opened URL
+     is `/api/runs/stream`" assertion below), and a public `closed` boolean flipped by
+     `close()`. `erasableSyntaxOnly` (tsconfig.app.json) forbids constructor parameter
+     properties, so declare fields explicitly and assign in the constructor body;
+     `noUnusedParameters` means `removeEventListener(type, listener)` must actually
+     consult its params (a real per-type listener map, not a stub).
+   - A registry returned fresh from each `installFakeEventSource()` call (not a shared
+     module-level array) — otherwise `instances.length === 1`/`=== 2` assertions leak
+     state across tests. It records every instance constructed, so a test can assert
+     "exactly one EventSource was opened" and grab a handle to drive it:
+     - `instance.emit(type, payload)` — dispatches a `MessageEvent` to listeners
+       registered for `type` via `addEventListener`; `payload` is a plain JS value that
+       `emit` `JSON.stringify`s into `.data` itself (the hook does `JSON.parse(ev.data)`,
+       so `.data` must be a string — callers pass the object, not a pre-serialised
+       string).
+     - `instance.emitRaw(type, data)` — dispatches a `MessageEvent` with `.data` set to
+       the given string verbatim, no stringification. Needed for the malformed-JSON
+       test: `emit('update', 'not json')` would `JSON.stringify` to `'"not json"'`,
+       which **is** valid JSON and would parse without exercising the `catch` path at
+       all — `emitRaw('update', '{')` (or any non-JSON string) is what actually produces
+       an unparseable `.data`.
+     - `instance.open()` — dispatches the `open` event (`useRuns.ts:33` subscribes to
+       it; the fake's required surface must include it, not just `snapshot`/`update`).
+     - `instance.error()` — invokes `onerror` if set.
+     - `instance.close()` — sets `closed = true` (also called by real code via the
+       hook's cleanup).
+   - `installFakeEventSource()` returns `{ instances, uninstall }`; sets
+     `globalThis.EventSource = FakeEventSource as unknown as typeof EventSource` and
+     restores the original on `uninstall()`. Call `installFakeEventSource()` in
+     `beforeEach`; in `afterEach`, call `@testing-library/react`'s `cleanup()` (which
+     unmounts and runs the hook's real `close()` on the fake) **before** `uninstall()`,
+     so unmount-driven `close()` still lands on the fake instance and not the restored
+     original.
+5. **Lifecycle tests** — new file `ui/src/hooks/useRuns.lifecycle.test.ts` (kept separate
+   from the existing pure-logic `useRuns.test.ts` so the DOM-dependent suite is
+   distinguishable at a glance). Import `cleanup` from `@testing-library/react` and call
+   it explicitly in `afterEach` (RTL only auto-registers `afterEach(cleanup)` when a
+   global `afterEach` exists, which `globals: false` does not provide). Use a named
+   wrapper function for `renderHook`, not an anonymous arrow, to avoid tripping
+   `react-hooks/rules-of-hooks` under `eslint-plugin-react-hooks` (`ui/eslint.config.js`
+   extends its flat recommended config repo-wide): `renderHook(function useRunsProbe() {
+   return useRuns() })`.
+   - Mount opens exactly one `EventSource` (assert `instances.length === 1` after
+     `renderHook(...)`, and assert the URL is `/api/runs/stream`).
+   - Unmount closes it: capture the instance, `unmount()`, assert `instance.closed`.
+   - Remount after unmount opens a fresh connection: unmount, `renderHook` again,
+     assert `instances.length === 2` and the second instance is distinct from
+     (`!==`) and not closed like the first.
+   - Runs arriving over SSE land in the store and re-render consumers: inside `act()`,
+     call `instance.emit('snapshot', [run])`; after the `act()` call, assert
+     `result.current.runs` reflects it; inside another `act()`, `instance.emit('update',
+     run2)`; assert both present.
+   - SSE error/disconnect does not wedge the store: inside `act()`, `instance.open()`
+     (or emit a `snapshot`) and assert `connected === true` first — the error assertion
+     must observe a real true→false transition, not vacuously pass from `connected`'s
+     `false` initial state; then inside `act()`, `instance.error()` and assert
+     `connected === false`; then inside `act()`, emit a further `snapshot` (not
+     `update` — only the `snapshot` listener calls `setConnected(true)`, at
+     `useRuns.ts:39`) and assert both that `runs` updates *and* `connected` returns to
+     `true` (proves the listeners are still live post-error, not torn down).
+   - Malformed JSON on `snapshot`/`update` does not wedge the store either: use
+     `instance.emitRaw('update', '{')` (genuinely unparseable, not the `emit`
+     convenience — see step 4), assert the hook doesn't throw and a subsequent
+     well-formed `emit('update', run)` still updates `runs` (exercises the `catch`
+     blocks at `useRuns.ts:40,50`, otherwise dead code as far as tests are concerned).
+6. **Prove the tests bite** — one concrete break per test, run `npx vitest run`,
+   confirm red, revert, before moving to the next:
+   - mount-opens-one → temporarily duplicate the `new EventSource(...)` call inside the
+     effect at `useRuns.ts:31` so two instances open on a single mount. (Dropping the
+     `[]` dep array alone will *not* trip this: `renderHook` renders once and RTL
+     doesn't wrap in `StrictMode`, so the effect still only runs once either way — lead
+     with the duplicate-call break, skip the dep-array variant.)
+   - unmount-closes → delete `return () => es.close()` (line 56).
+   - remount-opens-fresh → hoist `es` to a **lazily-created** module-level `let es`
+     (assigned inside the effect on first use, reused across mounts) rather than one
+     constructed at module load — a singleton built at import time would call `new
+     EventSource(...)` the moment `useRuns.ts` is imported, including by
+     `useRuns.test.ts` (which installs no fake), turning that unrelated suite red too
+     and muddying the signal.
+   - SSE-events-land → make the `update` listener body a no-op (drop the `setRuns` call
+     at line 48).
+   - error-doesn't-wedge → delete `es.onerror = () => setConnected(false)` (line 54).
+   - malformed-JSON-doesn't-wedge → remove the `try/catch` around `JSON.parse` in the
+     `snapshot` or `update` listener so a malformed payload throws uncaught.
+   Record each break→red→revert cycle's outcome in the PR body.
+7. **Leak check.** Given the Context section's up-front read, no leak is expected — the existing
+   cleanup already closes the connection. If the lifecycle test *does* reveal a leak
+   once written (e.g. a race between rapid mount/unmount), fix `useRuns.ts` and call it
+   out prominently in the PR body per the task's instruction. This step is conditional
+   on what the test actually finds, not assumed work.
+8. **`ui/README.md`** — append a short "## Testing" section with one line documenting
+   the DOM test utility choice: "DOM tests use `happy-dom` + `@testing-library/react`
+   (see `ui/src/testing/fakeEventSource.ts` for a reusable fake `EventSource`)." Leave
+   the existing Vite boilerplate content untouched — out of scope.
+9. **Commit the regenerated lockfile.** `ui/package-lock.json` was regenerated by
+   step 2's `npm install`; stage and commit it alongside `ui/package.json`.
+10. **Update the pinned Nix hash.** `flake.nix:23` pins `npmDepsHash` for the
+   `buildNpmPackage` UI derivation (`let ui = pkgs.buildNpmPackage { ...; src = ./ui;
+   npmDepsHash = "..."; ... }` inside `perSystem`) against the lockfile; step 2's
+   dependency change invalidates it. Run `nix build .#default` (the only package
+   output — `packages.default`, per `flake.nix`'s `perSystem`; there is no separate
+   `.#ui` attribute), take the
+   `got: sha256-...` hash from the resulting mismatch error, and update `npmDepsHash` at
+   `flake.nix:23` to that value. This file is not on the task's do-not-touch list.
+11. **Verify acceptance gate.** Run `npx vitest run`, `npx tsc -b`, `npx eslint .`, and
+    `npm run build` (production build) in `ui/` — `npm run build` already runs `tsc -b`
+    per `ui/package.json`, so this also re-confirms typecheck. Additionally run
+    `nix build .#default` to confirm the updated `npmDepsHash` is correct and the flake
+    still builds clean from this branch.
+
+## Files touched
+
+- `ui/package.json` (devDependencies only)
+- `ui/package-lock.json` (regenerated by `npm install`)
+- `ui/vite.config.ts` (switch import to `vitest/config`, add `test` block)
+- `ui/src/testing/fakeEventSource.ts` (new)
+- `ui/src/hooks/useRuns.lifecycle.test.ts` (new)
+- `ui/README.md` (one line, new "## Testing" section)
+- `flake.nix` (`npmDepsHash` update, line 23)
+- `ui/src/hooks/useRuns.ts` (only if step 7's leak check finds something to fix)
+
+## Explicitly out of scope
+
+`.github/workflows/`, `ui/src/fleet/`, `ui/src/theme/`, `server/`, `runs/`, `tmux/`, the
+run detail view, the mobile terminal. `useRuns.test.ts` (existing pure-logic file)
+stays untouched — new DOM tests go in a separate file.
+
+## Acceptance criteria
+
+- [ ] `happy-dom` + `@testing-library/react` wired into vitest config.
+- [ ] One line in `ui/README.md` documenting the DOM test utility.
+- [ ] `ui/src/testing/fakeEventSource.ts` exists as a reusable fake, used by the new
+      lifecycle tests (and ready for future SSE-hook tests).
+- [ ] Lifecycle tests cover: single EventSource on mount, close on unmount, fresh
+      connection on remount, SSE events updating the store/re-rendering, error not
+      wedging the store, malformed JSON not wedging the store.
+- [ ] Each significant test's break→red→revert cycle documented in the PR body.
+- [ ] Any leak found is fixed and called out prominently in the PR body (conditional).
+- [ ] `npx vitest run`, `npx tsc -b`, `npx eslint .`, and the production build all pass.
+- [ ] `nix build .#default` passes with the updated `npmDepsHash`.

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
             pname = "houston-ui";
             version = "0.1.0";
             src = ./ui;
-            npmDepsHash = "sha256-NyflCfn5AlUeWGWXniENFt80ZXAZjejHXyZ/Ly1GGcA=";
+            npmDepsHash = "sha256-CfgjiYGIxYTrAaYBtGMEhiwzcCXJo7RiEAThX3Dn5Ng=";
             buildPhase = "npm run build";
             installPhase = "cp -r dist $out";
             dontNpmInstall = true;

--- a/ui/README.md
+++ b/ui/README.md
@@ -71,3 +71,7 @@ export default defineConfig([
   },
 ])
 ```
+
+## Testing
+
+DOM tests use `happy-dom` + `@testing-library/react` (see `ui/src/testing/fakeEventSource.ts` for a reusable fake `EventSource`).

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -18,6 +18,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
+        "@testing-library/react": "^16.3.0",
         "@types/node": "^24.10.15",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
@@ -26,6 +27,7 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
         "globals": "^16.5.0",
+        "happy-dom": "^18.0.1",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.48.0",
         "vite": "^7.3.1",
@@ -264,6 +266,16 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1372,6 +1384,63 @@
         "win32"
       ]
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.3.tgz",
+      "integrity": "sha512-Uo193NgQbPMz6lrrhtRQQFcMC6Re/ELLFbbuVL30WDlZxlpZf9/lMHTAVxPRLw1q1iu9OJmR1c2BLiENRstdBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1478,6 +1547,13 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.56.1",
@@ -1918,6 +1994,17 @@
         "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -1940,6 +2027,17 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -2160,6 +2258,25 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.302",
@@ -2590,6 +2707,38 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/happy-dom": {
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-18.0.1.tgz",
+      "integrity": "sha512-qn+rKOW7KWpVTtgIUi6RVmTBZJSe2k0Db0vh1f7CWrWclkkc7/Q+FrOfkZIb2eiErLyqu5AXEzE7XthO9JVxRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "whatwg-mimetype": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2820,6 +2969,17 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.2.3.tgz",
@@ -3039,6 +3199,36 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3069,6 +3259,14 @@
       "peerDependencies": {
         "react": "^19.2.4"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -3551,6 +3749,16 @@
         "vite": {
           "optional": false
         }
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/which": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
+    "@testing-library/react": "^16.3.0",
     "@types/node": "^24.10.15",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
@@ -29,6 +30,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
+    "happy-dom": "^18.0.1",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.48.0",
     "vite": "^7.3.1",

--- a/ui/src/hooks/useRuns.lifecycle.test.ts
+++ b/ui/src/hooks/useRuns.lifecycle.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { useRuns } from './useRuns'
+import { installFakeEventSource } from '../testing/fakeEventSource'
+import type { FakeEventSourceHandle } from '../testing/fakeEventSource'
+import type { Run } from '../api/runs'
+
+function run(id: string, p: Partial<Run> = {}): Run {
+  return {
+    id, agent: 'claude', state: 'running',
+    activity: {}, tokens: { input: 0, output: 0 },
+    caps: { terminal: true, reply: true, kill: true },
+    updated_at: 1000,
+    ...p,
+  } as Run
+}
+
+// Named (not anonymous) so eslint-plugin-react-hooks recognises this as a
+// custom hook rather than an arbitrary function calling a hook.
+function useRunsProbe() {
+  return useRuns()
+}
+
+let fake: FakeEventSourceHandle
+
+beforeEach(() => {
+  fake = installFakeEventSource()
+})
+
+afterEach(() => {
+  // Unmount (and run useRuns' real cleanup, against the fake) before
+  // restoring the original EventSource.
+  cleanup()
+  fake.uninstall()
+})
+
+describe('useRuns lifecycle', () => {
+  it('opens exactly one EventSource on mount, against /api/runs/stream', () => {
+    renderHook(useRunsProbe)
+    expect(fake.instances.length).toBe(1)
+    expect(fake.instances[0].url).toBe('/api/runs/stream')
+  })
+
+  it('closes the EventSource on unmount', () => {
+    const { unmount } = renderHook(useRunsProbe)
+    const instance = fake.instances[0]
+    unmount()
+    expect(instance.closed).toBe(true)
+  })
+
+  it('opens a fresh EventSource on remount after unmount', () => {
+    const first = renderHook(useRunsProbe)
+    const firstInstance = fake.instances[0]
+    first.unmount()
+
+    renderHook(useRunsProbe)
+
+    expect(fake.instances.length).toBe(2)
+    const secondInstance = fake.instances[1]
+    expect(secondInstance).not.toBe(firstInstance)
+    expect(secondInstance.closed).toBe(false)
+  })
+
+  it('lands runs arriving over SSE in the store', () => {
+    const { result } = renderHook(useRunsProbe)
+    const instance = fake.instances[0]
+    const r1 = run('pane-1')
+
+    act(() => {
+      instance.emit('snapshot', [r1])
+    })
+    expect(result.current.runs).toEqual([r1])
+
+    const r2 = run('pane-2')
+    act(() => {
+      instance.emit('update', r2)
+    })
+    expect(result.current.runs).toEqual([r1, r2])
+  })
+
+  it('does not wedge the store on SSE error/disconnect', () => {
+    const { result } = renderHook(useRunsProbe)
+    const instance = fake.instances[0]
+
+    act(() => {
+      instance.open()
+    })
+    expect(result.current.connected).toBe(true)
+
+    act(() => {
+      instance.error()
+    })
+    expect(result.current.connected).toBe(false)
+
+    const r1 = run('pane-1')
+    act(() => {
+      instance.emit('snapshot', [r1])
+    })
+    expect(result.current.runs).toEqual([r1])
+    expect(result.current.connected).toBe(true)
+  })
+
+  it('does not wedge the store on malformed JSON', () => {
+    const { result } = renderHook(useRunsProbe)
+    const instance = fake.instances[0]
+
+    expect(() => {
+      act(() => {
+        instance.emitRaw('update', '{')
+      })
+    }).not.toThrow()
+
+    const r1 = run('pane-1')
+    act(() => {
+      instance.emit('update', r1)
+    })
+    expect(result.current.runs).toEqual([r1])
+  })
+})

--- a/ui/src/testing/fakeEventSource.ts
+++ b/ui/src/testing/fakeEventSource.ts
@@ -1,0 +1,94 @@
+/**
+ * A minimal EventSource stand-in for tests that need deterministic control
+ * over connection lifecycle and event delivery — real EventSource has
+ * neither.
+ */
+
+type Listener = (ev: MessageEvent) => void
+
+export class FakeEventSource {
+  url: string
+  closed = false
+  readyState = 0
+  onerror: ((ev: Event) => void) | null = null
+
+  private listeners = new Map<string, Set<Listener>>()
+
+  constructor(url: string) {
+    this.url = url
+  }
+
+  addEventListener(type: string, listener: Listener): void {
+    let set = this.listeners.get(type)
+    if (!set) {
+      set = new Set()
+      this.listeners.set(type, set)
+    }
+    set.add(listener)
+  }
+
+  removeEventListener(type: string, listener: Listener): void {
+    this.listeners.get(type)?.delete(listener)
+  }
+
+  close(): void {
+    this.closed = true
+    this.readyState = 2
+  }
+
+  emit(type: string, payload: unknown): void {
+    this.dispatch(type, JSON.stringify(payload))
+  }
+
+  /** Unlike `emit`, sends `data` verbatim — for tests of malformed payloads,
+   * where stringifying a string would round-trip back into valid JSON. */
+  emitRaw(type: string, data: string): void {
+    this.dispatch(type, data)
+  }
+
+  open(): void {
+    this.readyState = 1
+    this.dispatch('open', '')
+  }
+
+  error(): void {
+    this.onerror?.(new Event('error'))
+  }
+
+  private dispatch(type: string, data: string): void {
+    const ev = new MessageEvent(type, { data })
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(ev)
+    }
+  }
+}
+
+export interface FakeEventSourceHandle {
+  instances: FakeEventSource[]
+  uninstall: () => void
+}
+
+/**
+ * Installs FakeEventSource as `globalThis.EventSource` and returns a handle
+ * with a fresh registry of every instance constructed while installed.
+ */
+export function installFakeEventSource(): FakeEventSourceHandle {
+  const instances: FakeEventSource[] = []
+  const original = globalThis.EventSource
+
+  class TrackedFakeEventSource extends FakeEventSource {
+    constructor(url: string) {
+      super(url)
+      instances.push(this)
+    }
+  }
+
+  globalThis.EventSource = TrackedFakeEventSource as unknown as typeof EventSource
+
+  return {
+    instances,
+    uninstall: () => {
+      globalThis.EventSource = original
+    },
+  }
+}

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 
 export default defineConfig({
@@ -15,5 +15,9 @@ export default defineConfig({
     outDir: 'dist',
     emptyOutDir: true,
     chunkSizeWarningLimit: 600,
+  },
+  test: {
+    environment: 'happy-dom',
+    globals: false,
   },
 })


### PR DESCRIPTION
## Summary

Adds a DOM test utility to the frontend vitest setup and covers the `useRuns()` store's lifecycle — specifically, whether unmounting closes the `EventSource`.

- **DOM test utility: `happy-dom` + `@testing-library/react`.** Both jsdom and happy-dom would work; happy-dom is the smaller footprint (no bundled native deps, faster startup), so it wins. `ui/vite.config.ts` switches its `defineConfig` import from `vite` to `vitest/config` (required — `vite.config.ts` is strictly type-checked via `tsconfig.node.json`, and Vite's own `UserConfig` has no `test` property) and adds a `happy-dom` environment.
- **Reusable fake `EventSource`** at `ui/src/testing/fakeEventSource.ts` — neither jsdom nor happy-dom's native `EventSource` (if any) gives deterministic control over connection lifecycle and event delivery, which the tests need. Not inline in the test file, since a future run-detail view's SSE hook will reuse it.
- **Lifecycle tests** at `ui/src/hooks/useRuns.lifecycle.test.ts`:
  - Mounting opens exactly one `EventSource`, against `/api/runs/stream`.
  - **Unmounting closes it** — the headline question.
  - A remount after unmount opens a fresh connection, not a closed one.
  - Runs arriving over SSE (`snapshot`/`update`) land in the store and re-render consumers.
  - An SSE error doesn't wedge the store (`connected` flips to `false` and back to `true` on the next `snapshot`, and `runs` keeps updating).
  - Malformed JSON on an `update` doesn't wedge the store either (the hook's existing `try/catch` is otherwise dead code as far as tests are concerned).
- One line added to `ui/README.md` under a new "## Testing" section.

## No leak found

Read `useRuns.ts` before writing any tests: its effect cleanup already calls `es.close()`. The lifecycle tests confirm this is correct — **`useRuns.ts` is untouched** in this PR.

## Prove the tests bite

Per the binding practice in `docs/superpowers/2026-09-08-state-of-play.md`, each test was demonstrated to fail against deliberately broken code, then reverted:

| Test | Break | Result |
|---|---|---|
| mount opens exactly one | Duplicated the `new EventSource(...)` call | `expected 2 to be 1` |
| **unmount closes it** | Deleted `return () => es.close()` | `expected false to be true` on `instance.closed`, isolated |
| remount opens fresh | Hoisted `es` to an import-time module-level singleton | `expected +0 to be 2` — no second instance ever opened |
| SSE events land in store | Made the `update` listener a no-op | Second run missing from `result.current.runs` |
| error doesn't wedge | Deleted `es.onerror = () => setConnected(false)` | `expected true to be false` on `connected` |
| malformed JSON doesn't wedge | Removed the `try/catch` around `JSON.parse` | Uncaught `SyntaxError` |

All six were independently re-verified during review (a fresh reviewer subagent and I each separately broke and reverted different tests off the pushed diff) — same isolated failures, clean reverts.

## Also touched: `flake.nix`

Adding `happy-dom` + `@testing-library/react` as devDependencies regenerated `ui/package-lock.json`, which invalidated the pinned `npmDepsHash` for the `buildNpmPackage` UI derivation in `flake.nix:23`. Updated it to match — `nix build .#default` passes clean. Not on the task's do-not-touch list; flagging here since another worker (#6, adding CI) may also touch this file and the hash bump could get lost in a rebase.

## Process notes

- Went through two rounds of adversarial plan review before implementation (both caught real issues: a `tsc -b`-breaking config mistake, the stale Nix hash, a vacuous assertion in the original error-test design, and an under-specified malformed-JSON test that as originally planned couldn't have failed).
- `npx vitest run` (18/18), `npx tsc -b`, `npx eslint .`, `npm run build`, and `nix build .#default` all pass clean.

Closes #21

https://claude.ai/code/session_017XWCevJ98fFhJzuftQcMFD