### PR TITLE
ci: gate the frontend vitest suite in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Frontend types
         run: nix develop -c bash -c 'cd ui && npx tsc -b'
 
+      - name: Frontend test
+        run: nix develop -c bash -c 'cd ui && npm test'
+
   race:
     runs-on: ubuntu-latest
     timeout-minutes: 20


### PR DESCRIPTION
## Summary
`ui/package.json` defines `\"test\": \"vitest run\"`, and the repo has real frontend tests, but nothing in `.github/workflows/` ran them — frontend regressions landed silently. Adds a "Frontend test" step to the existing `checks` job in `.github/workflows/ci.yml`, right after the existing "Frontend lint"/"Frontend types" steps, mirroring their style (`nix develop -c bash -c 'cd ui && ...'`).

No new job, no `actions/setup-node`/npm caching added — Node comes from the nix devshell like the other frontend steps, and `ui/node_modules` is already installed earlier in the same job by the `just build` step (`npm install --prefix ui`), so the new step just runs `npm test` against what's already there.

## Verification
- Ran `cd ui && npm test` locally on this branch: 8 files / 55 tests pass.
- Confirmed `npm test` exits non-zero: temporarily broke one assertion in `ui/src/api/runs.test.ts`, ran `npm test` (exit 1, test failure reported), then reverted — no broken assertion in this diff.
- Validated `.github/workflows/ci.yml` YAML via `yq` (actionlint isn't available in this devshell); confirmed the new step sits correctly inside the `checks` job's step list, before the `race:` job key.
- Independent review pass (yaml-reviewer): approved, no findings.

## Plan
Plan: task doc + a short reviewed plan (standard tier, `spec-plan-critic` plan-critic verdict: accept).

Closes #23

https://claude.ai/code/session_01UFYx58ZxBKgqaPxQ199i6s