### PR TITLE
feat(crews): crew grouping, branch-to-pane join, and answering a blocked worker

### DIFF
--- a/docs/superpowers/plans/2026-09-10-crews-tab-and-branch-pane-join.md
+++ b/docs/superpowers/plans/2026-09-10-crews-tab-and-branch-pane-join.md
@@ -1,0 +1,315 @@
+# Plan — Crews tab: crew grouping, branch→pane join, answering a blocked worker
+
+Issue #33. Spec: `docs/superpowers/specs/2026-09-10-crews-tab.md`.
+
+The work splits into eight components, referred to below as C1-C8: the crew-ref
+model (C1), registry composition (C2), crew bus semantics (C3), the branch-pane
+join (C4), the reply endpoint (C5), the run card (C6), the Crews tab (C7), and
+the integration gate (C8). `I1`-`I9` are the interfaces held stable across that
+split, each pinned inline in the step that owns it.
+
+Order: `C1 ∥ C3 ∥ C5 ∥ C6`, then `C1 → C2 → C4`, `C3 → C4`, `C6 → C7`, and
+`{C4, C5, C7} → C8`.
+
+Baseline before any step: Go build, vet and tests green; 61 UI tests green; the
+"before" evidence for criterion 1 already captured.
+
+Revised once after plan-critic. Six blocking findings, all verified in the code
+and all adopted: three sets of existing tests the plan changed in effect but never
+named, one step whose red-then-green proof cannot exist, and two acceptance
+criteria whose verification could not fail. Two components' owned criteria move as
+a result — the registry half of criterion 10 becomes C2's, and criterion 20 gains
+a test step in C7. One boundary is widened deliberately and said so in the open:
+C1 also touches `runs/tmuxsource_test.go`, because C1's own change is what turns
+that test red.
+
+## C1 — crew-ref model and the worker's colour
+
+- [ ] **Step 1: harvest `@crew_color`.** In `tmux/options.go` add `#{@crew_color}`
+      to `windowOptionsFormat`, a `CrewColor` field to `WindowOptions`, and move
+      `ParseWindowOptions`'s field count 11 → 12. Update the three existing cases
+      in `tmux/options_test.go` to the new width and assert `CrewColor` on the
+      enriched row. Append `#{@crew_color}` **last**, as index 11, so every
+      existing field index in `ParseWindowOptions` stays put and only the trailing
+      separator changes in the four fixture lines.
+- [ ] **Step 2: `tmuxColorToHex`.** New `runs/color.go`. `colour168` → `#d75f87`
+      by the standard xterm cube (16–231) and greyscale (232–255) formulas;
+      `#rrggbb` passes through; `colour0`–`colour15`, a colour name, `default`,
+      empty and anything unparseable → `""`. Comment states why 0–15 are excluded
+      (terminal-theme-dependent, and crew's own palette starts at `colour25`) —
+      that reason must be true, not plausible. `runs/color_test.go` covers every
+      branch including `colour16`, `colour231`, `colour232`, `colour255`.
+- [ ] **Step 3: split `CrewRef`.** In `runs/run.go` apply `I1`'s struct verbatim,
+      including the doc comments saying which source owns each field and that
+      `Name` keeps its non-`omitempty` tag. In `runs/tmuxsource.go` change only the
+      `r.Crew = …` assignment to `&CrewRef{Codename: w.CrewName, Color:
+      tmuxColorToHex(w.CrewColor)}` — `Name` is no longer tmux's to set. Keep the
+      existing `if w.CrewName != ""` guard, so a window with a colour but no
+      codename still publishes no `Crew` — lazytmux writes the pair together, and
+      that guard is what keeps `TestDeltasFromTmuxOmitsAbsentEnrichment` true.
+- [ ] **Step 3a: fix the test this breaks.** `runs/tmuxsource_test.go:42` asserts
+      `Crew.Name == "mauve"`, which is exactly the meaning Step 3 removes. Add
+      `CrewColor: "colour168"` to the window fixture and assert
+      `Crew.Codename == "mauve"`, `Crew.Name == ""` and `Crew.Color == "#d75f87"`.
+      **This widens C1's boundary** to `runs/tmuxsource_test.go`, which its
+      `may touch` list omits: C1's own change is what turns the test red, so no
+      other component can own the fix without inheriting a broken build.
+- [ ] **Step 4: verify C1.** `go build ./...`, `go vet`, `go test ./runs/... ./tmux/...`.
+
+## C3 — what the bus says about a branch
+
+- [ ] **Step 5: make reply records readable.** In `runs/crewsource.go` change
+      `crewRecord.Body` to `json.RawMessage` and decode it into the status struct
+      only when `Kind == "status"`; add `To string \`json:"to"\``. Verified live:
+      a `msg` body is a JSON string while a status body is an object, so today's
+      struct fails to unmarshal every reply line and `deltasFromCrewLog` skips it
+      whole — which is why replies are invisible.
+      **This change is not observable on its own.** A dispatcher `msg` carries
+      `from: "dispatcher:…"`, so `branchFromWorker` returns `""` and
+      `deltasFromCrewLog` skips the record after the fix exactly as it did before;
+      the returned map is byte-identical. Do not try to write a red test here. The
+      first observable consequence is Step 7, and that is where the red-then-green
+      demonstration belongs.
+- [ ] **Step 6: a detailless `blocked` still carries a question.** Add a package
+      const for the wording (houston's own description, never a quote) and set it
+      when a `blocked` status has an empty detail, with `Via: "crew"`. Test both
+      the detailed and detailless cases.
+- [ ] **Step 7: retire an answered question.** Per `I5`: if a branch's latest
+      status is `blocked` at `T` and a `kind: "msg"` record from a `dispatcher:`
+      sender whose `branchFromWorker(To)` is that branch has `TS > T`, publish
+      `State == ""` and `Question == nil`, keeping `Branch`, `Crew` and `Agent`.
+      Order within the log is by `ts`, not by line order. Tests: answered,
+      unanswered, reply older than the block, reply addressed to a different
+      branch, and a reply from a non-dispatcher sender.
+      The early guard is in the way and must be restructured: today a record whose
+      branch resolves to neither `rec.Branch` nor `branchFromWorker(rec.From)` is
+      `continue`d, which drops a dispatcher reply even after the `Body` fix. A
+      `kind: "msg"` record from a `dispatcher:` sender resolves its branch from
+      `To` instead.
+      This step carries the proof for Step 5 as well:
+      `TestDeltasFromCrewLogRetiresAnAnsweredQuestion` must be red before the
+      `Body`/`To` change (composing `blocked`, question intact) and green after.
+      A bus holds a single shared `events.jsonl` rather than one file per crew, so
+      a reply and its blocking status are always in the same file and `scanRoots`'
+      per-file fold cannot separate them. Confirm, but do not be surprised.
+- [ ] **Step 8: verify C3.** `go test ./runs/...`; then prove Steps 6 and 7 bite by
+      reverting each in turn and watching its test go red.
+
+## C5 — the reply endpoint (security-sensitive)
+
+- [ ] **Step 9: the runner seam** (implement: opus). New `server/runs_reply.go`
+      with `replyExec`, `replyResult` and `replyRunner` exactly as `I4` fixes them,
+      plus the real `execCrewReply`: `exec.CommandContext` with argv
+      `{"crew","reply","worker:"+branch,text}` — an argv slice, never a shell, and
+      **no `--`**, because `crew reply` takes its operands positionally and would
+      consume `--` as the recipient (verified). `Dir` is the run's `Worktree`;
+      `Env` is `os.Environ()` plus `CREW_ID=<Crew.Name>`. Add the `replyRunner`
+      field to `Server` and default it in `New`.
+- [ ] **Step 10: the handler** (implement: opus). `handleRunReply` resolves the run
+      from `s.runs.Snapshot()` by `{id}` — never from a client-supplied branch or
+      path — then checks every precondition in `I3`'s table and returns 4xx
+      **before** touching the runner: unknown id, no `Crew`/`Branch`/`Worktree`,
+      `Question` nil or `Via != "crew"`, empty text. Body is bounded by
+      `http.MaxBytesReader` and text by `maxReplyText`; the command by
+      `replyTimeout`. Map outcomes to 204/400/404/409/413/502/504 exactly as `I3`
+      says, with crew's stderr verbatim on 409. Log run id, branch and outcome.
+- [ ] **Step 11: register it** (implement: opus). One line in `server/server.go`:
+      `apiMux.HandleFunc("POST /api/runs/{id}/reply", s.handleRunReply)` — on
+      `apiMux`, so it inherits the token, origin and `Host` gates unchanged, and a
+      `GET` is refused by the mux before reaching the handler.
+- [ ] **Step 12: prove the gates hold** (implement: opus). Through `s.Handler()`,
+      not the handler directly: unauthenticated → 401, cross-origin → 403, rebound
+      `Host` → 421, `GET` → not 2xx — each asserting the stub recorded **zero**
+      invocations. This is the falsifiable question that caught a critical hole
+      last time: is there a residual path to a state change without a valid token?
+- [ ] **Step 13: prove the argv is literal** (implement: opus). A stub capturing
+      `replyExec`: an answer containing `; rm -rf /`, backticks, `$(…)` and a
+      leading dash arrives as exactly one argv element, with the recipient still
+      `worker:<branch>`. Plus each outcome row of `I3` and the precondition
+      refusals, all asserting call counts. Drive these through `s.Handler()`, or
+      call `req.SetPathValue("id", …)`: a request built by `httptest.NewRequest`
+      and handed straight to the handler has no path value, so `PathValue("id")`
+      is `""` and every case returns 404 for the wrong reason.
+- [ ] **Step 14: end to end against the real `crew`** (implement: opus). New
+      `server/runs_reply_e2e_test.go`, skipping with an explicit message when
+      `crew` is not on `PATH`. A scratch git repo with its own bus and a live
+      blocked worker, driven through the handler with the real runner: the answer
+      lands on that bus addressed to that worker and no other bus is touched. A
+      second case with a terminal session returns 409 carrying crew's own refusal
+      text. This is the only test that can falsify the working-directory and
+      `CREW_ID` choices.
+
+## C2 — registry composition
+
+- [ ] **Step 15: field-wise `CrewRef` merge.** In `mergeInto`, allocate `dst.Crew`
+      on the first non-nil `src.Crew` and copy `Name`, `Codename`, `Color`, `Tier`
+      individually when non-empty. Every other pointer ref stays wholesale. Update
+      `TestPointerRefsReplaceWholesale`, whose comment names `Crew` as
+      wholesale-owned — that stops being true and the comment must not outlive it.
+- [ ] **Step 16: signature fields.** Add `Crew.Codename`, `Crew.Color` and
+      `Question.Via` to `runSignature`. Without this a change to any of them never
+      reaches a subscriber — the defect class the state-of-play records for `Caps`.
+- [ ] **Step 17: the `Question ⇒ blocked` invariant.** In `composeLocked`, after
+      merging: a non-nil `Question` forces `State = StateBlocked`. Derived at
+      composition time in one place, exactly as `deriveCaps` is. Precedence is
+      untouched — `TestCrewBeatsTmuxButNotHooks` still passes, because its crew
+      layer carries no `Question`, and the comment must say so.
+- [ ] **Step 18: the `crew/` id.** `idFor` gains the `crew/` case from `I2` and
+      drops `branch/`, which no source emits after C4. The test that actually goes
+      red is `TestIdForIsURLPathSafe` (`runs/registry_test.go:194`), whose table
+      asserts `idFor("branch/fix/412") == "branch-" + base64url("fix/412")`.
+      Replace that row with
+      `{"crew/" + busDir + "/fix/412", "crew-" + base64.RawURLEncoding.EncodeToString([]byte(busDir + "/fix/412"))}`,
+      keeping the `%307` and `claude/` rows and the path-safety assertion.
+      `TestCapsReplyRequiresLayerNotJustFlag` (which keys on `branch/fix/1`) and
+      `TestPointerRefsReplaceWholesale` (whose comment calls `Crew` wholesale-owned)
+      both still pass — they are comment and key hygiene, not failures, and are
+      updated so neither outlives the truth it states.
+- [ ] **Step 18a: the composition half of criterion 10.** In
+      `runs/registry_test.go`, compose tmux(`%1`, agent + running) + hooks(`%1`,
+      tool-running) + crew(`%1`, `State: ""`, `Question: nil`) and assert the
+      snapshot run is `running` with no question; contrast with the same layers
+      where the crew layer still carries its question, which must compose as
+      `blocked`. This is the half that shows the badge actually goes dark once a
+      question is answered — the regression R5 exists to prevent — and C3 cannot
+      own it, because its boundaries forbid `runs/registry.go`.
+- [ ] **Step 19: prove Steps 15–17 bite.** Revert each in turn and watch its test go
+      red; a test that passes against the bug proves nothing.
+
+## C4 — the branch↔pane join (widest blast radius)
+
+- [ ] **Step 20: share the tmux index** (implement: opus). Extract
+      `deltasFromTmux`'s inline `byTarget` map into `windowsByTarget` per `I6` and
+      use it in both sources. Narrow `CrewSource.client` from `*tmux.Client` to the
+      existing `lister` interface — `*tmux.Client` still satisfies it, so
+      `server.go`'s call site does not change — which is what makes the join
+      fakeable in tests.
+- [ ] **Step 21: the pure resolution function** (implement: opus). `resolvePane`
+      per `I6`, returning the pane id and the candidate count. A candidate is a pane
+      whose window's `@branch` matches, whose window's `@git_root` maps to the same
+      bus, and whose `@claude_status` is non-empty — that last clause is
+      `TmuxSource`'s own test for an agent pane, and without it a crew layer would
+      promote a shell into a listed run. Exactly one candidate joins. Tests: one,
+      zero, two, a shell-only window, and two buses sharing a branch name.
+- [ ] **Step 22: group the scan by bus** (implement: opus). `scanRoots` returns
+      `busDir → branch → Run` instead of folding every root into one map, so two
+      repos holding a `main` record no longer collide. `scan` builds the window and
+      pane lists once and passes them down; a tmux error on **either** query skips
+      the whole tick, as today.
+- [ ] **Step 23: publish under the resolved key and carry `Worktree`**
+      (implement: opus). For each `(bus, branch)`: key on the pane id when exactly
+      one candidate exists, otherwise `crew/<bus>/<branch>`; `Worktree` is the
+      lexicographically smallest `@git_root` among windows on that branch in that
+      bus, or `""`. No fallback root when no window matches — an unmatched branch
+      is refused a reply rather than handed another worker's checkout, which since
+      `WORKER_TASK.md` outranks `CREW_ID` (measured) would execute under the wrong
+      crew id. `slog.Debug` records bus, branch and candidate count so the
+      no-join path is observable. `tickCrewDeltas` keeps emitting all updates
+      before all `Gone`s; add a test pinning that order and the resulting
+      `Removed` payload.
+- [ ] **Step 23a: migrate the five existing crewsource tests** (implement: opus).
+      These break on signature, not assertion, so the package test build dies until
+      they move:
+      - `TestScanFindsBusFromInsideAWorktree:96` calls `s.scanRoots([]string{wt})`
+        and indexes `got["feat/x"]`. `scanRoots` now returns `busDir → branch → Run`,
+        so index `got[busDir]["feat/x"]` and assert the bus key is the main
+        checkout's `crewDir`. This is a **compile error** first, not a red assertion.
+      - `TestTickCrewDeltasEvictsFinishedRunsAfterGrace:107`,
+        `…KeepsFreshlyFinishedRuns:136`, `…NeverEvictsAQuietBlockedRun:152` and
+        `…KeepsADispatchedRunWithNoStatusYet:168` key `current` by bare branch
+        and expect `branch/fix/412`. `tickCrewDeltas` now receives final registry
+        keys, so key the fixtures by the resolved key — `%307` for a joined case,
+        `crew/<bus>/fix/412` for an unjoined one — and assert the `Gone` key comes
+        back verbatim. Only the `scanRoots` test is a compile error (and it has a
+        second one: `keysOf(got)` at `:100` takes `map[string]Run`); the tick tests
+        break on assertions, and the eviction one may pass unchanged. Migrate all
+        five anyway, but do not use "the build is red" as the signal for the four.
+- [ ] **Step 24: verify C4.** `go test ./runs/...`. Confirm criterion 5 by
+      asserting a shell-only pane never becomes a listed run; criterion 11 by
+      asserting `Worktree` equals the matching window's `@git_root` on a joined key
+      and `""` with no matching window, since that string becomes a command's
+      working directory; and criterion 3's second half by asserting two
+      `crew/<bus>/main` layers from different buses coexist as two runs in
+      `Registry.Snapshot()`.
+
+## C6 — the card shows the worker
+
+- [ ] **Step 25: TS mirror.** Add `codename` to `CrewRef` in `ui/src/api/runs.ts`
+      per `I1`, with the comment that `name` is `''` — not `undefined` — when only
+      tmux knows the run.
+- [ ] **Step 26: `RunCard`.** Show `crew.codename` in place of today's crew-id
+      chip, add a tier chip when `crew.tier` is set, and set
+      `style={{ ['--run-accent']: run.crew.color }}` only when `crew.color` is
+      non-empty, written once, as
+      `style={{ '--run-accent': run.crew.color } as React.CSSProperties}` —
+      `React.CSSProperties` has no index signature, so an unasserted custom
+      property fails `tsc -b`, and the literal `--run-accent` must survive into the
+      bundle for Step 33's grep. In `fleet.css` add `.run-chip.tier`,
+      `.run-chip.codename` and a `.run-card` rule consuming `var(--run-accent, …)`
+      — those two class literals are what Step 33 greps for, so spell them exactly.
+      An accented card that is also `.attention` must still show the attention
+      border; the accent may not replace it. New `RunCard.test.tsx` covers all four.
+      While here, note in `ui/src/api/runs.ts` that `RunState` can now be `''` on
+      the wire, since R5 makes a crew layer publish no state opinion; runtime
+      already tolerates it through `var(--state-${run.state}, var(--text-faint))`.
+      That comment is a second region of `ui/src/api/runs.ts`, whose C6 boundary
+      names the `CrewRef` interface only; it cannot collide with C7's `replyRun`
+      region, and it is called out here rather than made silently.
+
+## C7 — the Crews tab
+
+- [ ] **Step 27: the client.** `replyRun` and `ReplyOutcome` in
+      `ui/src/api/runs.ts` per `I3`, keeping `refused` (the worker's own words) and
+      `failed` (houston's fault) distinct — collapsing them is what makes
+      "surface the failure honestly" untestable.
+- [ ] **Step 28: `ReplyComposer`.** A sibling of the card, never inside it —
+      `RunCard` is a `<button>`, so a nested field would be invalid HTML and every
+      keystroke would bubble to `onOpen`. Disabled while in flight, cleared only on
+      success; on 409 it shows crew's refusal verbatim. Its root class is
+      `.crew-reply` and its outcome line `.crew-reply-status`, both spelled exactly
+      as Step 33 greps for them. After a success it says the
+      answer is waiting to be picked up, not that the worker resumed. Tests cover
+      the double-tap guard and each outcome.
+- [ ] **Step 29: `CrewsView`.** Group by `Crew.Name`; a run with no crew or an
+      empty crew id appears in no group and is not shown, with an empty state
+      saying so. Group header: shortened crew id with the full id as `title`, member
+      count, blocked count. Members render through `RunCard`, sorted blocked-first
+      then most recent; crews sorted by any-blocked then most recent member. A
+      composer renders only for `question.via === 'crew'`. Root class `.crews`,
+      group header `.crews-group` — again the literals Step 33 greps for.
+- [ ] **Step 29a: `CrewsView.test.tsx`.** Criterion 20 otherwise ships with a
+      verification that cannot fail, since `npx vitest run` passes trivially when
+      the file does not exist. Four cases: (a) two runs with different `crew.name`
+      render two `.crews-group` headers with the right member and blocked counts;
+      (b) a run with no `crew`, and one with `crew.name === ''`, appear in no group,
+      and the empty state shows when they are the only runs; (c) a member with
+      `crew.tier` renders `.run-chip.tier` and one with a `pr` renders the PR chip;
+      (d) a composer renders for `question.via === 'crew'` and not for
+      `via === 'pane'`.
+- [ ] **Step 30: wire it into `Shell.tsx`.** Narrow `PLACEHOLDER` to
+      `Record<Exclude<Tab, 'fleet' | 'crews'>, string>`, drop its `crews` entry,
+      render `CrewsView` inside `<div hidden={tab !== 'crews'}>` so a half-typed
+      answer survives a tab switch, and leave the placeholder branch for the
+      remaining two tabs, and pass `CrewsView` the same
+      `onOpen={(r) => { window.location.hash = `#/fleet/${r.id}/activity` }}`
+      handler `FleetView` gets, or every crew card is inert. Nothing else.
+- [ ] **Step 31: verify C6 + C7.** `npx tsc -b`, `npx eslint .`, `npx vitest run`.
+
+## C8 — the proofs no component can give
+
+- [ ] **Step 32: full gate.** Go build, vet, test; UI typecheck, lint, tests;
+      `gofmt -l` clean on touched files.
+- [ ] **Step 33: bundle greps.** `npm run build`, then grep the built CSS for a
+      declaration of each of `.crews`, `.crews-group`, `.crew-reply`,
+      `.crew-reply-status`, `.run-chip.tier`, `.run-chip.codename`, and the built JS
+      for the literal `--run-accent`. A passing build proves nothing here — the
+      whole Mocha token file once shipped unimported behind a green build.
+- [ ] **Step 34: live before/after.** Run the built binary against the live tmux
+      and crew bus on a spare loopback port with a scratch state dir. Confirm each
+      dispatcher worker is now **one** run carrying both the crew question and the
+      `Tmux` ref, that `crew.color` is non-empty, and record the per-branch
+      candidate counts. Compare against the captured "before".
+- [ ] **Step 35: PR body.** Security section for the reply endpoint answering the
+      falsifiable question directly; the plain statement that no browser and no
+      display exist here, so the rendering is unverified; the accepted consequences
+      and the residual risks from the spec.

--- a/docs/superpowers/specs/2026-09-10-crews-tab.md
+++ b/docs/superpowers/specs/2026-09-10-crews-tab.md
@@ -1,0 +1,429 @@
+# Spec — Crews tab: crew grouping, branch→pane join, answering a blocked worker
+
+Issue #33. Plan B in `docs/superpowers/2026-09-08-state-of-play.md`, scoped to the
+Crews tab only. Binding design authority:
+`docs/superpowers/specs/2026-09-07-houston-overhaul-design.md`.
+
+Revision 2, after two spec-critic passes (the revision cap). Pass 1's B1-B10 and
+every note were adopted, except B4's `--` recommendation, refuted with evidence
+below. Pass 2 raised six further blocking findings; all six are adopted here —
+the `CREW_ID` precedence is now measured rather than inferred, R2's fallback root
+is **removed** rather than patched, the unjoined key is bus-qualified, the
+`blocked`-without-detail hole is closed, an answered question is now superseded
+from the bus itself, and the missing criteria are added.
+
+## Evidence gathered before writing (not assertions)
+
+| Claim | How it was checked | Result |
+|---|---|---|
+| `@crew_color` exists | `tmux show-options -w -t houston:4` on this live server | `@crew_color colour168`, `@crew_name blush` |
+| codenames collide | same command across live windows | `houston:2` and `houston:4` are both `blush`, different branches |
+| `crew reply <to> <body>` parses positionally | ran it in a scratch repo with body `--help -f /etc/passwd; rm -rf /` | body stored verbatim, exit 0 |
+| `--` is **not** an end-of-options marker | ran `crew reply -- worker:feat/x hello` | recipient became `--`, body became `worker:feat/x` |
+| branch-only target resolves | `crew reply worker:feat/x …` | landed on `worker:feat/x#s1-1` |
+| terminal-session refusal | posted a `done` status, replied again | stderr `crew: newest session on feat/x is done — …`, exit 1 |
+| unknown branch refusal | replied to an unknown branch | stderr `crew: no session on feat/nope — …`, exit 1 |
+| missing crew id refusal | replied with `CREW_ID` unset and no task doc | stderr `crew: CREW_ID unset and no WORKER_TASK.md crew_id`, exit 1 |
+| `WORKER_TASK.md` outranks `CREW_ID` | scratch repo with task-doc crew `TASKDOC-CREW`, invoked with `CREW_ID=ENV-CREW` | the record carried `TASKDOC-CREW`; the task doc wins |
+| a multi-line answer stays one JSONL line | replied with an answer containing a newline, a tab and quotes | one line added, still valid JSON, body round-tripped |
+| an answered question lingers on the bus | measured the two real dispatcher replies in this repo's bus against the worker's next status | 783 s and 348 s of lag |
+| hooks layer keys on the pane id | `runs/hooksource.go:116-124` | it does, and always publishes a `State` |
+| no browser is available | `DISPLAY`/`WAYLAND_DISPLAY` unset, no browser binary on `PATH` | none |
+
+## Problem
+
+Three gaps, in dependency order.
+
+**1. A dispatcher worker is two runs, not one.** `TmuxSource` keys layers on the
+pane id; `CrewSource` keys on `branch/<name>` because a worker knows its branch,
+not its pane. Both layers claim an `Agent`, so both compose into listed runs and
+the fleet shows the same worker twice — once with a terminal and PR badge, once
+with the crew's question. Neither card is complete.
+
+**2. `Run.Crew` cannot express a crew.** `CrewRef.Name` is written by two sources
+with incompatible meanings: `TmuxSource` writes lazytmux's `@crew_name`, the
+*worker's* codename, which collides by construction (`cksum(branch) % 32`, and
+two live windows here share `blush`); `CrewSource` writes the crew id. Grouping
+by `Crew.Name` today merges colliding codenames and splits one crew apart.
+`CrewRef.Color` is declared but written by nobody.
+
+**3. There is no way to answer a blocked worker.** `Question.Via == "crew"` is
+already set by `CrewSource` and `Caps.Reply` is already derived, but no endpoint
+delivers an answer. The design spec reserves `POST /api/runs/{id}/reply`.
+
+## Decisions already made — inherited, not relitigated
+
+- The correlation key is the tmux pane id.
+- Sources publish sparse layers; the registry composes by fixed precedence
+  `tmux → crew → hooks`, lowest first. A zero field means "no opinion".
+- houston never recomputes what lazytmux already computes.
+- `Caps` is derived at composition time. Nothing here may reintroduce a
+  source-published `Caps`.
+- `blocked` is the only state meaning "a human is required".
+
+## Requirements
+
+### R1 — CrewSource resolves (repo, branch) → pane and publishes under the pane key
+
+`CrewSource` already calls `ListWindowOptions()`; it also reads `ListPaneOptions()`,
+which already carries `pane_id`, `session:window` and `@claude_status`. Nothing new
+is needed from `tmux/` for the join — state-of-play's "only `session:window →
+pane_id` is missing" is stale.
+
+`deltasFromTmux` builds its `session:window → window` map inline, so there is no
+existing helper to reuse. That map is extracted into a named function in `runs/`
+and used by both sources, rather than written twice. `CrewSource.client` is
+narrowed from `*tmux.Client` to the same `lister` interface `TmuxSource` already
+takes, so the pane query is fakeable in tests exactly as `TmuxSource`'s is.
+
+- **The join key is (bus directory, branch), never a bare branch.** `scanRoots`
+  currently folds every git root's bus into one `map[branch]Run`, so two checkouts
+  sharing a branch name already collide, and a bare-branch join could attach one
+  repo's question to another repo's pane. Roots are grouped by the bus directory
+  `crewDir(root)` returns — several worktrees of one repo resolve to the same
+  common git dir and therefore to one bus, which is the correct dedupe.
+- A **candidate pane** for `(bus, branch)` is a pane whose window's `@branch`
+  equals the branch, whose window's `@git_root` maps to the same bus directory,
+  and whose `@claude_status` is non-empty.
+- Requiring a non-empty `@claude_status` is load-bearing: it is `TmuxSource`'s own
+  test for "this pane is an agent run". Joining onto a shell pane would let the
+  crew layer's `Agent` promote that shell into a listed run.
+- A branch joins only when there is **exactly one** candidate. Zero, or two or
+  more, → the layer falls back to a **bus-qualified** key, `crew/<bus dir>/<branch>`,
+  and a `slog.Debug` line records the bus, branch and candidate count so the
+  negative path is observable rather than silent.
+- The fallback key must carry the bus, not a bare branch. Today's
+  `branch/<name>` collides outright: two repos each holding a `main` crew record
+  produce one registry key, and the second layer overwrites the first in
+  `r.layers[key]["crew"]`. Live windows here span four repos with a `main`
+  branch, so this is reachable, not theoretical. `idFor` gains a `crew/` case
+  mapping it to `crew-<base64url>`; the now-unreachable `branch/` case goes with
+  it, since no source emits that prefix afterwards.
+- The key may flip either way as panes open and close. `tickCrewDeltas` must emit
+  the new key's delta **before** the abandoned key's `Gone`, so a subscriber never
+  briefly holds neither.
+- A tmux error must not be read as "every pane vanished": the existing
+  skip-the-tick rule extends to the pane query.
+
+### R2 — The crew layer carries a working directory
+
+`deltasFromCrewLog` sets only `Branch`, `Crew`, `Agent`, `State`, `UpdatedAt` and
+`Question`, so a crew run that does not join to a pane has no directory at all —
+and that is exactly the run R3 must still be able to answer.
+
+- The crew layer publishes `Worktree`: the `@git_root` of a window whose
+  `@branch` matches that branch within that bus. Where several windows match,
+  the lexicographically smallest root, for determinism rather than map order.
+- **When no window matches the branch, `Worktree` stays empty and the reply is
+  refused.** An earlier draft fell back to "the shortest root on that bus". That
+  is unsafe: the root set comes only from `@git_root` of live windows, so with no
+  main-checkout window open the shortest root is *another worker's worktree* —
+  and since `WORKER_TASK.md` outranks `CREW_ID` (measured above), the reply would
+  execute under that other worker's crew id and misroute silently. Refusing is
+  the honest answer, and a branch with no tmux window at all is a worker with no
+  live session, which `crew reply` would refuse anyway.
+- On a joined key this equals what the tmux layer already publishes, so the crew
+  layer's higher precedence changes nothing. `Repo` is deliberately not set here.
+
+### R3 — `CrewRef` distinguishes the crew from the worker
+
+```go
+type CrewRef struct {
+    Name     string // crew id — the grouping key. Crew bus only.
+    Codename string // lazytmux @crew_name: this worker's codename. tmux only.
+    Color    string // CSS colour from lazytmux @crew_color. tmux only.
+    Tier     string
+}
+```
+
+- `TmuxSource` stops writing `@crew_name` into `Name` and writes it into
+  `Codename`, alongside `Color`. `tmux/options.go` harvests `@crew_color`, which
+  the design spec already lists among the options `tmuxsource` harvests.
+- `@crew_color` is a tmux 256-palette code (`colour168` observed live). It is
+  converted to hex in `runs/` so the wire format is CSS-renderable and no tmux
+  vocabulary leaks into the API. Codes 16–255 convert by the standard xterm cube
+  and greyscale formulas. A `#rrggbb` value passes through. Codes 0–15, a named
+  colour, `default`, an empty value and anything unparseable all yield `""`,
+  meaning "no opinion" — the UI then falls back to its ordinary card border.
+  0–15 are excluded because they are terminal-theme-dependent, and crew's own
+  palette never emits one (every entry is ≥ `colour25`).
+- `mergeInto` must merge `CrewRef` **field-wise**, not by pointer replacement.
+  Two layers now own different fields of one struct, so today's `dst.Crew =
+  src.Crew` would discard the tmux layer's colour and codename the instant the
+  crew layer arrived. This is the one merge rule this work changes.
+- `runSignature` must include `Codename`, `Color` and `Question.Via`. A field that
+  changes without entering the signature never reaches a subscriber — the defect
+  class the state-of-play records for `Caps`.
+- `ui/src/api/runs.ts`'s `CrewRef` mirror gains `codename`.
+
+### R4 — A composed run may not contradict its own `Question` invariant
+
+`runs/run.go` documents "non-nil `Question` implies `State == StateBlocked`".
+The join breaks it: `hooksource.go` keys on the pane id too and sits **above** the
+crew layer, and a worker blocked on `crew await` is, to Claude's hooks, inside a
+running `Bash` tool. Composed `State` would be `running` while the crew's
+`Question` survives, so the attention border, the Fleet badge and the Crews tab's
+blocked count would all go dark for exactly the workers this tab exists to
+surface. This inversion is **created** by R1, not inherited.
+
+- `composeLocked` enforces the invariant after merging: a composed run with a
+  non-nil `Question` has `State == StateBlocked`. This is derived at composition
+  time, in one place, exactly as `deriveCaps` is — it restores a documented model
+  invariant rather than reordering precedence, which stays untouched. Precedence
+  is deliberately left alone: `runs/registry_test.go` asserts that hooks outrank
+  a crew `blocked`, and a blanket "any layer blocked wins" would contradict it.
+- **A crew `blocked` always carries a question, so the invariant always fires.**
+  `crew status <from> blocked` takes an optional detail, and `deltasFromCrewLog`
+  builds a `Question` only when the detail is non-empty — leaving the one variant
+  the invariant cannot see, which the higher hooks layer would then overwrite
+  with `running`. `CrewSource` therefore synthesises a question for a detailless
+  `blocked`, worded as houston's own description rather than a quote from anyone.
+  That makes the gap unrepresentable instead of leaving it to a second rule.
+- Where both layers are blocked, hooks' pane question wins the `Question` field on
+  precedence, and R7 then correctly refuses to crew-answer it. `LastMessage` is
+  never cleared in `hook/`, so a worker that merely ended a turn can carry one;
+  the rule is right, but the reason is that a pane question must never be posted
+  to the bus, not that a pane prompt is necessarily more urgent.
+
+### R5 — An answered question stops being a question
+
+Measured on this repo's own bus: a worker's next status arrived **783 s** and
+**348 s** after the dispatcher's reply. Until then the crew layer keeps publishing
+`blocked` and the question. Today that staleness sits on a duplicate branch card;
+R1 moves it onto the canonical card, into the attention border, the Fleet badge
+and the Crews blocked count — a regression in the one signal this tab exists to
+carry, and `FRESH_MS` is an hour, so it would not age out either.
+
+- `CrewSource` already reads every bus record, replies included. Where the latest
+  status for a branch is `blocked` and a `kind: "msg"` record from a
+  `dispatcher:` sender addressed to that branch's worker is **newer** than it,
+  the question has been answered.
+- The crew layer then publishes **no opinion**: no `Question`, and an empty
+  `State`. That is the sparse-layer contract used exactly as intended — the bus
+  has nothing left to say about a question it has already answered, so the tmux
+  and hooks layers describe what the worker is actually doing.
+- Derived wholly from data the source already reads. No server-side memory of
+  what houston sent, which would be wrong the moment a reply came from the
+  dispatcher's own terminal instead.
+
+### R6 — `POST /api/runs/{id}/reply` delivers a crew answer
+
+- Registered on `apiMux`, so it inherits the token, origin and `Host` gates
+  unchanged. Nothing may be registered outside that mux.
+- `POST` only. The origin allowlist's safety argument in `server/auth.go` depends
+  on every mutating route being `POST`; a `GET` must not mutate.
+- The target is resolved from the registry snapshot by `{id}`. A client can name a
+  run; it cannot name a command target, a branch, or a directory.
+- Delivery is `exec.CommandContext` with an **argv slice** —
+  `crew reply worker:<branch> <text>` — never a shell string.
+  - No `--` separator. `crew reply` takes its two operands positionally and does
+    no option parsing, so a leading-dash answer is already literal (verified), and
+    `--` would be consumed as the recipient (verified). Adding it would be a bug,
+    not a hardening.
+- Working directory is the run's `Worktree`. R2 makes it the worktree of the
+  window carrying that branch, or empty; empty is refused before anything runs.
+  `CREW_ID=<Crew.Name>` is also passed in the environment. Measured order: a
+  `WORKER_TASK.md` at the git toplevel **outranks** `CREW_ID`, so the target
+  worktree's own task document wins where it exists — correct, because R2 makes
+  that worktree the target's own — and the explicit id covers a checkout with no
+  task document. The stderr wording `CREW_ID unset and no WORKER_TASK.md crew_id`
+  suggests the opposite order; it is wording, not behaviour.
+- Bounded: `http.MaxBytesReader` on the body, an explicit maximum answer length
+  rejected with 413, and a command timeout after which the request is 504.
+- A multi-line answer is safe: `crew` builds its record with `jq --arg`, so a
+  newline, tab or quote round-trips inside one valid JSONL line (verified). No
+  escaping or rejection is needed here, and adding some would be a wrong reason
+  written into the code.
+- Refusal is surfaced honestly. `crew reply` exits 1 with an explanatory stderr
+  line when the newest session is terminal, when no session exists, and when no
+  crew id resolves (all three verified verbatim). That text reaches the user and a
+  non-zero exit is never reported as success.
+- Preconditions returning 4xx **before** any command runs: unknown id; no `Crew`;
+  no `Branch`; no `Worktree`; `Question` absent or `Question.Via != "crew"`; empty
+  answer. Answering a pane question through the crew bus would post to a bus
+  nobody is reading while the agent sits at a pane prompt — a false success.
+- The command is invoked through a `replyRunner` field on `Server`, defaulting to
+  the real `exec` call. Without that seam "no command ran" cannot be observed, only
+  asserted.
+- Every attempt is logged with the run id, branch and outcome. This is the only
+  route in houston that executes a command.
+- Explicit outcome contract, so the UI and the tests agree on what each case is:
+
+  | Case | Status | Body |
+  |---|---|---|
+  | delivered | `204` | empty |
+  | precondition unmet (unknown id, no crew/branch/worktree, wrong `Via`, empty answer) | `400`/`404` | `text/plain` reason |
+  | answer too large | `413` | `text/plain` |
+  | `crew` refused (non-zero exit) | `409` | `text/plain`, its stderr verbatim |
+  | `crew` missing, or houston failed | `502` | `text/plain` |
+  | timed out | `504` | `text/plain` |
+
+  `409` is what the UI shows as the worker's own refusal; `502` is houston's
+  fault. Collapsing them would make "surface the failure honestly" untestable.
+
+### R7 — Crews tab
+
+A `CrewsView` under `ui/src/fleet/`, wired into `Shell.tsx`. That wiring is about
+three lines, not one: `PLACEHOLDER` is typed `Record<Exclude<Tab,'fleet'>, string>`
+and `Shell.tsx` renders it for every non-fleet tab, so both need editing.
+`CrewsView` stays mounted like `FleetView`, so a half-typed answer survives a tab
+switch.
+
+- Groups runs by `Crew.Name`. A run with no crew, or a crew with no id, appears in
+  **no group and is not shown at all** — the Fleet tab already lists every run, and
+  a Crews tab that also lists non-crew runs is a second fleet list. An empty state
+  says so.
+- Each group shows the crew id, its member count and how many members are blocked.
+  The crew id is the label because the bus carries no crew-level title: the only
+  `title` on it is per-dispatch, i.e. one worker's task, not the crew's name. It
+  is shown shortened, with the full id available as the element's `title`.
+- Members render with the existing `RunCard` — same card, chips, attention border.
+  No second visual language. `RunCard` gains a tier chip when `crew.tier` is set
+  and shows `crew.codename` in place of today's crew chip, both of which also
+  improve the Fleet tab.
+- The worker's `Color` accents its own card. **This overrides the task's wording**
+  ("using the crew `Color` for its accent"): the colour is derived from the branch,
+  so it identifies a worker, not a crew, and using it as a group accent would give
+  one crew several accents and two crews the same one. The group header keeps the
+  existing `.fleet-group` treatment.
+- A member with `question.via === 'crew'` gets a reply composer rendered as a
+  **sibling of the card, never inside it** — `RunCard` is a `<button>`, so a nested
+  input would be invalid HTML and every keystroke would bubble to `onOpen`. The
+  composer shows the question, a text field, a send button, and on a `409` the
+  worker's own refusal text verbatim. It disables while a send is in flight and
+  clears only on success, so a double tap from one phone cannot post twice.
+  After a successful send it says the answer was delivered and is waiting to be
+  picked up, rather than claiming the worker has resumed — R5 is what actually
+  retires the question, and it does so from the bus.
+- Sort: blocked members first, then most recently updated. Crews sort by whether
+  any member is blocked, then by most recent member activity.
+
+## Non-goals
+
+- Workspace and Dispatch. Another worker may be editing Workspace.
+- `GET /api/crews`. The UI groups runs it already streams; a second endpoint is a
+  second source of truth.
+- The pane-keys half of `POST /api/runs/{id}/reply`. `MobileInputBar` already
+  reaches panes through the legacy route; unifying them belongs with plan D.
+- Changing merge precedence. R4 restores a documented invariant; it does not
+  reorder layers.
+- Evicting finished runs beyond the grace `CrewSource` already applies.
+- Carrying a branch id alias so an open detail view survives a key flip (see the
+  accepted consequence below).
+
+## Accepted consequences
+
+- **A run's `ID` changes when its key flips**, because `idFor` maps
+  `branch/foo → branch-<b64>` and `%307 → pane-307`. A user sitting on
+  `#/fleet/branch-<b64>/activity` when the join lands sees `RunDetail`'s existing
+  "no longer available" state with its back CTA. The flip happens once per worker,
+  within a poll tick of its pane appearing, and the successor run is on the Fleet
+  list. An alias map is not worth its complexity here.
+- **A crew record with no live tmux window** stays on the bus-qualified key and
+  is still listed, but has no `Worktree`, so a reply is refused up front. A branch
+  with no window is a worker with no live session, which `crew reply` refuses
+  anyway; the refusal simply arrives sooner and more cheaply.
+- **No server-side idempotency on the reply.** The composer's in-flight guard is
+  per client, so two phones, or a reload mid-flight, can post twice. The bus is
+  append-only and a worker reads its inbox in order, so a duplicate answer is
+  noise rather than damage.
+- **`crewDir` caches negative results for the process lifetime** (state-of-play's
+  known defect 8). Both R1's join key and R2's root grouping now key on it, so one
+  transient `git rev-parse` failure un-joins that repo until houston restarts.
+  Pre-existing and out of scope here, but newly load-bearing, so it is named
+  rather than left silent.
+
+## Acceptance criteria
+
+Every criterion names how it is proven. Criteria marked **bite** must additionally
+be shown to fail against the unfixed code before the fix lands.
+
+1. **The goal itself: one run, not two.** Against the live server and the running
+   crew, `GET /api/runs` before the change shows a dispatcher worker as two
+   entries — a `pane-*` and a `branch-*`. Already captured: `feat/33` and
+   `feat/34` each appear twice, `crew.name` reads `blush`/`bronze` on the pane
+   rows and the crew id on the branch rows, `feat/23` and `feat/33` collide on
+   `blush`, and `crew.color` is empty on every row. After the change the same
+   query must show one `pane-*` entry per worker, carrying both the crew question
+   and the `Tmux` ref, with the per-branch candidate counts recorded.
+2. Exactly one candidate pane joins; zero and two-or-more fall back. Unit test
+   over the pure resolution function.
+3. Two buses sharing a branch name neither cross-join nor collide: each keeps its
+   own layer under its own bus-qualified key, and both runs survive in the
+   snapshot. Unit test with two bus directories. (This is the half the previous
+   draft could not have passed, because a bare-branch fallback key made the two
+   layers overwrite each other.)
+4. A key flip emits the new key's delta **before** the abandoned key's `Gone`, and
+   the registry then broadcasts `Removed` for the old id. Unit test asserting
+   delta order and the `Removed` payload.
+5. A shell pane never becomes a listed run because a crew layer joined to it.
+   Unit test where the branch's only pane has an empty `@claude_status`.
+6. **bite** `mergeInto` preserves the tmux layer's `Codename`/`Color` under a crew
+   layer setting `Name`/`Tier`.
+7. **bite** `runSignature` changes when `Codename`, `Color` or `Question.Via`
+   changes.
+8. **bite** A key composed from tmux + crew(`blocked`, question) + hooks
+   (`tool-running`) composes as `blocked` and keeps the crew question. This is R4;
+   without it the tab's own trigger is dead.
+9. **bite** The same composition with a crew `blocked` carrying **no detail** also
+   composes as `blocked`, via the synthesised question. This is the variant the
+   invariant alone cannot see.
+10. **bite** A dispatcher reply newer than the blocking status retires the
+    question: the crew layer publishes no `Question` and no `State`, and the
+    composed run is described by the remaining layers. Unit test over
+    `deltasFromCrewLog` plus a registry composition test. Without it an answered
+    question holds the badge lit for the measured minutes.
+11. The crew layer publishes `Worktree`: on a joined key it equals what the tmux
+    layer publishes for the same window; with no matching window it is empty.
+    Unit test for both, since this string becomes a command's working directory.
+12. `@crew_color` reaches `Run.Crew.Color` as hex: a parse test over `colour168`
+    plus the `#rrggbb` pass-through and the no-opinion cases (`0`-`15`, a name,
+    `default`, empty, garbage), a `ParseWindowOptions` test at the new field
+    count, **and** a non-empty `crew.color` observed in live `/api/runs` output.
+    A fixture-only test would pass even if lazytmux never set the option.
+13. An unauthenticated `POST /api/runs/{id}/reply` is 401, a cross-origin one 403,
+    a rebound `Host` 421 — each through `s.Handler()`, and each with the
+    `replyRunner` stub recording **zero** invocations.
+14. `GET` on the reply route does not mutate and runs no command.
+15. Each row of R6's outcome table is produced by the case it names, checked on
+    status **and** body: notably `409` carries the stub's stderr verbatim and
+    `502` does not.
+16. An answer containing `; rm -rf /`, backticks, `$(...)` **and** a leading dash
+    arrives as exactly one argv element, with the recipient still the intended
+    worker. Stub-driven.
+17. A run whose question is `via: "pane"`, or which has no crew, branch or
+    worktree, is refused before any command runs. Stub-driven.
+18. An over-long body is 413; a command that outlives its timeout is 504.
+19. **End to end, against the real `crew` binary.** A scratch git repo with its
+    own bus and a live blocked worker, driven through the handler with the real
+    runner: the answer lands on that bus addressed to that worker, and no other
+    bus is touched. A second case, with the worker's session terminal, returns
+    409 carrying crew's own refusal text. This is the only criterion that can
+    falsify the working-directory and `CREW_ID` choices — a stub written by the
+    same author cannot. Skipped with an explicit message if `crew` is not on
+    `PATH`, and run for real here.
+20. `CrewsView` groups by crew id, hides crew-less runs, shows tier and PR badges,
+    and renders a composer only for `via === 'crew'` members. DOM tests with
+    `@testing-library/react`.
+21. The composer cannot post twice from a double tap, and after a success says
+    the answer is waiting to be picked up rather than that the worker resumed.
+    DOM test.
+22. The new styles actually ship. Grep the built CSS bundle for each new class
+    declaration by literal name, and the built JS bundle for the literal accent
+    property string the card sets inline, since a per-worker accent is an inline
+    style no stylesheet grep can prove. The exact strings are fixed in the plan
+    so the criterion is not self-graded. A passing build is not evidence.
+
+## Risks
+
+- **Precedence inversion below the `Question` invariant.** R4 and R5 together
+  make sure `blocked` is never lost and never lingers once answered. A residue
+  remains: a crew `working` status outranks a live `@claude_status` of, say,
+  `compacting`. That residue is **created by the join**, not inherited — before
+  it, the two layers never shared a key — and it is cosmetic only because no
+  remaining case touches `blocked`. Recorded, not fixed.
+- **Codename collisions** are inherent. The codename is a label; nothing joins on it.
+- **`crew` is resolved from `PATH`.** If absent, the endpoint fails with an honest
+  error rather than silently doing nothing.
+- **No browser.** Verified absent here, so the rendering is unverified and the PR
+  must say so plainly rather than claiming otherwise.

--- a/runs/color.go
+++ b/runs/color.go
@@ -1,0 +1,60 @@
+package runs
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// cubeLevels are the six intensity steps tmux's 256-colour cube (indices
+// 16-231) uses per channel.
+var cubeLevels = [6]int{0, 95, 135, 175, 215, 255}
+
+// tmuxColorToHex converts a tmux colour value (as read from a user option
+// like @crew_color) to a CSS hex colour, or "" for "no opinion".
+//
+// Indices 16-231 are the 6x6x6 colour cube, 232-255 are the greyscale ramp,
+// and a "#rrggbb" value (exactly six hex digits) passes through unchanged;
+// anything else starting with "#" maps to "" rather than a malformed value.
+// Indices 0-15 map to "" rather than a colour, because they're
+// terminal-theme-dependent — there's no fixed RGB for "colour1", it's
+// whatever the user's palette says red is — and the crew palette this feeds
+// never emits one anyway (its lowest entry is colour25).
+func tmuxColorToHex(v string) string {
+	if strings.HasPrefix(v, "#") {
+		if isHex6(v[1:]) {
+			return v
+		}
+		return ""
+	}
+	n, ok := strings.CutPrefix(v, "colour")
+	if !ok {
+		return ""
+	}
+	i, err := strconv.Atoi(n)
+	if err != nil || i < 16 || i > 255 {
+		return ""
+	}
+	if i >= 232 {
+		g := 8 + 10*(i-232)
+		return fmt.Sprintf("#%02x%02x%02x", g, g, g)
+	}
+	i -= 16
+	r := cubeLevels[i/36]
+	g := cubeLevels[(i/6)%6]
+	b := cubeLevels[i%6]
+	return fmt.Sprintf("#%02x%02x%02x", r, g, b)
+}
+
+// isHex6 reports whether s is exactly six hexadecimal digits.
+func isHex6(s string) bool {
+	if len(s) != 6 {
+		return false
+	}
+	for _, c := range s {
+		if !strings.ContainsRune("0123456789abcdefABCDEF", c) {
+			return false
+		}
+	}
+	return true
+}

--- a/runs/color_test.go
+++ b/runs/color_test.go
@@ -1,0 +1,35 @@
+package runs
+
+import "testing"
+
+func TestTmuxColorToHex(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"cube low corner", "colour16", "#000000"},
+		{"cube high corner", "colour231", "#ffffff"},
+		{"cube mid", "colour168", "#d75f87"},
+		{"greyscale low", "colour232", "#080808"},
+		{"greyscale high", "colour255", "#eeeeee"},
+		{"hex passthrough", "#abcdef", "#abcdef"},
+		{"hex too short", "#abcde", ""},
+		{"hex too long", "#abcdef1", ""},
+		{"hex non-hex characters", "#abcdez", ""},
+		{"theme-dependent low index", "colour1", ""},
+		{"theme-dependent high boundary", "colour15", ""},
+		{"colour name", "red", ""},
+		{"default", "default", ""},
+		{"empty", "", ""},
+		{"unparseable", "colourfoo", ""},
+		{"out of range", "colour256", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := tmuxColorToHex(c.in); got != c.want {
+				t.Errorf("tmuxColorToHex(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}

--- a/runs/crewjoin.go
+++ b/runs/crewjoin.go
@@ -1,0 +1,60 @@
+package runs
+
+import "github.com/noamsto/houston/tmux"
+
+// resolvePane finds the one agent pane running (bus, branch), if there is
+// exactly one. busOf maps a window's @git_root to its bus directory; "" means
+// the root has no bus and disqualifies the window. An empty @git_root never
+// reaches busOf: `git -C ""` is a documented no-op, so it would resolve to
+// houston's own cwd and pull unrelated windows into that bus.
+//
+// A candidate's @claude_status must be non-empty because that is TmuxSource's
+// own test for "this pane is an agent run" — joining onto a shell pane would
+// let the crew layer's Agent promote that shell into a listed run.
+func resolvePane(bus, branch string, wins []tmux.WindowOptions, panes []tmux.PaneOptions, busOf func(gitRoot string) string) (paneID string, candidates int) {
+	byTarget := windowsByTarget(wins)
+	for _, p := range panes {
+		if p.ClaudeStatus == "" {
+			continue
+		}
+		w, ok := byTarget[p.Target]
+		if !ok || w.Branch != branch || w.GitRoot == "" {
+			continue
+		}
+		if b := busOf(w.GitRoot); b == "" || b != bus {
+			continue
+		}
+		candidates++
+		paneID = p.PaneID
+	}
+	if candidates != 1 {
+		return "", candidates
+	}
+	return paneID, candidates
+}
+
+// worktreeFor is the working directory the crew layer publishes for (bus,
+// branch): the lexicographically smallest @git_root among that bus's windows
+// on that branch, for determinism rather than map order.
+//
+// With no matching window it returns "" and the reply endpoint refuses the
+// run. There is deliberately no fallback root: the root set comes only from
+// live windows, so with no main-checkout window open the smallest root is
+// another worker's worktree, and a WORKER_TASK.md at that toplevel outranks
+// the CREW_ID environment variable — the reply would run under the wrong crew
+// identity.
+func worktreeFor(bus, branch string, wins []tmux.WindowOptions, busOf func(gitRoot string) string) string {
+	best := ""
+	for _, w := range wins {
+		if w.Branch != branch || w.GitRoot == "" {
+			continue
+		}
+		if b := busOf(w.GitRoot); b == "" || b != bus {
+			continue
+		}
+		if best == "" || w.GitRoot < best {
+			best = w.GitRoot
+		}
+	}
+	return best
+}

--- a/runs/crewsource.go
+++ b/runs/crewsource.go
@@ -11,8 +11,6 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
-
-	"github.com/noamsto/houston/tmux"
 )
 
 // CrewSource reads dispatcher's git-backed bus. It contributes the one thing
@@ -22,7 +20,7 @@ import (
 // uses, rather than taking them from the caller — that keeps construction free
 // of I/O and self-contained.
 type CrewSource struct {
-	client *tmux.Client
+	client lister
 	every  time.Duration
 
 	// crewDirs caches root -> bus directory, keyed by lazytmux's @git_root.
@@ -31,7 +29,7 @@ type CrewSource struct {
 	crewDirs map[string]string
 }
 
-func NewCrewSource(c *tmux.Client, every time.Duration) *CrewSource {
+func NewCrewSource(c lister, every time.Duration) *CrewSource {
 	if every <= 0 {
 		every = 3 * time.Second
 	}
@@ -91,18 +89,22 @@ func crewRunFinished(r Run, now time.Time) bool {
 	return now.Sub(time.Unix(r.UpdatedAt, 0)) > crewEvictionGrace
 }
 
-// tickCrewDeltas computes this cycle's deltas from the branches scan()
-// currently sees, evicting anything whose bus status has been terminal for
-// longer than crewEvictionGrace. seen is the previous tick's emitted key
-// set; it returns the deltas to send and the new seen set.
+// tickCrewDeltas computes this cycle's deltas from the runs scan() currently
+// sees, already keyed by their final registry keys, evicting anything whose
+// bus status has been terminal for longer than crewEvictionGrace. seen is the
+// previous tick's emitted key set; it returns the deltas to send and the new
+// seen set.
+//
+// Every update is emitted before every Gone. A branch's key flips as its pane
+// opens and closes, and that order is what stops a subscriber briefly holding
+// neither key.
 func tickCrewDeltas(current map[string]Run, seen map[string]bool, now time.Time) ([]Delta, map[string]bool) {
 	var deltas []Delta
 	newSeen := map[string]bool{}
-	for branch, r := range current {
+	for key, r := range current {
 		if crewRunFinished(r, now) {
 			continue
 		}
-		key := "branch/" + branch
 		deltas = append(deltas, Delta{Source: "crew", Key: key, Run: r})
 		newSeen[key] = true
 	}
@@ -114,13 +116,21 @@ func tickCrewDeltas(current map[string]Run, seen map[string]bool, now time.Time)
 	return deltas, newSeen
 }
 
-// scan returns ok=false when ListWindowOptions failed — a transient tmux
-// error, not evidence every crew-sourced branch vanished. The caller must
-// skip the tick entirely rather than diff against an empty map.
-func (s *CrewSource) scan() (branches map[string]Run, ok bool) {
+// scan returns this tick's runs under their final registry keys: the pane id
+// where the branch joins exactly one agent pane, otherwise "crew/<bus>/<branch>".
+//
+// ok=false means a tmux query failed — a transient error, not evidence every
+// crew-sourced branch vanished. The caller must skip the tick entirely rather
+// than diff against an empty map.
+func (s *CrewSource) scan() (map[string]Run, bool) {
 	wins, err := s.client.ListWindowOptions()
 	if err != nil {
 		slog.Debug("crew source: list window options", "error", err)
+		return nil, false
+	}
+	panes, err := s.client.ListPaneOptions()
+	if err != nil {
+		slog.Debug("crew source: list pane options", "error", err)
 		return nil, false
 	}
 
@@ -135,14 +145,30 @@ func (s *CrewSource) scan() (branches map[string]Run, ok bool) {
 	for repo := range roots {
 		rootList = append(rootList, repo)
 	}
-	return s.scanRoots(rootList), true
+
+	out := map[string]Run{}
+	for bus, branches := range s.scanRoots(rootList) {
+		for branch, r := range branches {
+			r.Worktree = worktreeFor(bus, branch, wins, s.crewDir)
+			paneID, candidates := resolvePane(bus, branch, wins, panes, s.crewDir)
+			key := paneID
+			if candidates != 1 {
+				key = "crew/" + bus + "/" + branch
+				slog.Debug("crew source: no pane join", "bus", bus, "branch", branch, "candidates", candidates)
+			}
+			out[key] = r
+		}
+	}
+	return out, true
 }
 
 // scanRoots reads every root's crew bus and folds it into the latest state per
-// branch. Split out from scan() so the root list can be injected in tests
-// without going through tmux.
-func (s *CrewSource) scanRoots(roots []string) map[string]Run {
-	merged := map[string]Run{}
+// branch, grouped by bus directory. Several worktrees of one repo resolve to
+// the same common git dir and therefore to one bus, which is the correct
+// dedupe; two repos each holding a `main` record stay apart. Split out from
+// scan() so the root list can be injected in tests without going through tmux.
+func (s *CrewSource) scanRoots(roots []string) map[string]map[string]Run {
+	merged := map[string]map[string]Run{}
 	for _, repo := range roots {
 		dir := s.crewDir(repo)
 		if dir == "" {
@@ -159,7 +185,10 @@ func (s *CrewSource) scanRoots(roots []string) map[string]Run {
 				continue
 			}
 			for branch, r := range deltasFromCrewLog(f) {
-				merged[branch] = r
+				if merged[dir] == nil {
+					merged[dir] = map[string]Run{}
+				}
+				merged[dir][branch] = r
 			}
 			_ = f.Close()
 		}
@@ -204,6 +233,7 @@ type crewRecord struct {
 	TS     int64  `json:"ts"`
 	CrewID string `json:"crew_id"`
 	From   string `json:"from"`
+	To     string `json:"to"`
 	Kind   string `json:"kind"`
 	Branch string `json:"branch"`
 	Title  string `json:"title"`
@@ -213,17 +243,37 @@ type crewRecord struct {
 	// Session is a tmux session name, present on the dispatch record. It is
 	// useful for the later branch->pane join but is not used yet.
 	Session string `json:"session"`
-	Body    struct {
-		State  string `json:"state"`
-		Detail string `json:"detail"`
-		PRURL  string `json:"pr_url"`
-	} `json:"body"`
+	// Body is a JSON object on a status record but a JSON string on a msg
+	// record, so decoding straight into a struct fails on every msg line and
+	// drops that record whole. Decode it only where the shape is known.
+	Body json.RawMessage `json:"body"`
 }
+
+// crewStatusBody is crewRecord.Body decoded for a "status" record.
+type crewStatusBody struct {
+	State  string `json:"state"`
+	Detail string `json:"detail"`
+	PRURL  string `json:"pr_url"`
+}
+
+// crewBlockedNoDetail is the question synthesised for a `crew status <from>
+// blocked` carrying no detail, since that detail is optional. The composed-run
+// invariant (a non-nil Question implies StateBlocked) can only protect a
+// blocked status that has a Question, so without this the higher-precedence
+// hooks layer overwrites State and the block goes unseen. Worded as houston's
+// own description: there is no worker text here to quote.
+const crewBlockedNoDetail = "Blocked, no detail given."
 
 // deltasFromCrewLog folds one bus log into the latest state per branch. The bus
 // is append-only, so later records win.
 func deltasFromCrewLog(rd io.Reader) map[string]Run {
 	out := map[string]Run{}
+	// lastStatusTS and dispatcherReplyTS are compared by timestamp, not by
+	// line order, to decide whether a blocked question has been answered —
+	// see the retirement pass below.
+	lastStatusTS := map[string]int64{}
+	dispatcherReplyTS := map[string]int64{}
+
 	sc := bufio.NewScanner(rd)
 	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 
@@ -233,8 +283,15 @@ func deltasFromCrewLog(rd io.Reader) map[string]Run {
 			continue // the bus is written by shell; a torn line is not fatal
 		}
 
+		// A dispatcher reply is addressed with from: "dispatcher:…", to:
+		// "worker:<branch>#…" — its branch lives in To, not From, since From
+		// never resolves through branchFromWorker.
 		branch := rec.Branch
-		if branch == "" {
+		switch {
+		case branch != "":
+		case rec.Kind == "msg" && strings.HasPrefix(rec.From, "dispatcher:"):
+			branch = branchFromWorker(rec.To)
+		default:
 			branch = branchFromWorker(rec.From)
 		}
 		if branch == "" {
@@ -259,16 +316,41 @@ func deltasFromCrewLog(rd io.Reader) map[string]Run {
 		if rec.Engine != "" {
 			r.Agent = rec.Engine
 		}
-		if rec.Kind == "status" && rec.Body.State != "" {
-			r.State = FromCrewState(rec.Body.State)
-			r.UpdatedAt = rec.TS / 1000
-			r.Question = nil
-			if r.State == StateBlocked && rec.Body.Detail != "" {
-				r.Question = &Question{Text: rec.Body.Detail, Via: "crew"}
+		if rec.Kind == "msg" && strings.HasPrefix(rec.From, "dispatcher:") && rec.TS > dispatcherReplyTS[branch] {
+			dispatcherReplyTS[branch] = rec.TS
+		}
+		if rec.Kind == "status" {
+			var body crewStatusBody
+			if err := json.Unmarshal(rec.Body, &body); err == nil && body.State != "" {
+				r.State = FromCrewState(body.State)
+				r.UpdatedAt = rec.TS / 1000
+				lastStatusTS[branch] = rec.TS
+				r.Question = nil
+				if r.State == StateBlocked {
+					r.Question = &Question{Text: crewBlockedNoDetail, Via: "crew"}
+					if body.Detail != "" {
+						r.Question.Text = body.Detail
+					}
+				}
 			}
 		}
 		out[branch] = r
 	}
+
+	// A dispatcher reply newer than the blocking status has answered the
+	// question: measured on this repo's own bus, a worker's next status
+	// arrived 783s and 348s after the dispatcher's reply, so without this the
+	// question — and the attention badge — persists for minutes after it was
+	// answered. The layer then has no opinion left to publish: no Question,
+	// no State.
+	for branch, r := range out {
+		if r.State == StateBlocked && dispatcherReplyTS[branch] > lastStatusTS[branch] {
+			r.State = ""
+			r.Question = nil
+			out[branch] = r
+		}
+	}
+
 	return out
 }
 

--- a/runs/crewsource_test.go
+++ b/runs/crewsource_test.go
@@ -1,12 +1,16 @@
 package runs
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/noamsto/houston/tmux"
 )
 
 const crewFixture = `{"ts":1000,"crew_id":"c1","kind":"dispatch","branch":"fix/412","title":"fix the ws drop","tier":"standard","engine":"claude","model":"sonnet","session":"houston"}
@@ -95,9 +99,13 @@ func TestScanFindsBusFromInsideAWorktree(t *testing.T) {
 	s := &CrewSource{crewDirs: map[string]string{}}
 	got := s.scanRoots([]string{wt})
 
-	r, ok := got["feat/x"]
+	byBranch, ok := got[busDir]
 	if !ok {
-		t.Fatalf("scan found nothing from inside a worktree — keys %v", keysOf(got))
+		t.Fatalf("no bus keyed on the main checkout's crew dir %q — buses %v", busDir, busKeysOf(got))
+	}
+	r, ok := byBranch["feat/x"]
+	if !ok {
+		t.Fatalf("scan found nothing from inside a worktree — keys %v", keysOf(byBranch))
 	}
 	if r.State != StateBlocked || r.Question == nil {
 		t.Fatalf("got %+v, want a blocked run carrying its question", r)
@@ -106,10 +114,11 @@ func TestScanFindsBusFromInsideAWorktree(t *testing.T) {
 
 func TestTickCrewDeltasEvictsFinishedRunsAfterGrace(t *testing.T) {
 	now := time.Now()
+	const key = "crew/" + testBus + "/fix/412"
 	current := map[string]Run{
-		"fix/412": {Branch: "fix/412", State: StateDone, UpdatedAt: now.Add(-30 * time.Minute).Unix()},
+		key: {Branch: "fix/412", State: StateDone, UpdatedAt: now.Add(-30 * time.Minute).Unix()},
 	}
-	seen := map[string]bool{"branch/fix/412": true}
+	seen := map[string]bool{key: true}
 
 	deltas, newSeen := tickCrewDeltas(current, seen, now)
 
@@ -122,21 +131,21 @@ func TestTickCrewDeltasEvictsFinishedRunsAfterGrace(t *testing.T) {
 	if len(gone) != 1 {
 		t.Fatalf("got %d Gone deltas, want exactly 1: %+v", len(gone), deltas)
 	}
-	if gone[0].Key != "branch/fix/412" {
-		t.Errorf("Gone delta Key = %q, want branch/fix/412", gone[0].Key)
+	if gone[0].Key != key {
+		t.Errorf("Gone delta Key = %q, want %q verbatim — Registry.Apply matches on the key it was given", gone[0].Key, key)
 	}
 	if gone[0].Source != "crew" {
 		t.Errorf("Gone delta Source = %q, want crew — Registry.Apply deletes r.layers[key][Source], so an empty Source silently no-ops eviction", gone[0].Source)
 	}
-	if newSeen["branch/fix/412"] {
-		t.Error("branch/fix/412 still present in the new seen set, want evicted")
+	if newSeen[key] {
+		t.Errorf("%s still present in the new seen set, want evicted", key)
 	}
 }
 
 func TestTickCrewDeltasKeepsFreshlyFinishedRuns(t *testing.T) {
 	now := time.Now()
 	current := map[string]Run{
-		"fix/412": {Branch: "fix/412", State: StateDone, UpdatedAt: now.Add(-1 * time.Minute).Unix()},
+		"%307": {Branch: "fix/412", State: StateDone, UpdatedAt: now.Add(-1 * time.Minute).Unix()},
 	}
 
 	deltas, newSeen := tickCrewDeltas(current, map[string]bool{}, now)
@@ -144,15 +153,16 @@ func TestTickCrewDeltasKeepsFreshlyFinishedRuns(t *testing.T) {
 	if len(deltas) != 1 || deltas[0].Gone {
 		t.Fatalf("deltas = %+v, want one non-Gone delta for a freshly finished run", deltas)
 	}
-	if !newSeen["branch/fix/412"] {
-		t.Error("branch/fix/412 missing from the new seen set, want present")
+	if !newSeen["%307"] {
+		t.Error("the pane key is missing from the new seen set, want present")
 	}
 }
 
 func TestTickCrewDeltasNeverEvictsAQuietBlockedRun(t *testing.T) {
 	now := time.Now()
+	const key = "crew/" + testBus + "/fix/412"
 	current := map[string]Run{
-		"fix/412": {Branch: "fix/412", State: StateBlocked, UpdatedAt: now.Add(-24 * time.Hour).Unix()},
+		key: {Branch: "fix/412", State: StateBlocked, UpdatedAt: now.Add(-24 * time.Hour).Unix()},
 	}
 
 	deltas, newSeen := tickCrewDeltas(current, map[string]bool{}, now)
@@ -160,15 +170,16 @@ func TestTickCrewDeltasNeverEvictsAQuietBlockedRun(t *testing.T) {
 	if len(deltas) != 1 || deltas[0].Gone {
 		t.Fatalf("deltas = %+v, want one non-Gone delta — a quiet blocked run must never be evicted", deltas)
 	}
-	if !newSeen["branch/fix/412"] {
-		t.Error("branch/fix/412 missing from the new seen set, want present")
+	if !newSeen[key] {
+		t.Errorf("%s missing from the new seen set, want present", key)
 	}
 }
 
 func TestTickCrewDeltasKeepsADispatchedRunWithNoStatusYet(t *testing.T) {
 	now := time.Now()
+	const key = "crew/" + testBus + "/fix/412"
 	current := map[string]Run{
-		"fix/412": {Branch: "fix/412"},
+		key: {Branch: "fix/412"},
 	}
 
 	deltas, newSeen := tickCrewDeltas(current, map[string]bool{}, now)
@@ -176,8 +187,8 @@ func TestTickCrewDeltasKeepsADispatchedRunWithNoStatusYet(t *testing.T) {
 	if len(deltas) != 1 || deltas[0].Gone {
 		t.Fatalf("deltas = %+v, want one non-Gone delta — a dispatch-only run has nothing to evict", deltas)
 	}
-	if !newSeen["branch/fix/412"] {
-		t.Error("branch/fix/412 missing from the new seen set, want present")
+	if !newSeen[key] {
+		t.Errorf("%s missing from the new seen set, want present", key)
 	}
 }
 
@@ -187,4 +198,417 @@ func keysOf(m map[string]Run) []string {
 		out = append(out, k)
 	}
 	return out
+}
+
+func busKeysOf(m map[string]map[string]Run) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func TestDeltasFromCrewLogParsesMsgRecords(t *testing.T) {
+	// Before the Body/json.RawMessage fix, a msg record's string body failed
+	// to unmarshal into the old struct-typed Body, which failed the whole
+	// line's json.Unmarshal — dropping fields ordinary to any record, like
+	// tier, along with it. This msg record carries a tier the dispatch record
+	// did not; seeing it stick is proof the line was actually parsed, not
+	// skipped.
+	const fixture = `{"ts":1000,"crew_id":"c1","kind":"dispatch","branch":"fix/4","engine":"claude"}
+{"ts":1100,"crew_id":"c1","from":"worker:fix/4#s1","kind":"msg","tier":"deep","body":"{\"ok\":true}"}
+`
+	got := deltasFromCrewLog(strings.NewReader(fixture))
+	r, ok := got["fix/4"]
+	if !ok {
+		t.Fatalf("no entry for fix/4, got keys %v", keysOf(got))
+	}
+	if r.Crew == nil || r.Crew.Tier != "deep" {
+		t.Fatalf("Crew = %+v, want Tier deep from the msg record", r.Crew)
+	}
+}
+
+func TestDeltasFromCrewLogBlockedAlwaysCarriesAQuestion(t *testing.T) {
+	t.Run("with detail", func(t *testing.T) {
+		const fixture = `{"ts":1000,"crew_id":"c1","kind":"dispatch","branch":"fix/5","engine":"claude"}
+{"ts":1100,"crew_id":"c1","from":"worker:fix/5#s1","kind":"status","body":{"state":"blocked","detail":"Keep the alias?"}}
+`
+		got := deltasFromCrewLog(strings.NewReader(fixture))
+		r := got["fix/5"]
+		if r.State != StateBlocked {
+			t.Fatalf("State = %q, want blocked", r.State)
+		}
+		if r.Question == nil || r.Question.Via != "crew" || r.Question.Text != "Keep the alias?" {
+			t.Fatalf("Question = %+v, want the detail text with Via crew", r.Question)
+		}
+	})
+
+	t.Run("without detail", func(t *testing.T) {
+		const fixture = `{"ts":1000,"crew_id":"c1","kind":"dispatch","branch":"fix/6","engine":"claude"}
+{"ts":1100,"crew_id":"c1","from":"worker:fix/6#s1","kind":"status","body":{"state":"blocked"}}
+`
+		got := deltasFromCrewLog(strings.NewReader(fixture))
+		r := got["fix/6"]
+		if r.State != StateBlocked {
+			t.Fatalf("State = %q, want blocked", r.State)
+		}
+		if r.Question == nil || r.Question.Via != "crew" || r.Question.Text != crewBlockedNoDetail {
+			t.Fatalf("Question = %+v, want the synthesised text with Via crew", r.Question)
+		}
+	})
+}
+
+func TestDeltasFromCrewLogRetiresAnAnsweredQuestion(t *testing.T) {
+	const blocked = `{"ts":1000,"crew_id":"c1","kind":"dispatch","branch":"fix/9","engine":"claude"}
+{"ts":2000,"crew_id":"c1","from":"worker:fix/9#s1","kind":"status","body":{"state":"blocked","detail":"Keep the alias?"}}
+`
+
+	t.Run("answered", func(t *testing.T) {
+		fixture := blocked + `{"ts":3000,"crew_id":"c1","from":"dispatcher:c1","to":"worker:fix/9#s1","kind":"msg","body":"keep it"}
+`
+		got := deltasFromCrewLog(strings.NewReader(fixture))
+		r, ok := got["fix/9"]
+		if !ok {
+			t.Fatalf("no entry for fix/9, got keys %v", keysOf(got))
+		}
+		if r.State != "" {
+			t.Errorf("State = %q, want \"\" — the question was answered", r.State)
+		}
+		if r.Question != nil {
+			t.Errorf("Question = %+v, want nil — the question was answered", r.Question)
+		}
+		if r.Branch != "fix/9" || r.Crew == nil || r.Crew.Name != "c1" || r.Agent != "claude" {
+			t.Errorf("Branch/Crew/Agent must survive retirement: Branch=%q Crew=%+v Agent=%q", r.Branch, r.Crew, r.Agent)
+		}
+	})
+
+	t.Run("unanswered", func(t *testing.T) {
+		got := deltasFromCrewLog(strings.NewReader(blocked))
+		r := got["fix/9"]
+		if r.State != StateBlocked || r.Question == nil {
+			t.Fatalf("got %+v, want still blocked with a question — no reply exists", r)
+		}
+	})
+
+	t.Run("reply older than the block", func(t *testing.T) {
+		const fixture = `{"ts":1000,"crew_id":"c1","kind":"dispatch","branch":"fix/9","engine":"claude"}
+{"ts":1500,"crew_id":"c1","from":"dispatcher:c1","to":"worker:fix/9#s1","kind":"msg","body":"old news"}
+{"ts":2000,"crew_id":"c1","from":"worker:fix/9#s1","kind":"status","body":{"state":"blocked","detail":"Keep the alias?"}}
+`
+		got := deltasFromCrewLog(strings.NewReader(fixture))
+		r := got["fix/9"]
+		if r.State != StateBlocked || r.Question == nil {
+			t.Fatalf("got %+v, want still blocked — the reply predates the block", r)
+		}
+	})
+
+	t.Run("reply addressed to a different branch", func(t *testing.T) {
+		fixture := blocked + `{"ts":3000,"crew_id":"c1","from":"dispatcher:c1","to":"worker:other/branch#s1","kind":"msg","body":"unrelated"}
+`
+		got := deltasFromCrewLog(strings.NewReader(fixture))
+		r := got["fix/9"]
+		if r.State != StateBlocked || r.Question == nil {
+			t.Fatalf("got %+v, want still blocked — the reply was addressed elsewhere", r)
+		}
+	})
+
+	t.Run("reply from a non-dispatcher sender", func(t *testing.T) {
+		fixture := blocked + `{"ts":3000,"crew_id":"c1","from":"worker:other#s1","to":"worker:fix/9#s1","kind":"msg","body":"not the dispatcher"}
+`
+		got := deltasFromCrewLog(strings.NewReader(fixture))
+		r := got["fix/9"]
+		if r.State != StateBlocked || r.Question == nil {
+			t.Fatalf("got %+v, want still blocked — only a dispatcher reply retires the question", r)
+		}
+	})
+}
+
+// testBus stands in for a bus directory in tests that never touch git.
+const testBus = "/repo/.git/crew"
+
+// testBusOf is the busOf a join test uses in place of CrewSource.crewDir:
+// two worktrees of one repo share a bus, /other has its own, and anything
+// else is unknown.
+func testBusOf(root string) string {
+	switch root {
+	case "/wt/a", "/wt/b":
+		return testBus
+	case "/other":
+		return "/other/.git/crew"
+	}
+	return ""
+}
+
+func agentPane(id, target string) tmux.PaneOptions {
+	return tmux.PaneOptions{PaneID: id, Target: target, ClaudeStatus: "processing 1 "}
+}
+
+func TestResolvePane(t *testing.T) {
+	win := func(window int, branch, root string) tmux.WindowOptions {
+		return tmux.WindowOptions{Session: "h", Window: window, Branch: branch, GitRoot: root}
+	}
+
+	tests := []struct {
+		name     string
+		wins     []tmux.WindowOptions
+		panes    []tmux.PaneOptions
+		wantPane string
+		wantN    int
+	}{
+		{
+			name:     "one candidate joins",
+			wins:     []tmux.WindowOptions{win(1, "fix/412", "/wt/a")},
+			panes:    []tmux.PaneOptions{agentPane("%307", "h:1")},
+			wantPane: "%307",
+			wantN:    1,
+		},
+		{
+			name:  "no window on that branch",
+			wins:  []tmux.WindowOptions{win(1, "main", "/wt/a")},
+			panes: []tmux.PaneOptions{agentPane("%307", "h:1")},
+			wantN: 0,
+		},
+		{
+			name:  "two candidates are ambiguous",
+			wins:  []tmux.WindowOptions{win(1, "fix/412", "/wt/a"), win(2, "fix/412", "/wt/b")},
+			panes: []tmux.PaneOptions{agentPane("%307", "h:1"), agentPane("%308", "h:2")},
+			wantN: 2,
+		},
+		{
+			// Without the @claude_status clause the crew layer's Agent would
+			// promote this shell into a listed run.
+			name:  "the only pane is a shell",
+			wins:  []tmux.WindowOptions{win(1, "fix/412", "/wt/a")},
+			panes: []tmux.PaneOptions{{PaneID: "%9", Target: "h:1"}},
+			wantN: 0,
+		},
+		{
+			name:  "another bus holds the same branch name",
+			wins:  []tmux.WindowOptions{win(1, "fix/412", "/other")},
+			panes: []tmux.PaneOptions{agentPane("%307", "h:1")},
+			wantN: 0,
+		},
+		{
+			name:  "an unknown root disqualifies its window",
+			wins:  []tmux.WindowOptions{win(1, "fix/412", "/not/a/repo")},
+			panes: []tmux.PaneOptions{agentPane("%307", "h:1")},
+			wantN: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pane, n := resolvePane(testBus, "fix/412", tc.wins, tc.panes, testBusOf)
+			if n != tc.wantN {
+				t.Errorf("candidates = %d, want %d", n, tc.wantN)
+			}
+			if pane != tc.wantPane {
+				t.Errorf("paneID = %q, want %q", pane, tc.wantPane)
+			}
+		})
+	}
+}
+
+func TestResolvePaneKeepsTwoBusesApart(t *testing.T) {
+	wins := []tmux.WindowOptions{
+		{Session: "h", Window: 1, Branch: "main", GitRoot: "/wt/a"},
+		{Session: "h", Window: 2, Branch: "main", GitRoot: "/other"},
+	}
+	panes := []tmux.PaneOptions{agentPane("%1", "h:1"), agentPane("%2", "h:2")}
+
+	if pane, n := resolvePane(testBus, "main", wins, panes, testBusOf); pane != "%1" || n != 1 {
+		t.Errorf("bus A: got (%q, %d), want (%%1, 1) — the other bus's window must not count", pane, n)
+	}
+	if pane, n := resolvePane("/other/.git/crew", "main", wins, panes, testBusOf); pane != "%2" || n != 1 {
+		t.Errorf("bus B: got (%q, %d), want (%%2, 1)", pane, n)
+	}
+}
+
+// writeBus creates a bus directory holding one dispatch record per branch.
+func writeBus(t *testing.T, branches ...string) string {
+	t.Helper()
+	dir := t.TempDir()
+	var b strings.Builder
+	for _, br := range branches {
+		fmt.Fprintf(&b, `{"ts":1000,"crew_id":"c1","kind":"dispatch","branch":%q,"engine":"claude"}`+"\n", br)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "events.jsonl"), []byte(b.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// crewScanner builds a CrewSource whose bus lookup is pre-seeded, so scan()
+// exercises the join without shelling out to git.
+func crewScanner(dirs map[string]string, wins []tmux.WindowOptions, panes []tmux.PaneOptions) *CrewSource {
+	return &CrewSource{
+		client:   &fakeLister{steps: []fakeStep{{wins: wins, panes: panes}}},
+		crewDirs: dirs,
+	}
+}
+
+func TestScanPublishesUnderTheJoinedPaneKey(t *testing.T) {
+	bus := writeBus(t, "fix/412")
+	s := crewScanner(
+		map[string]string{"/wt/a": bus},
+		[]tmux.WindowOptions{{Session: "h", Window: 1, Branch: "fix/412", GitRoot: "/wt/a"}},
+		[]tmux.PaneOptions{agentPane("%307", "h:1")},
+	)
+
+	got, ok := s.scan()
+	if !ok {
+		t.Fatal("scan reported failure")
+	}
+	r, found := got["%307"]
+	if !found {
+		t.Fatalf("no run under the pane key — keys %v", keysOf(got))
+	}
+	if r.Worktree != "/wt/a" {
+		t.Errorf("Worktree = %q, want /wt/a — this string becomes the reply command's working directory", r.Worktree)
+	}
+}
+
+func TestScanFallsBackWhenNoPaneJoins(t *testing.T) {
+	t.Run("the only pane is a shell", func(t *testing.T) {
+		bus := writeBus(t, "fix/412")
+		s := crewScanner(
+			map[string]string{"/wt/a": bus},
+			[]tmux.WindowOptions{{Session: "h", Window: 1, Branch: "fix/412", GitRoot: "/wt/a"}},
+			[]tmux.PaneOptions{{PaneID: "%9", Target: "h:1"}},
+		)
+
+		got, _ := s.scan()
+		want := "crew/" + bus + "/fix/412"
+		if _, found := got[want]; !found {
+			t.Fatalf("no run under %q — keys %v", want, keysOf(got))
+		}
+		if _, found := got["%9"]; found {
+			t.Error("the crew layer landed on a shell pane, which its Agent would promote into a listed run")
+		}
+		if got[want].Worktree != "/wt/a" {
+			t.Errorf("Worktree = %q, want /wt/a — an unjoined branch still has a window", got[want].Worktree)
+		}
+	})
+
+	t.Run("no window on that branch", func(t *testing.T) {
+		bus := writeBus(t, "fix/412")
+		s := crewScanner(
+			map[string]string{"/wt/a": bus},
+			[]tmux.WindowOptions{{Session: "h", Window: 1, Branch: "main", GitRoot: "/wt/a"}},
+			[]tmux.PaneOptions{agentPane("%1", "h:1")},
+		)
+
+		got, _ := s.scan()
+		want := "crew/" + bus + "/fix/412"
+		r, found := got[want]
+		if !found {
+			t.Fatalf("no run under %q — keys %v", want, keysOf(got))
+		}
+		// Deliberately not /wt/a: the root set comes only from live windows,
+		// so falling back to one would hand this branch another worker's
+		// checkout, and WORKER_TASK.md there outranks CREW_ID.
+		if r.Worktree != "" {
+			t.Errorf("Worktree = %q, want \"\" — no window carries this branch", r.Worktree)
+		}
+	})
+}
+
+func TestScanKeepsTwoBusesApart(t *testing.T) {
+	busA := writeBus(t, "main")
+	busB := writeBus(t, "main")
+	s := crewScanner(
+		map[string]string{"/wt/a": busA, "/other": busB},
+		[]tmux.WindowOptions{
+			{Session: "h", Window: 1, Branch: "main", GitRoot: "/wt/a"},
+			{Session: "h", Window: 2, Branch: "main", GitRoot: "/other"},
+		},
+		nil,
+	)
+
+	got, _ := s.scan()
+	keyA, keyB := "crew/"+busA+"/main", "crew/"+busB+"/main"
+	if len(got) != 2 {
+		t.Fatalf("%d runs, want 2 — two repos holding a main record must not collide: keys %v", len(got), keysOf(got))
+	}
+	if got[keyA].Worktree != "/wt/a" || got[keyB].Worktree != "/other" {
+		t.Fatalf("worktrees crossed buses: %q and %q", got[keyA].Worktree, got[keyB].Worktree)
+	}
+
+	reg := NewRegistry(DefaultOrder)
+	for key, r := range got {
+		reg.Apply(Delta{Source: "crew", Key: key, Run: r})
+	}
+	snap := reg.Snapshot()
+	if len(snap) != 2 {
+		t.Fatalf("Snapshot has %d runs, want 2: %+v", len(snap), snap)
+	}
+	if snap[0].ID == snap[1].ID {
+		t.Errorf("both runs share the id %q", snap[0].ID)
+	}
+}
+
+// errPaneLister answers the window query but fails the pane query, which is
+// the half of the skip-the-tick rule the pane query added.
+type errPaneLister struct{}
+
+func (errPaneLister) ListWindowOptions() ([]tmux.WindowOptions, error) {
+	return []tmux.WindowOptions{{Session: "h", Window: 1, Branch: "fix/412", GitRoot: "/wt/a"}}, nil
+}
+
+func (errPaneLister) ListPaneOptions() ([]tmux.PaneOptions, error) {
+	return nil, errors.New("tmux boom")
+}
+
+func TestScanSkipsTheTickOnAPaneQueryError(t *testing.T) {
+	s := &CrewSource{client: errPaneLister{}, crewDirs: map[string]string{"/wt/a": writeBus(t, "fix/412")}}
+	if got, ok := s.scan(); ok {
+		t.Fatalf("scan reported success with %v — a tmux error must skip the tick, not retire every branch", keysOf(got))
+	}
+}
+
+func TestTickCrewDeltasEmitsTheNewKeyBeforeTheOldGone(t *testing.T) {
+	oldKey := "crew/" + testBus + "/fix/412"
+	current := map[string]Run{"%307": {Branch: "fix/412", State: StateBlocked, UpdatedAt: time.Now().Unix()}}
+
+	deltas, newSeen := tickCrewDeltas(current, map[string]bool{oldKey: true}, time.Now())
+
+	if len(deltas) != 2 {
+		t.Fatalf("deltas = %+v, want the new key's update and the old key's Gone", deltas)
+	}
+	if deltas[0].Gone || deltas[0].Key != "%307" {
+		t.Fatalf("first delta = %+v, want the new key's update — a subscriber must never briefly hold neither key", deltas[0])
+	}
+	if !deltas[1].Gone || deltas[1].Key != oldKey {
+		t.Fatalf("second delta = %+v, want Gone for %q", deltas[1], oldKey)
+	}
+	if newSeen[oldKey] {
+		t.Error("the abandoned key is still in the new seen set")
+	}
+}
+
+func TestKeyFlipBroadcastsTheNewRunThenRemovesTheOldID(t *testing.T) {
+	oldKey := "crew/" + testBus + "/fix/412"
+	blocked := Run{Agent: "claude", Branch: "fix/412", State: StateBlocked,
+		Question: &Question{Text: "Keep the alias?", Via: "crew"}}
+
+	reg := NewRegistry(DefaultOrder)
+	reg.Apply(Delta{Source: "crew", Key: oldKey, Run: blocked})
+
+	sub := reg.Subscribe()
+	defer reg.Unsubscribe(sub)
+
+	// The pane opened: scan() now resolves the same branch to %307.
+	deltas, _ := tickCrewDeltas(map[string]Run{"%307": blocked}, map[string]bool{oldKey: true}, time.Now())
+	for _, d := range deltas {
+		reg.Apply(d)
+	}
+
+	first := <-sub
+	if first.ID != idFor("%307") || first.Removed {
+		t.Fatalf("first broadcast = %+v, want the new key's run", first)
+	}
+	second := <-sub
+	if second.ID != idFor(oldKey) || !second.Removed {
+		t.Fatalf("second broadcast = %+v, want Removed for the old id %q", second, idFor(oldKey))
+	}
 }

--- a/runs/registry.go
+++ b/runs/registry.go
@@ -159,6 +159,16 @@ func (r *Registry) composeLocked(key string) (Run, bool) {
 	}
 	out.ID = idFor(key)
 	out.Caps = deriveCaps(bySource)
+	// run.go documents "non-nil Question implies State == StateBlocked", and
+	// composition is where that invariant must actually hold: hooksource.go
+	// keys on the same pane id as the crew layer and sits above it in
+	// DefaultOrder, so a worker blocked on `crew await` merges as State ==
+	// StateRunning from hooks while the crew layer's Question survives. Forcing
+	// it here restores the invariant without touching precedence: a layer that
+	// reports blocked without a Question is unaffected.
+	if out.Question != nil {
+		out.State = StateBlocked
+	}
 	return out, true
 }
 
@@ -183,17 +193,18 @@ func deriveCaps(bySource map[string]Run) Caps {
 // idFor derives a URL-path-safe Run.ID from a source's correlation key. The
 // key itself keeps flowing internally unchanged — it is load-bearing for layer
 // bookkeeping — only the externally visible ID differs. Without this, "%307"
-// decodes as a path segment to "/07", and "branch/fix/412" or "claude/<sid>"
-// contain slashes that break /api/runs/{id} segment routing outright.
+// decodes as a path segment to "/07", and "crew/<busDir>/<branch>" or
+// "claude/<sid>" contain slashes that break /api/runs/{id} segment routing
+// outright.
 func idFor(key string) string {
 	switch {
 	case strings.HasPrefix(key, "%"):
 		return "pane-" + strings.TrimPrefix(key, "%")
 	case strings.HasPrefix(key, "claude/"):
 		return "sess-" + strings.TrimPrefix(key, "claude/")
-	case strings.HasPrefix(key, "branch/"):
-		b := strings.TrimPrefix(key, "branch/")
-		return "branch-" + base64.RawURLEncoding.EncodeToString([]byte(b))
+	case strings.HasPrefix(key, "crew/"):
+		b := strings.TrimPrefix(key, "crew/")
+		return "crew-" + base64.RawURLEncoding.EncodeToString([]byte(b))
 	default:
 		return "key-" + base64.RawURLEncoding.EncodeToString([]byte(key))
 	}
@@ -225,11 +236,11 @@ func runSignature(r Run) string {
 	}
 	b.WriteByte('|')
 	if r.Crew != nil {
-		b.WriteString(r.Crew.Name + "," + r.Crew.Tier)
+		b.WriteString(r.Crew.Name + "," + r.Crew.Codename + "," + r.Crew.Color + "," + r.Crew.Tier)
 	}
 	b.WriteByte('|')
 	if r.Question != nil {
-		b.WriteString(r.Question.Text)
+		b.WriteString(r.Question.Text + "," + r.Question.Via)
 	}
 	b.WriteByte('|')
 	b.WriteString(r.Activity.Tool + "," + r.Activity.Hint + "," + r.Activity.Message + "," + r.Activity.Task + "," + r.Activity.Preview)
@@ -277,7 +288,25 @@ func mergeInto(dst *Run, src Run) {
 		dst.PR = src.PR
 	}
 	if src.Crew != nil {
-		dst.Crew = src.Crew
+		// Field-wise, not wholesale: tmux owns Codename/Color and the crew bus
+		// owns Name/Tier, so two layers can each set half of this struct on the
+		// same key. Wholesale replacement would let whichever layer merges last
+		// erase the other's half.
+		if dst.Crew == nil {
+			dst.Crew = &CrewRef{}
+		}
+		if src.Crew.Name != "" {
+			dst.Crew.Name = src.Crew.Name
+		}
+		if src.Crew.Codename != "" {
+			dst.Crew.Codename = src.Crew.Codename
+		}
+		if src.Crew.Color != "" {
+			dst.Crew.Color = src.Crew.Color
+		}
+		if src.Crew.Tier != "" {
+			dst.Crew.Tier = src.Crew.Tier
+		}
 	}
 	if src.Question != nil {
 		dst.Question = src.Question

--- a/runs/registry_test.go
+++ b/runs/registry_test.go
@@ -52,6 +52,71 @@ func TestCrewBeatsTmuxButNotHooks(t *testing.T) {
 	}
 }
 
+func TestQuestionForcesBlockedOverHooksRunning(t *testing.T) {
+	// hooksource.go keys on the same pane id as the crew layer and sits above
+	// it in DefaultOrder, so a worker blocked on `crew await` is, to Claude's
+	// hooks, inside a running Bash tool. Without the composeLocked invariant,
+	// hooks' State would win by precedence and the crew Question would survive
+	// pointing at a run the UI reports as running.
+	r := NewRegistry(DefaultOrder)
+	r.Apply(Delta{Source: "tmux", Key: "%1", Run: Run{Agent: "claude", State: StateRunning}})
+	r.Apply(Delta{Source: "crew", Key: "%1", Run: Run{
+		State:    StateBlocked,
+		Question: &Question{Text: "run tests?", Via: "crew"},
+	}})
+	r.Apply(Delta{Source: "hooks", Key: "%1", Run: Run{
+		State:    StateRunning,
+		Activity: Activity{Tool: "Bash"},
+	}})
+
+	got := r.Snapshot()[0]
+	if got.State != StateBlocked {
+		t.Fatalf("State = %q, want %q — a surviving Question must force blocked even though hooks composed running", got.State, StateBlocked)
+	}
+	if got.Question == nil || got.Question.Text != "run tests?" {
+		t.Fatalf("Question = %+v, want the crew layer's question intact", got.Question)
+	}
+}
+
+func TestAnsweredCrewLayerStopsForcingBlocked(t *testing.T) {
+	// R5: once the crew bus has answered a question, the crew layer publishes
+	// no opinion (State: "", Question: nil) rather than remembering the old
+	// blocked state. The badge must actually go dark then, not just stop being
+	// refreshed.
+	t.Run("crew layer retracts its question, running wins", func(t *testing.T) {
+		r := NewRegistry(DefaultOrder)
+		r.Apply(Delta{Source: "tmux", Key: "%1", Run: Run{Agent: "claude", State: StateRunning}})
+		r.Apply(Delta{Source: "hooks", Key: "%1", Run: Run{State: StateRunning}})
+		r.Apply(Delta{Source: "crew", Key: "%1", Run: Run{State: "", Question: nil}})
+
+		got := r.Snapshot()[0]
+		if got.State != StateRunning {
+			t.Fatalf("State = %q, want %q — an answered question must stop forcing blocked", got.State, StateRunning)
+		}
+		if got.Question != nil {
+			t.Fatalf("Question = %+v, want nil", got.Question)
+		}
+	})
+
+	t.Run("crew layer still carries its question, blocked wins", func(t *testing.T) {
+		r := NewRegistry(DefaultOrder)
+		r.Apply(Delta{Source: "tmux", Key: "%1", Run: Run{Agent: "claude", State: StateRunning}})
+		r.Apply(Delta{Source: "hooks", Key: "%1", Run: Run{State: StateRunning}})
+		r.Apply(Delta{Source: "crew", Key: "%1", Run: Run{
+			State:    StateBlocked,
+			Question: &Question{Text: "still waiting", Via: "crew"},
+		}})
+
+		got := r.Snapshot()[0]
+		if got.State != StateBlocked {
+			t.Fatalf("State = %q, want %q — the badge must stay lit while the question stands", got.State, StateBlocked)
+		}
+		if got.Question == nil {
+			t.Fatal("Question = nil, want the crew layer's question")
+		}
+	})
+}
+
 func TestGoneRemovesOnlyThatSourcesLayer(t *testing.T) {
 	r := NewRegistry(DefaultOrder)
 	// tmux carries its own Agent here — a real tmux layer does, whenever the
@@ -163,6 +228,45 @@ func TestApplyDedupesUnchangedUpdates(t *testing.T) {
 	}
 }
 
+func TestSignatureCoversCrewCodename(t *testing.T) {
+	r := NewRegistry(DefaultOrder)
+	sub := r.Subscribe()
+	defer r.Unsubscribe(sub)
+
+	r.Apply(Delta{Source: "tmux", Key: "%1", Run: Run{Agent: "claude", Crew: &CrewRef{Codename: "a"}}})
+	r.Apply(Delta{Source: "tmux", Key: "%1", Run: Run{Agent: "claude", Crew: &CrewRef{Codename: "b"}}})
+
+	if n := len(sub); n != 2 {
+		t.Fatalf("%d broadcasts, want 2 — a Crew.Codename change must reach a subscriber", n)
+	}
+}
+
+func TestSignatureCoversCrewColor(t *testing.T) {
+	r := NewRegistry(DefaultOrder)
+	sub := r.Subscribe()
+	defer r.Unsubscribe(sub)
+
+	r.Apply(Delta{Source: "tmux", Key: "%1", Run: Run{Agent: "claude", Crew: &CrewRef{Color: "#111111"}}})
+	r.Apply(Delta{Source: "tmux", Key: "%1", Run: Run{Agent: "claude", Crew: &CrewRef{Color: "#222222"}}})
+
+	if n := len(sub); n != 2 {
+		t.Fatalf("%d broadcasts, want 2 — a Crew.Color change must reach a subscriber", n)
+	}
+}
+
+func TestSignatureCoversQuestionVia(t *testing.T) {
+	r := NewRegistry(DefaultOrder)
+	sub := r.Subscribe()
+	defer r.Unsubscribe(sub)
+
+	r.Apply(Delta{Source: "hooks", Key: "%1", Run: Run{Agent: "claude", Question: &Question{Text: "q", Via: "pane"}}})
+	r.Apply(Delta{Source: "hooks", Key: "%1", Run: Run{Agent: "claude", Question: &Question{Text: "q", Via: "crew"}}})
+
+	if n := len(sub); n != 2 {
+		t.Fatalf("%d broadcasts, want 2 — a Question.Via change must reach a subscriber", n)
+	}
+}
+
 func TestDirtyReflectsADroppedUpdate(t *testing.T) {
 	r := NewRegistry(DefaultOrder)
 	ch := r.Subscribe()
@@ -192,10 +296,11 @@ func TestDirtyReflectsADroppedUpdate(t *testing.T) {
 }
 
 func TestIdForIsURLPathSafe(t *testing.T) {
+	busDir := "/repo/.git/crew"
 	cases := []struct{ key, want string }{
 		{"%307", "pane-307"},
 		{"claude/abc-123", "sess-abc-123"},
-		{"branch/fix/412", "branch-" + base64.RawURLEncoding.EncodeToString([]byte("fix/412"))},
+		{"crew/" + busDir + "/fix/412", "crew-" + base64.RawURLEncoding.EncodeToString([]byte(busDir+"/fix/412"))},
 	}
 	for _, c := range cases {
 		got := idFor(c.key)
@@ -260,9 +365,11 @@ func TestApplyDoesNotRaceSubscribeClose(t *testing.T) {
 
 func TestPointerRefsReplaceWholesale(t *testing.T) {
 	// Nested refs are swapped, not merged. This is safe only while every source
-	// that publishes one publishes it complete — tmux owns Issue/PR/Crew, and
-	// hooks and tmux both publish a full TmuxRef. If a source ever starts
-	// emitting a partial ref, this test is where that shows up.
+	// that publishes one publishes it complete — tmux owns Issue/PR, and hooks
+	// and tmux both publish a full TmuxRef. Crew is the one exception: two
+	// layers now own different fields of it, so it merges field-wise instead —
+	// see TestCrewMergesFieldWise. If another ref ever starts arriving partial
+	// from more than one layer, this test is where that shows up.
 	r := NewRegistry(DefaultOrder)
 	r.Apply(Delta{Source: "tmux", Key: "%1", Run: Run{Issue: &IssueRef{ID: "#1", Title: "rich"}}})
 	r.Apply(Delta{Source: "hooks", Key: "%1", Run: Run{Agent: "claude", Issue: &IssueRef{ID: "#1"}}})
@@ -300,6 +407,27 @@ func TestMergeIntoCoversEveryField(t *testing.T) {
 	}
 }
 
+func TestCrewMergesFieldWise(t *testing.T) {
+	r := NewRegistry(DefaultOrder)
+	// tmux owns Codename/Color; the crew bus owns Name/Tier. Wholesale
+	// replacement would let whichever layer merges last erase the other's half.
+	r.Apply(Delta{Source: "tmux", Key: "%1", Run: Run{
+		Agent: "claude",
+		Crew:  &CrewRef{Codename: "Ferris", Color: "#ff0000"},
+	}})
+	r.Apply(Delta{Source: "crew", Key: "%1", Run: Run{
+		Crew: &CrewRef{Name: "crab-crew", Tier: "lead"},
+	}})
+
+	got := r.Snapshot()[0].Crew
+	if got == nil {
+		t.Fatal("Crew = nil, want both layers' fields merged")
+	}
+	if got.Codename != "Ferris" || got.Color != "#ff0000" || got.Name != "crab-crew" || got.Tier != "lead" {
+		t.Errorf("Crew = %+v, want tmux's Codename/Color and crew's Name/Tier all present", got)
+	}
+}
+
 func TestCapsTerminalGoesFalseAfterTmuxLayerGoesGone(t *testing.T) {
 	r := NewRegistry(DefaultOrder)
 	r.Apply(Delta{Source: "tmux", Key: "%1", Run: Run{Agent: "claude"}})
@@ -327,7 +455,9 @@ func TestCapsTerminalGoesFalseAfterTmuxLayerGoesGone(t *testing.T) {
 func TestCapsReplyRequiresLayerNotJustFlag(t *testing.T) {
 	r := NewRegistry(DefaultOrder)
 	// Matches what crewsource.go publishes today: no Caps set on the delta.
-	r.Apply(Delta{Source: "crew", Key: "branch/fix/1", Run: Run{Agent: "claude", State: StateBlocked}})
+	// Key shape matches I2's zero-or-≥2-candidates case ("crew/" + busDir +
+	// "/" + branch) — no source emits "branch/" any more.
+	r.Apply(Delta{Source: "crew", Key: "crew//repo/.git/crew/fix/1", Run: Run{Agent: "claude", State: StateBlocked}})
 
 	got := r.Snapshot()
 	if len(got) != 1 {

--- a/runs/run.go
+++ b/runs/run.go
@@ -70,9 +70,10 @@ type PRRef struct {
 }
 
 type CrewRef struct {
-	Name  string `json:"name"`
-	Color string `json:"color,omitempty"`
-	Tier  string `json:"tier,omitempty"`
+	Name     string `json:"name"`               // crew id — the grouping key. Crew bus only. "" when only tmux knows this run.
+	Codename string `json:"codename,omitempty"` // lazytmux @crew_name: this worker's codename. tmux only.
+	Color    string `json:"color,omitempty"`    // "#rrggbb" or "". tmux only.
+	Tier     string `json:"tier,omitempty"`     // Crew bus only.
 }
 
 // Activity is what the run is doing right now.

--- a/runs/tmuxsource.go
+++ b/runs/tmuxsource.go
@@ -86,10 +86,7 @@ func (s *TmuxSource) Run(ctx context.Context, out chan<- Delta) error {
 // window was not listed is skipped rather than emitted bare — it means the two
 // queries raced a window closing.
 func deltasFromTmux(wins []tmux.WindowOptions, panes []tmux.PaneOptions) []Delta {
-	byTarget := make(map[string]tmux.WindowOptions, len(wins))
-	for _, w := range wins {
-		byTarget[fmt.Sprintf("%s:%d", w.Session, w.Window)] = w
-	}
+	byTarget := windowsByTarget(wins)
 
 	out := make([]Delta, 0, len(panes))
 	for _, p := range panes {
@@ -126,11 +123,21 @@ func deltasFromTmux(wins []tmux.WindowOptions, panes []tmux.PaneOptions) []Delta
 			}
 		}
 		if w.CrewName != "" {
-			r.Crew = &CrewRef{Name: w.CrewName}
+			r.Crew = &CrewRef{Codename: w.CrewName, Color: tmuxColorToHex(w.CrewColor)}
 		}
 		out = append(out, Delta{Source: "tmux", Key: p.PaneID, Run: r})
 	}
 	return out
+}
+
+// windowsByTarget indexes windows by the "session:window" string a pane
+// carries as its Target. Both sources join panes to windows through it.
+func windowsByTarget(wins []tmux.WindowOptions) map[string]tmux.WindowOptions {
+	byTarget := make(map[string]tmux.WindowOptions, len(wins))
+	for _, w := range wins {
+		byTarget[fmt.Sprintf("%s:%d", w.Session, w.Window)] = w
+	}
+	return byTarget
 }
 
 func firstNonEmpty(vals ...string) string {

--- a/runs/tmuxsource_test.go
+++ b/runs/tmuxsource_test.go
@@ -13,7 +13,7 @@ func TestDeltasFromTmuxJoinsPanesToWindows(t *testing.T) {
 	wins := []tmux.WindowOptions{{
 		Session: "lazytmux", Window: 2, Branch: "feat/320",
 		IssueID: "#320", PRNumber: "565", PRState: "open", PRCheckState: "passing",
-		CrewName: "mauve", GitRoot: "/home/n/git/lazytmux",
+		CrewName: "mauve", CrewColor: "colour168", GitRoot: "/home/n/git/lazytmux",
 	}}
 	panes := []tmux.PaneOptions{{
 		PaneID: "%459", Target: "lazytmux:2", ClaudeStatus: "processing 1788 ",
@@ -39,7 +39,7 @@ func TestDeltasFromTmuxJoinsPanesToWindows(t *testing.T) {
 	if d.Run.PR == nil || d.Run.PR.Number != "565" || d.Run.PR.CheckState != "passing" {
 		t.Errorf("PR = %+v", d.Run.PR)
 	}
-	if d.Run.Crew == nil || d.Run.Crew.Name != "mauve" {
+	if d.Run.Crew == nil || d.Run.Crew.Codename != "mauve" || d.Run.Crew.Name != "" || d.Run.Crew.Color != "#d75f87" {
 		t.Errorf("Crew = %+v", d.Run.Crew)
 	}
 	if d.Run.Repo != "lazytmux" {

--- a/server/runs_reply.go
+++ b/server/runs_reply.go
@@ -1,0 +1,181 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/noamsto/houston/runs"
+)
+
+const (
+	// maxReplyText bounds the answer itself. crew elides a bus line past ~4KiB,
+	// so anything materially larger is not going to survive delivery anyway.
+	maxReplyText = 8 << 10
+	// maxReplyBody bounds the JSON envelope, leaving room for escaping a
+	// maxReplyText answer made entirely of escaped characters.
+	maxReplyBody = 64 << 10
+
+	replyTimeout = 15 * time.Second
+)
+
+// replyExec is one crew reply, fully resolved by the handler. The runner adds
+// nothing and decides nothing.
+type replyExec struct {
+	Dir    string   // Run.Worktree — the working directory; never "" by the time a runner sees it
+	CrewID string   // Run.Crew.Name — passed as CREW_ID=<CrewID> appended to os.Environ()
+	Argv   []string // exactly {"crew", "reply", "worker:" + Run.Branch, text}; no shell, no "--"
+}
+
+type replyResult struct {
+	Stderr   string
+	ExitCode int   // 0 delivered; non-zero means crew refused → 409 with Stderr
+	Err      error // the command could not run or finish: exec.ErrNotFound → 502, context.DeadlineExceeded → 504
+}
+
+type replyRunner func(ctx context.Context, x replyExec) replyResult
+
+// execCrewReply is the real runner. The argv slice reaches execve untouched:
+// no shell, and no "--" — crew reply takes its two operands positionally and
+// does no option parsing, so a leading-dash answer is already literal and a
+// "--" would be consumed as the recipient.
+func execCrewReply(ctx context.Context, x replyExec) replyResult {
+	cmd := exec.CommandContext(ctx, x.Argv[0], x.Argv[1:]...)
+	cmd.Dir = x.Dir
+	cmd.Env = append(os.Environ(), "CREW_ID="+x.CrewID)
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+
+	res := replyResult{Stderr: strings.TrimSpace(stderr.String())}
+	var exitErr *exec.ExitError
+	switch {
+	case err == nil:
+	case errors.Is(ctx.Err(), context.DeadlineExceeded):
+		// A timeout kills the child, so Run reports "signal: killed" — an
+		// ExitError. Checking the context first is what keeps 504 from being
+		// misread as crew's own refusal.
+		res.Err = context.DeadlineExceeded
+	case errors.As(err, &exitErr):
+		res.ExitCode = exitErr.ExitCode()
+	default:
+		res.Err = err
+	}
+	return res
+}
+
+// handleRunReply delivers a crew answer to a blocked worker.
+//
+//	POST /api/runs/{id}/reply  {"text": "<answer>"} → 204
+//
+// This is the only route in houston that turns client input into a process
+// argument, so the target is resolved entirely from the registry: a client can
+// name a run, never a command, a branch, or a directory.
+func (s *Server) handleRunReply(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if s.runs == nil {
+		http.Error(w, "run registry not started", http.StatusServiceUnavailable)
+		return
+	}
+
+	run, ok := s.findRun(id)
+	if !ok {
+		replyOutcome(w, id, "", http.StatusNotFound, "no such run")
+		return
+	}
+
+	switch {
+	case run.Crew == nil || run.Crew.Name == "":
+		replyOutcome(w, id, run.Branch, http.StatusBadRequest, "run has no crew")
+		return
+	case run.Branch == "":
+		replyOutcome(w, id, run.Branch, http.StatusBadRequest, "run has no branch")
+		return
+	case run.Worktree == "":
+		replyOutcome(w, id, run.Branch, http.StatusBadRequest, "run has no worktree")
+		return
+	case run.Question == nil:
+		replyOutcome(w, id, run.Branch, http.StatusBadRequest, "run is not asking anything")
+		return
+	case run.Question.Via != "crew":
+		// Answering a pane question over the bus posts to something nobody is
+		// reading while the agent sits at its prompt — a false success.
+		replyOutcome(w, id, run.Branch, http.StatusBadRequest, "question is not answered over the crew bus")
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxReplyBody)
+	var body struct {
+		Text string `json:"text"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		var tooBig *http.MaxBytesError
+		if errors.As(err, &tooBig) {
+			replyOutcome(w, id, run.Branch, http.StatusRequestEntityTooLarge, "answer too large")
+			return
+		}
+		replyOutcome(w, id, run.Branch, http.StatusBadRequest, "malformed request body")
+		return
+	}
+	if len(body.Text) > maxReplyText {
+		replyOutcome(w, id, run.Branch, http.StatusRequestEntityTooLarge, "answer too large")
+		return
+	}
+	if strings.TrimSpace(body.Text) == "" {
+		replyOutcome(w, id, run.Branch, http.StatusBadRequest, "empty answer")
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), replyTimeout)
+	defer cancel()
+
+	res := s.replyRunner(ctx, replyExec{
+		Dir:    run.Worktree,
+		CrewID: run.Crew.Name,
+		Argv:   []string{"crew", "reply", "worker:" + run.Branch, body.Text},
+	})
+
+	switch {
+	case errors.Is(res.Err, context.DeadlineExceeded):
+		replyOutcome(w, id, run.Branch, http.StatusGatewayTimeout, "crew reply timed out")
+	case res.Err != nil:
+		replyOutcome(w, id, run.Branch, http.StatusBadGateway, "could not run crew reply: "+res.Err.Error())
+	case res.ExitCode != 0:
+		// crew's own words, verbatim: 409 is the worker's refusal, not ours.
+		reason := res.Stderr
+		if reason == "" {
+			reason = "crew reply refused"
+		}
+		replyOutcome(w, id, run.Branch, http.StatusConflict, reason)
+	default:
+		replyOutcome(w, id, run.Branch, http.StatusNoContent, "delivered")
+	}
+}
+
+// findRun resolves a run by its externally visible ID. No registry method
+// exists for this and none is needed — the snapshot is already the answer.
+func (s *Server) findRun(id string) (runs.Run, bool) {
+	for _, run := range s.runs.Snapshot() {
+		if run.ID == id {
+			return run, true
+		}
+	}
+	return runs.Run{}, false
+}
+
+// replyOutcome logs the attempt and writes its result. 204 is the one case
+// with no body, which http.Error cannot express.
+func replyOutcome(w http.ResponseWriter, id, branch string, code int, detail string) {
+	slog.Info("run reply", "id", id, "branch", branch, "status", code, "outcome", detail)
+	if code == http.StatusNoContent {
+		w.WriteHeader(code)
+		return
+	}
+	http.Error(w, detail, code)
+}

--- a/server/runs_reply_e2e_test.go
+++ b/server/runs_reply_e2e_test.go
@@ -1,0 +1,160 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/noamsto/houston/runs"
+)
+
+// requireCrew skips when the real CLI is absent. Every other test in this
+// package runs against a stub; this one exists to check the two choices a stub
+// cannot check — the working directory and CREW_ID.
+func requireCrew(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("crew"); err != nil {
+		t.Skip("crew not on PATH: skipping the only test that exercises the real bus, the working directory and CREW_ID")
+	}
+}
+
+// newCrewBus builds a scratch git repo with its own bus, holding a dispatch
+// record for replyBranch and one status for session s. It returns the repo
+// root (the worktree the handler will run crew in) and the bus log path.
+func newCrewBus(t *testing.T, session, state string) (root, log string) {
+	t.Helper()
+	root = t.TempDir()
+	if out, err := exec.Command("git", "-C", root, "init", "-q").CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v: %s", err, out)
+	}
+
+	dir := filepath.Join(root, ".git", "crew")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir bus: %v", err)
+	}
+	log = filepath.Join(dir, "events.jsonl")
+
+	ts := time.Now().UnixMilli()
+	lines := []string{
+		fmt.Sprintf(`{"ts":%d,"crew_id":%q,"from":"dispatcher:%s","kind":"dispatch","branch":%q,"session":%q}`,
+			ts, replyCrew, replyCrew, replyBranch, session),
+		fmt.Sprintf(`{"ts":%d,"crew_id":%q,"from":"worker:%s#%s","kind":"status","body":{"state":%q,"detail":"which base branch?"}}`,
+			ts+1, replyCrew, replyBranch, session, state),
+	}
+	if err := os.WriteFile(log, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatalf("write bus: %v", err)
+	}
+	return root, log
+}
+
+type busRecord struct {
+	CrewID string          `json:"crew_id"`
+	From   string          `json:"from"`
+	To     string          `json:"to"`
+	Kind   string          `json:"kind"`
+	Body   json.RawMessage `json:"body"`
+}
+
+func lastBusRecord(t *testing.T, log string) busRecord {
+	t.Helper()
+	b, err := os.ReadFile(log)
+	if err != nil {
+		t.Fatalf("read bus: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(b)), "\n")
+	var rec busRecord
+	if err := json.Unmarshal([]byte(lines[len(lines)-1]), &rec); err != nil {
+		t.Fatalf("decode bus line %q: %v", lines[len(lines)-1], err)
+	}
+	return rec
+}
+
+// The only test that can falsify the working-directory and CREW_ID choices: a
+// wrong Dir writes to a different repo's bus (or houston's own), and a missing
+// CREW_ID makes crew exit 1 before it writes anything.
+func TestReplyReachesTheRealCrewBus(t *testing.T) {
+	requireCrew(t)
+
+	const session = "s100-1"
+	root, log := newCrewBus(t, session, "blocked")
+	_, otherLog := newCrewBus(t, "s200-1", "blocked")
+	otherBefore, err := os.ReadFile(otherLog)
+	if err != nil {
+		t.Fatalf("read other bus: %v", err)
+	}
+
+	s := newReplyServer(t, execCrewReply, crewDelta(func(r *runs.Run) { r.Worktree = root }))
+
+	// Leading "--" on purpose: crew reply does no option parsing, so the
+	// endpoint must not insert a separator of its own — one would be consumed
+	// as the recipient. Nothing but the real CLI can check that.
+	const answer = "-- rebase onto main, not merge; `id` $(id)"
+	rec := doReply(t, s, replyRequest("POST", replyPath(t, s), replyBody(t, answer)))
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status %d, want 204 (body %q)", rec.Code, rec.Body.String())
+	}
+	got := lastBusRecord(t, log)
+	if got.Kind != "msg" {
+		t.Errorf("kind %q, want %q", got.Kind, "msg")
+	}
+	if want := "worker:" + replyBranch + "#" + session; got.To != want {
+		t.Errorf("to %q, want %q — the answer must be addressed to the live worker", got.To, want)
+	}
+	if got.CrewID != replyCrew {
+		t.Errorf("crew_id %q, want %q — CREW_ID did not reach crew", got.CrewID, replyCrew)
+	}
+	if want := "dispatcher:" + replyCrew; got.From != want {
+		t.Errorf("from %q, want %q", got.From, want)
+	}
+	var body string
+	if err := json.Unmarshal(got.Body, &body); err != nil {
+		t.Fatalf("body is not a JSON string: %v", err)
+	}
+	if body != answer {
+		t.Errorf("body %q, want %q — the answer must round-trip verbatim", body, answer)
+	}
+
+	otherAfter, err := os.ReadFile(otherLog)
+	if err != nil {
+		t.Fatalf("read other bus: %v", err)
+	}
+	if string(otherAfter) != string(otherBefore) {
+		t.Error("a second repo's bus changed — the working directory did not pin the delivery")
+	}
+}
+
+// A terminal session is the worker's own refusal, not houston's failure.
+func TestReplyToFinishedWorkerIsRefusedWithCrewsWords(t *testing.T) {
+	requireCrew(t)
+
+	root, log := newCrewBus(t, "s100-1", "done")
+	before, err := os.ReadFile(log)
+	if err != nil {
+		t.Fatalf("read bus: %v", err)
+	}
+
+	s := newReplyServer(t, execCrewReply, crewDelta(func(r *runs.Run) { r.Worktree = root }))
+
+	rec := doReply(t, s, replyRequest("POST", replyPath(t, s), replyBody(t, "go ahead")))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status %d, want 409 (body %q)", rec.Code, rec.Body.String())
+	}
+	body := strings.TrimSpace(rec.Body.String())
+	if !strings.Contains(body, "is done") {
+		t.Errorf("body %q does not carry crew's own refusal", body)
+	}
+
+	after, err := os.ReadFile(log)
+	if err != nil {
+		t.Fatalf("read bus: %v", err)
+	}
+	if string(after) != string(before) {
+		t.Error("a refused reply still wrote to the bus")
+	}
+}

--- a/server/runs_reply_test.go
+++ b/server/runs_reply_test.go
@@ -1,0 +1,428 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/noamsto/houston/runs"
+)
+
+const (
+	replyToken  = "reply-secret"
+	replyOrigin = "http://good.example"
+	replyHost   = "127.0.0.1:9090"
+	replyBranch = "feat/x"
+	replyBus    = "/repo/.git/crew"
+	replyCrew   = "c-test"
+	replyDir    = "/tmp/houston-reply-worktree"
+)
+
+// stubRunner stands in for the real crew invocation. Its call count is the
+// only way to prove a refusal happened before anything ran.
+type stubRunner struct {
+	mu     sync.Mutex
+	calls  []replyExec
+	result replyResult
+}
+
+func (s *stubRunner) run(_ context.Context, x replyExec) replyResult {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls = append(s.calls, x)
+	return s.result
+}
+
+func (s *stubRunner) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.calls)
+}
+
+func (s *stubRunner) last(t *testing.T) replyExec {
+	t.Helper()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.calls) == 0 {
+		t.Fatal("runner was never called")
+	}
+	return s.calls[len(s.calls)-1]
+}
+
+// crewDelta is a blocked crew-sourced run that satisfies every precondition.
+// mut relaxes exactly one of them per test.
+func crewDelta(mut func(*runs.Run)) runs.Delta {
+	r := runs.Run{
+		Agent:    "claude",
+		State:    runs.StateBlocked,
+		Branch:   replyBranch,
+		Worktree: replyDir,
+		Crew:     &runs.CrewRef{Name: replyCrew},
+		Question: &runs.Question{Text: "rebase or merge?", Via: "crew"},
+	}
+	if mut != nil {
+		mut(&r)
+	}
+	return runs.Delta{Source: "crew", Key: "crew/" + replyBus + "/" + replyBranch, Run: r}
+}
+
+// newReplyServer wires the real gates the way New does, without touching disk
+// or spawning tmux.
+func newReplyServer(t *testing.T, runner replyRunner, deltas ...runs.Delta) *Server {
+	t.Helper()
+	reg := runs.NewRegistry(runs.DefaultOrder)
+	for _, d := range deltas {
+		reg.Apply(d)
+	}
+	allowed := []string{replyOrigin}
+	return &Server{
+		auth:        &authGate{token: replyToken, enabled: true, allowedOrigins: allowed},
+		hosts:       deriveHosts(nil, allowed),
+		runs:        reg,
+		replyRunner: runner,
+	}
+}
+
+// replyPath is the route for the single seeded run, read back from the
+// registry so the test never has to reimplement ID derivation.
+func replyPath(t *testing.T, s *Server) string {
+	t.Helper()
+	snap := s.runs.Snapshot()
+	if len(snap) != 1 {
+		t.Fatalf("registry holds %d listed runs, want 1", len(snap))
+	}
+	return "/api/runs/" + snap[0].ID + "/reply"
+}
+
+func replyRequest(method, path, body string) *http.Request {
+	req := httptest.NewRequest(method, "http://"+replyHost+path, strings.NewReader(body))
+	req.Host = replyHost
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: authCookie, Value: replyToken})
+	return req
+}
+
+func replyBody(t *testing.T, text string) string {
+	t.Helper()
+	b, err := json.Marshal(map[string]string{"text": text})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(b)
+}
+
+func doReply(t *testing.T, s *Server, req *http.Request) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rec, req)
+	return rec
+}
+
+// The falsifiable question: is there any residual path from an unauthenticated,
+// cross-origin, rebound or non-POST request to a command running? Each case
+// asserts zero invocations, not just a status code.
+func TestReplyGatesLeaveNoPathToACommand(t *testing.T) {
+	cases := []struct {
+		name    string
+		want    int
+		prepare func(*http.Request)
+	}{
+		{"no token", http.StatusUnauthorized, func(r *http.Request) {
+			r.Header.Del("Cookie")
+		}},
+		{"cross origin", http.StatusForbidden, func(r *http.Request) {
+			r.Header.Set("Origin", "http://evil.example")
+		}},
+		{"rebound host", http.StatusMisdirectedRequest, func(r *http.Request) {
+			r.Host = "evil.example"
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stub := &stubRunner{}
+			s := newReplyServer(t, stub.run, crewDelta(nil))
+			req := replyRequest("POST", replyPath(t, s), replyBody(t, "yes"))
+			tc.prepare(req)
+
+			rec := doReply(t, s, req)
+			if rec.Code != tc.want {
+				t.Errorf("status %d, want %d", rec.Code, tc.want)
+			}
+			if n := stub.count(); n != 0 {
+				t.Fatalf("runner called %d times behind a closed gate — a command ran without a valid request", n)
+			}
+		})
+	}
+
+	t.Run("GET", func(t *testing.T) {
+		stub := &stubRunner{}
+		s := newReplyServer(t, stub.run, crewDelta(nil))
+		rec := doReply(t, s, replyRequest("GET", replyPath(t, s), ""))
+
+		// 405 rather than merely non-2xx: the method pattern is what refuses
+		// this, in the mux, before the handler exists.
+		if rec.Code != http.StatusMethodNotAllowed {
+			t.Errorf("status %d, want 405 — a GET must not reach a mutating route", rec.Code)
+		}
+		if n := stub.count(); n != 0 {
+			t.Fatalf("runner called %d times on a GET, want 0", n)
+		}
+	})
+}
+
+// The reply is an argv element, so shell metacharacters are inert and a
+// leading dash is an operand rather than a flag.
+func TestReplyArgvIsOneLiteralElement(t *testing.T) {
+	const nasty = "-n; rm -rf / `id` $(id) \"quoted\" && echo pwned\nsecond line"
+
+	stub := &stubRunner{}
+	s := newReplyServer(t, stub.run, crewDelta(nil))
+
+	rec := doReply(t, s, replyRequest("POST", replyPath(t, s), replyBody(t, nasty)))
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status %d, want 204", rec.Code)
+	}
+
+	got := stub.last(t)
+	want := []string{"crew", "reply", "worker:" + replyBranch, nasty}
+	if len(got.Argv) != len(want) {
+		t.Fatalf("argv %q, want %q", got.Argv, want)
+	}
+	for i := range want {
+		if got.Argv[i] != want[i] {
+			t.Errorf("argv[%d] = %q, want %q", i, got.Argv[i], want[i])
+		}
+	}
+	if got.Dir != replyDir {
+		t.Errorf("Dir = %q, want %q", got.Dir, replyDir)
+	}
+	if got.CrewID != replyCrew {
+		t.Errorf("CrewID = %q, want %q", got.CrewID, replyCrew)
+	}
+}
+
+func TestReplyOutcomes(t *testing.T) {
+	cases := []struct {
+		name     string
+		result   replyResult
+		want     int
+		wantBody string
+	}{
+		{"delivered", replyResult{}, http.StatusNoContent, ""},
+		{
+			"crew refused",
+			replyResult{ExitCode: 1, Stderr: "crew: newest session on feat/x is done — a stopped session never reads its inbox"},
+			http.StatusConflict,
+			"crew: newest session on feat/x is done — a stopped session never reads its inbox",
+		},
+		{
+			"crew not on PATH",
+			replyResult{Err: &exec.Error{Name: "crew", Err: exec.ErrNotFound}},
+			http.StatusBadGateway,
+			"crew",
+		},
+		{"timed out", replyResult{Err: context.DeadlineExceeded}, http.StatusGatewayTimeout, "timed out"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stub := &stubRunner{result: tc.result}
+			s := newReplyServer(t, stub.run, crewDelta(nil))
+
+			rec := doReply(t, s, replyRequest("POST", replyPath(t, s), replyBody(t, "yes")))
+			if rec.Code != tc.want {
+				t.Fatalf("status %d, want %d (body %q)", rec.Code, tc.want, rec.Body.String())
+			}
+			body := strings.TrimSpace(rec.Body.String())
+			if tc.wantBody == "" {
+				if body != "" {
+					t.Errorf("body %q, want empty", body)
+				}
+				return
+			}
+			if !strings.Contains(body, tc.wantBody) {
+				t.Errorf("body %q, want it to contain %q", body, tc.wantBody)
+			}
+			if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/plain") {
+				t.Errorf("Content-Type %q, want text/plain", ct)
+			}
+		})
+	}
+}
+
+// 409 carries crew's own words so the UI can show the worker's refusal rather
+// than houston's paraphrase of it.
+func TestReplyRefusalIsCrewStderrVerbatim(t *testing.T) {
+	const stderr = "crew: no session on feat/x — dispatch a worker before replying to one"
+
+	stub := &stubRunner{result: replyResult{ExitCode: 1, Stderr: stderr}}
+	s := newReplyServer(t, stub.run, crewDelta(nil))
+
+	rec := doReply(t, s, replyRequest("POST", replyPath(t, s), replyBody(t, "yes")))
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status %d, want 409", rec.Code)
+	}
+	if got := strings.TrimSpace(rec.Body.String()); got != stderr {
+		t.Errorf("body %q, want %q", got, stderr)
+	}
+}
+
+func TestReplyPreconditionsRefuseBeforeRunning(t *testing.T) {
+	cases := []struct {
+		name  string
+		delta runs.Delta
+		body  string
+		path  string
+		want  int
+	}{
+		{
+			name:  "unknown id",
+			delta: crewDelta(nil),
+			path:  "/api/runs/branch-bm9wZQ/reply",
+			want:  http.StatusNotFound,
+		},
+		{
+			name:  "no crew",
+			delta: crewDelta(func(r *runs.Run) { r.Crew = nil }),
+			want:  http.StatusBadRequest,
+		},
+		{
+			name:  "empty crew name",
+			delta: crewDelta(func(r *runs.Run) { r.Crew = &runs.CrewRef{Codename: "sage"} }),
+			want:  http.StatusBadRequest,
+		},
+		{
+			name:  "no branch",
+			delta: crewDelta(func(r *runs.Run) { r.Branch = "" }),
+			want:  http.StatusBadRequest,
+		},
+		{
+			name:  "no worktree",
+			delta: crewDelta(func(r *runs.Run) { r.Worktree = "" }),
+			want:  http.StatusBadRequest,
+		},
+		{
+			name:  "no question",
+			delta: crewDelta(func(r *runs.Run) { r.Question = nil }),
+			want:  http.StatusBadRequest,
+		},
+		{
+			name:  "question answered at the pane",
+			delta: crewDelta(func(r *runs.Run) { r.Question = &runs.Question{Text: "1 or 2?", Via: "pane"} }),
+			want:  http.StatusBadRequest,
+		},
+		{
+			name:  "empty text",
+			delta: crewDelta(nil),
+			body:  `{"text":"   \n  "}`,
+			want:  http.StatusBadRequest,
+		},
+		{
+			name:  "missing text",
+			delta: crewDelta(nil),
+			body:  `{}`,
+			want:  http.StatusBadRequest,
+		},
+		{
+			name:  "malformed body",
+			delta: crewDelta(nil),
+			body:  `{"text":`,
+			want:  http.StatusBadRequest,
+		},
+		{
+			name:  "text over maxReplyText",
+			delta: crewDelta(nil),
+			body:  `{"text":"` + strings.Repeat("a", maxReplyText+1) + `"}`,
+			want:  http.StatusRequestEntityTooLarge,
+		},
+		{
+			name:  "body over MaxBytesReader",
+			delta: crewDelta(nil),
+			body:  `{"text":"` + strings.Repeat("a", maxReplyBody+1) + `"}`,
+			want:  http.StatusRequestEntityTooLarge,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stub := &stubRunner{}
+			s := newReplyServer(t, stub.run, tc.delta)
+
+			path := tc.path
+			if path == "" {
+				path = replyPath(t, s)
+			}
+			body := tc.body
+			if body == "" {
+				body = replyBody(t, "yes")
+			}
+
+			rec := doReply(t, s, replyRequest("POST", path, body))
+			if rec.Code != tc.want {
+				t.Errorf("status %d, want %d (body %q)", rec.Code, tc.want, rec.Body.String())
+			}
+			if n := stub.count(); n != 0 {
+				t.Fatalf("runner called %d times on a failed precondition, want 0", n)
+			}
+		})
+	}
+}
+
+// A branch is never taken from the request: two runs on different branches
+// differ only by the id in the path, and that id picks the argv target.
+func TestReplyTargetComesFromTheRegistryNotTheRequest(t *testing.T) {
+	stub := &stubRunner{}
+	s := newReplyServer(t, stub.run, crewDelta(nil))
+
+	req := replyRequest("POST", replyPath(t, s), replyBody(t, "yes"))
+	req.URL.RawQuery = "branch=attacker/branch&worktree=/etc"
+	req.Header.Set("X-Branch", "attacker/branch")
+
+	if rec := doReply(t, s, req); rec.Code != http.StatusNoContent {
+		t.Fatalf("status %d, want 204", rec.Code)
+	}
+	if got := stub.last(t); got.Argv[2] != "worker:"+replyBranch || got.Dir != replyDir {
+		t.Errorf("argv[2]=%q dir=%q — the target must come from the registry", got.Argv[2], got.Dir)
+	}
+}
+
+// execCrewReply's own error mapping, exercised without a crew binary.
+func TestExecCrewReplyReportsMissingBinary(t *testing.T) {
+	res := execCrewReply(context.Background(), replyExec{
+		Dir:    t.TempDir(),
+		CrewID: replyCrew,
+		Argv:   []string{"houston-no-such-binary", "reply", "worker:x", "hi"},
+	})
+	if res.Err == nil {
+		t.Fatalf("Err = nil, want a not-found error (exit %d, stderr %q)", res.ExitCode, res.Stderr)
+	}
+	if res.ExitCode != 0 {
+		t.Errorf("ExitCode = %d, want 0 — a command that never ran has no exit code", res.ExitCode)
+	}
+}
+
+// The deadline branch is the tricky one: killing the child makes Run report an
+// ExitError, which would otherwise be mistaken for crew's own refusal.
+func TestExecCrewReplyReportsTimeoutNotRefusal(t *testing.T) {
+	if _, err := exec.LookPath("sleep"); err != nil {
+		t.Skip("sleep not on PATH")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	res := execCrewReply(ctx, replyExec{Dir: t.TempDir(), CrewID: replyCrew, Argv: []string{"sleep", "10"}})
+	if !errors.Is(res.Err, context.DeadlineExceeded) {
+		t.Fatalf("Err = %v, want context.DeadlineExceeded", res.Err)
+	}
+	if res.ExitCode != 0 {
+		t.Errorf("ExitCode = %d, want 0 — a killed command did not choose its exit code", res.ExitCode)
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -93,6 +93,10 @@ type Server struct {
 	// runs composes the hook, tmux and crew sources into one Run per key.
 	runs *runs.Registry
 
+	// replyRunner delivers a crew answer. It exists so a test can observe that
+	// no command ran, which no assertion about the response alone can prove.
+	replyRunner replyRunner
+
 	auth  *authGate
 	hosts *hostGate
 }
@@ -146,6 +150,7 @@ func New(cfg Config) (*Server, error) {
 		uiFS:         cfg.UIFS,
 		lastActivity: make(map[string]time.Time),
 		hub:          hub.New(cfg.StatusDir, slog.Default()),
+		replyRunner:  execCrewReply,
 	}
 
 	// Run the hub in the background. It watches <status-dir>/claude/ and the
@@ -241,6 +246,7 @@ func (s *Server) Handler() http.Handler {
 	apiMux.HandleFunc("/api/agents/stream", s.handleAgentsStream)
 	apiMux.HandleFunc("/api/runs", s.handleRunsSnapshot)
 	apiMux.HandleFunc("/api/runs/stream", s.handleRunsStream)
+	apiMux.HandleFunc("POST /api/runs/{id}/reply", s.handleRunReply)
 	mux.Handle("/api/", s.auth.middleware(apiMux))
 
 	// The host gate wraps everything, including "/", so a rebound domain is

--- a/tmux/options.go
+++ b/tmux/options.go
@@ -15,7 +15,7 @@ const optSep = "\x1f"
 // tmux resolves #{@name} inline, so no per-window show-options loop is needed.
 const windowOptionsFormat = "#{session_name}" + optSep + "#{window_index}" + optSep + "#{@branch}" + optSep + "#{@issue_id}" + optSep +
 	"#{@pr_number}" + optSep + "#{@crew_name}" + optSep + "#{@pr_state}" + optSep + "#{@pr_check_state}" + optSep + "#{@pr_mergeable}" + optSep +
-	"#{@window_task}" + optSep + "#{@git_root}"
+	"#{@window_task}" + optSep + "#{@git_root}" + optSep + "#{@crew_color}"
 
 const paneOptionsFormat = "#{pane_id}" + optSep + "#{session_name}:#{window_index}" + optSep + "#{@claude_status}" + optSep + "#{@claude_task}"
 
@@ -33,6 +33,7 @@ type WindowOptions struct {
 	PRMergeable  string
 	Task         string
 	GitRoot      string
+	CrewColor    string
 }
 
 type PaneOptions struct {
@@ -62,7 +63,7 @@ func ParseWindowOptions(out string) []WindowOptions {
 	var res []WindowOptions
 	for _, line := range strings.Split(out, "\n") {
 		f := strings.Split(line, optSep)
-		if len(f) != 11 {
+		if len(f) != 12 {
 			continue
 		}
 		idx, err := strconv.Atoi(f[1])
@@ -72,7 +73,7 @@ func ParseWindowOptions(out string) []WindowOptions {
 		res = append(res, WindowOptions{
 			Session: f[0], Window: idx, Branch: f[2], IssueID: f[3],
 			PRNumber: f[4], CrewName: f[5], PRState: f[6], PRCheckState: f[7],
-			PRMergeable: f[8], Task: f[9], GitRoot: f[10],
+			PRMergeable: f[8], Task: f[9], GitRoot: f[10], CrewColor: f[11],
 		})
 	}
 	return res

--- a/tmux/options_test.go
+++ b/tmux/options_test.go
@@ -4,8 +4,8 @@ import "testing"
 
 func TestParseWindowOptions(t *testing.T) {
 	// Real output shape, including the common all-empty-options case.
-	out := "lazytmux\x1f2\x1ffeat/320-relay\x1f#320\x1f565\x1fmauve\x1fopen\x1fpassing\x1fMERGEABLE\x1f\x1f\n" +
-		"houston\x1f1\x1fmain\x1f\x1f\x1f\x1f\x1f\x1f\x1f\x1f\n"
+	out := "lazytmux\x1f2\x1ffeat/320-relay\x1f#320\x1f565\x1fmauve\x1fopen\x1fpassing\x1fMERGEABLE\x1f\x1f\x1fcolour168\n" +
+		"houston\x1f1\x1fmain\x1f\x1f\x1f\x1f\x1f\x1f\x1f\x1f\x1f\n"
 
 	got := ParseWindowOptions(out)
 	if len(got) != 2 {
@@ -22,6 +22,9 @@ func TestParseWindowOptions(t *testing.T) {
 	if w.CrewName != "mauve" || w.PRState != "open" || w.PRCheckState != "passing" {
 		t.Errorf("got crew=%q pr_state=%q checks=%q", w.CrewName, w.PRState, w.PRCheckState)
 	}
+	if w.CrewColor != "colour168" {
+		t.Errorf("CrewColor = %q, want colour168", w.CrewColor)
+	}
 
 	bare := got[1]
 	if bare.Branch != "main" || bare.IssueID != "" || bare.PRNumber != "" {
@@ -30,7 +33,7 @@ func TestParseWindowOptions(t *testing.T) {
 }
 
 func TestParseWindowOptionsSkipsMalformedLines(t *testing.T) {
-	got := ParseWindowOptions("too\x1ffew\x1ffields\n\nhouston\x1f1\x1fmain\x1f\x1f\x1f\x1f\x1f\x1f\x1f\x1f\n")
+	got := ParseWindowOptions("too\x1ffew\x1ffields\n\nhouston\x1f1\x1fmain\x1f\x1f\x1f\x1f\x1f\x1f\x1f\x1f\x1f\n")
 	if len(got) != 1 {
 		t.Fatalf("%d windows, want 1 — short and empty lines are skipped, not fatal", len(got))
 	}
@@ -40,7 +43,7 @@ func TestParseWindowOptionsSurvivesPipeInFreeText(t *testing.T) {
 	// @window_task is free text captured from a user prompt, so it can contain
 	// anything. With a "|" delimiter this shifted GitRoot into garbage and
 	// silently dropped the real value.
-	out := "houston\x1f1\x1fmain\x1f\x1f\x1f\x1f\x1f\x1f\x1frun x | grep fail\x1f/home/n/git/houston\n"
+	out := "houston\x1f1\x1fmain\x1f\x1f\x1f\x1f\x1f\x1f\x1frun x | grep fail\x1f/home/n/git/houston\x1f\n"
 
 	got := ParseWindowOptions(out)
 	if len(got) != 1 {

--- a/ui/src/api/runs.ts
+++ b/ui/src/api/runs.ts
@@ -1,4 +1,6 @@
 // Mirror of runs.State (Go). Exactly one state means "a human is required".
+// Can also be '' on the wire: a crew layer that has nothing left to say (R5)
+// publishes no state opinion, and runtime already tolerates the empty value.
 export type RunState =
   | 'thinking'
   | 'running'
@@ -32,8 +34,9 @@ export interface PRRef {
 }
 
 export interface CrewRef {
-  name: string
-  color?: string
+  name: string // crew id; '' when only tmux knows this run — such a run belongs to no crew group
+  codename?: string
+  color?: string // always '#rrggbb' when present; never a tmux colour name
   tier?: string
 }
 
@@ -95,6 +98,35 @@ export interface Run {
   stale?: boolean
   caps: Caps
   removed?: boolean
+}
+
+// Mirror of server/runs_reply.go's response contract. `refused` (409, the
+// worker's own stderr) and `failed` (502/504/network, houston's fault) must
+// stay distinct — collapsing them is what makes "surface the failure
+// honestly" untestable.
+export type ReplyOutcome =
+  | { kind: 'delivered' }
+  | { kind: 'refused'; reason: string }
+  | { kind: 'rejected'; reason: string }
+  | { kind: 'failed'; reason: string }
+
+export async function replyRun(id: string, text: string): Promise<ReplyOutcome> {
+  let res: Response
+  try {
+    res = await fetch(`/api/runs/${id}/reply`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text }),
+    })
+  } catch {
+    return { kind: 'failed', reason: 'network error' }
+  }
+  if (res.status === 204) return { kind: 'delivered' }
+  // http.Error appends a trailing newline server-side; trim it, not the text itself.
+  const reason = (await res.text()).trim()
+  if (res.status === 409) return { kind: 'refused', reason }
+  if (res.status === 400 || res.status === 404 || res.status === 413) return { kind: 'rejected', reason }
+  return { kind: 'failed', reason }
 }
 
 // The pane WS route (`server/server.go:parsePaneTarget`) percent-decodes the

--- a/ui/src/fleet/CrewsView.test.tsx
+++ b/ui/src/fleet/CrewsView.test.tsx
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import { CrewsView } from './CrewsView'
+import type { Run } from '../api/runs'
+
+const now = 1_800_000_000_000 // fixed ms
+
+function run(p: Partial<Run> = {}): Run {
+  return {
+    id: 'pane-1', agent: 'claude', state: 'running',
+    activity: {}, tokens: { input: 0, output: 0 },
+    caps: { terminal: true, reply: true, kill: true },
+    updated_at: Math.floor(now / 1000),
+    ...p,
+  } as Run
+}
+
+afterEach(cleanup)
+
+describe('CrewsView grouping', () => {
+  it('groups two runs with different crew.name into two headers with the right member and blocked counts', () => {
+    const runs = [
+      run({ id: 'a', crew: { name: 'crew-a' }, state: 'running' }),
+      run({ id: 'b', crew: { name: 'crew-b' }, state: 'blocked' }),
+    ]
+    const { container } = render(<CrewsView runs={runs} now={now} />)
+
+    const headers = container.querySelectorAll('.crews-group')
+    expect(headers.length).toBe(2)
+
+    const crewA = Array.from(headers).find((h) => h.getAttribute('title') === 'crew-a')!
+    expect(crewA.textContent).toContain('1 member')
+    expect(crewA.textContent).not.toContain('blocked')
+
+    const crewB = Array.from(headers).find((h) => h.getAttribute('title') === 'crew-b')!
+    expect(crewB.textContent).toContain('1 member')
+    expect(crewB.textContent).toContain('1 blocked')
+  })
+
+  it('excludes a run with no crew and one with crew.name === "", showing the empty state when that is all there is', () => {
+    const runs = [
+      run({ id: 'no-crew' }),
+      run({ id: 'blank-crew', crew: { name: '' } }),
+    ]
+    const { container } = render(<CrewsView runs={runs} now={now} />)
+
+    expect(container.querySelectorAll('.crews-group').length).toBe(0)
+    expect(screen.getByText(/no crews/i)).toBeTruthy()
+  })
+
+  it('renders the tier chip for a member with crew.tier and the PR chip for a member with a pr', () => {
+    const runs = [
+      run({ id: 'tiered', crew: { name: 'crew-c', tier: 'lead' } }),
+      run({ id: 'prd', crew: { name: 'crew-c' }, pr: { number: '42' } }),
+    ]
+    const { container } = render(<CrewsView runs={runs} now={now} />)
+
+    expect(container.querySelector('.run-chip.tier')?.textContent).toBe('lead')
+    expect(container.querySelector('.run-chip.pr')?.textContent).toBe('#42')
+  })
+
+  it('renders a composer only for a member whose question.via is "crew"', () => {
+    const runs = [
+      run({ id: 'crew-q', crew: { name: 'crew-d' }, state: 'blocked', question: { text: 'proceed?', via: 'crew' } }),
+      run({ id: 'pane-q', crew: { name: 'crew-d' }, state: 'blocked', question: { text: 'y/n?', via: 'pane' } }),
+    ]
+    const { container } = render(<CrewsView runs={runs} now={now} />)
+
+    const composers = container.querySelectorAll('.crew-reply')
+    expect(composers.length).toBe(1)
+  })
+
+  it('orders crew groups: a group with a blocked member first, then by most recent member activity', () => {
+    const nowSec = Math.floor(now / 1000)
+    const runs = [
+      run({ id: 'old', crew: { name: 'crew-old' }, state: 'running', updated_at: nowSec - 100_000 }),
+      run({ id: 'recent', crew: { name: 'crew-recent' }, state: 'running', updated_at: nowSec - 10 }),
+      run({ id: 'blocked', crew: { name: 'crew-blocked' }, state: 'blocked', updated_at: nowSec }),
+    ]
+    const { container } = render(<CrewsView runs={runs} now={now} />)
+
+    const order = Array.from(container.querySelectorAll('.crews-group')).map((h) => h.getAttribute('title'))
+    expect(order).toEqual(['crew-blocked', 'crew-recent', 'crew-old'])
+  })
+
+  it('orders members within a group: blocked first, then by most recently updated', () => {
+    const nowSec = Math.floor(now / 1000)
+    const runs = [
+      run({ id: 'old', crew: { name: 'crew-e' }, state: 'running', updated_at: nowSec - 1_000 }),
+      run({ id: 'new', crew: { name: 'crew-e' }, state: 'running', updated_at: nowSec }),
+      run({ id: 'blocked', crew: { name: 'crew-e' }, state: 'blocked', updated_at: nowSec - 5 }),
+    ]
+    const { container } = render(<CrewsView runs={runs} now={now} />)
+
+    const section = container.querySelector('section')!
+    const order = Array.from(section.querySelectorAll('.run-name')).map((n) => n.textContent)
+    expect(order).toEqual(['blocked', 'new', 'old'])
+  })
+})

--- a/ui/src/fleet/CrewsView.tsx
+++ b/ui/src/fleet/CrewsView.tsx
@@ -1,0 +1,90 @@
+import { useMemo } from 'react'
+import type { Run } from '../api/runs'
+import { needsYou } from './staleness'
+import { RunCard } from './RunCard'
+import { ReplyComposer } from './ReplyComposer'
+import './fleet.css'
+
+interface CrewsViewProps {
+  runs: Run[]
+  now: number
+  onOpen?: (r: Run) => void
+}
+
+interface CrewGroup {
+  name: string
+  members: Run[]
+  blocked: number
+  lastActive: number
+}
+
+// The bus carries no crew-level title, only the id — shorten it for the
+// header but keep the full id reachable as the element's `title`.
+function shortId(name: string): string {
+  return name.length > 12 ? `${name.slice(0, 10)}…` : name
+}
+
+export function CrewsView({ runs, now, onOpen }: CrewsViewProps) {
+  const groups = useMemo<CrewGroup[]>(() => {
+    const byCrew = new Map<string, Run[]>()
+    for (const r of runs) {
+      // No crew, or a crew with no id, belongs to no group — the Fleet tab
+      // already lists every run; this would just be a second fleet list.
+      const name = r.crew?.name
+      if (!name) continue
+      const list = byCrew.get(name)
+      if (list) list.push(r)
+      else byCrew.set(name, [r])
+    }
+
+    const entries = Array.from(byCrew.entries()).map(([name, members]) => {
+      const sorted = [...members].sort((a, b) => {
+        const an = needsYou(a, now) ? 1 : 0
+        const bn = needsYou(b, now) ? 1 : 0
+        if (an !== bn) return bn - an
+        return b.updated_at - a.updated_at
+      })
+      const blocked = sorted.filter((m) => needsYou(m, now)).length
+      const lastActive = sorted.reduce((max, m) => Math.max(max, m.updated_at), 0)
+      return { name, members: sorted, blocked, lastActive }
+    })
+
+    entries.sort((a, b) => {
+      const ab = a.blocked > 0 ? 1 : 0
+      const bb = b.blocked > 0 ? 1 : 0
+      if (ab !== bb) return bb - ab
+      return b.lastActive - a.lastActive
+    })
+    return entries
+  }, [runs, now])
+
+  return (
+    <div className="crews mocha">
+      <header className="fleet-nav">
+        <h1>Crews</h1>
+      </header>
+
+      {groups.length === 0 && (
+        <div className="fleet-empty">No crews yet — runs appear here once they carry a crew id.</div>
+      )}
+
+      {groups.map((g) => (
+        <section key={g.name}>
+          <div className="crews-group" title={g.name}>
+            <span>{shortId(g.name)}</span>
+            <span>
+              {g.members.length} member{g.members.length === 1 ? '' : 's'}
+              {g.blocked > 0 ? ` · ${g.blocked} blocked` : ''}
+            </span>
+          </div>
+          {g.members.map((r) => (
+            <div key={r.id}>
+              <RunCard run={r} now={now} onOpen={onOpen} />
+              {r.question?.via === 'crew' && <ReplyComposer runId={r.id} />}
+            </div>
+          ))}
+        </section>
+      ))}
+    </div>
+  )
+}

--- a/ui/src/fleet/ReplyComposer.test.tsx
+++ b/ui/src/fleet/ReplyComposer.test.tsx
@@ -27,8 +27,8 @@ describe('ReplyComposer accessibility', () => {
   })
 })
 
-describe('ReplyComposer double-tap guard', () => {
-  it('produces exactly one replyRun call from two rapid clicks', async () => {
+describe('ReplyComposer disabled-while-sending', () => {
+  it('produces exactly one replyRun call from two rapid clicks, because the second click hits a disabled button', async () => {
     let resolve!: (o: ReplyOutcome) => void
     replyRunMock.mockReturnValue(new Promise((r) => { resolve = r }))
 

--- a/ui/src/fleet/ReplyComposer.test.tsx
+++ b/ui/src/fleet/ReplyComposer.test.tsx
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { ReplyComposer } from './ReplyComposer'
+import type { ReplyOutcome } from '../api/runs'
+
+const replyRunMock = vi.fn<(id: string, text: string) => Promise<ReplyOutcome>>()
+vi.mock('../api/runs', () => ({
+  replyRun: (id: string, text: string) => replyRunMock(id, text),
+}))
+
+async function typeAndSend(value = 'go ahead') {
+  fireEvent.change(screen.getByLabelText(/reply to the crew/i), { target: { value } })
+  fireEvent.click(screen.getByRole('button', { name: /send/i }))
+}
+
+afterEach(() => {
+  cleanup()
+  replyRunMock.mockReset()
+})
+
+describe('ReplyComposer accessibility', () => {
+  it('exposes the field and send action by name, with no adjacent question text to anchor them', () => {
+    render(<ReplyComposer runId="run-1" />)
+
+    expect(screen.getByRole('textbox', { name: /reply to the crew/i })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /send/i })).toBeTruthy()
+  })
+})
+
+describe('ReplyComposer double-tap guard', () => {
+  it('produces exactly one replyRun call from two rapid clicks', async () => {
+    let resolve!: (o: ReplyOutcome) => void
+    replyRunMock.mockReturnValue(new Promise((r) => { resolve = r }))
+
+    render(<ReplyComposer runId="run-1" />)
+    fireEvent.change(screen.getByLabelText(/reply to the crew/i), { target: { value: 'go ahead' } })
+    const button = screen.getByRole('button', { name: /send/i })
+    fireEvent.click(button)
+    fireEvent.click(button)
+
+    expect(replyRunMock).toHaveBeenCalledTimes(1)
+    resolve({ kind: 'delivered' })
+    await screen.findByText(/waiting to be picked up/i)
+  })
+})
+
+describe('ReplyComposer outcomes', () => {
+  it('delivered: says the answer is waiting to be picked up, not that the worker resumed, and clears the field', async () => {
+    replyRunMock.mockResolvedValue({ kind: 'delivered' })
+    render(<ReplyComposer runId="run-1" />)
+    await typeAndSend()
+
+    const status = await screen.findByText(/waiting to be picked up/i)
+    expect(status.textContent).not.toMatch(/resum/i)
+    expect(status.className).toContain('delivered')
+    expect((screen.getByLabelText(/reply to the crew/i) as HTMLInputElement).value).toBe('')
+  })
+
+  it('refused (409): shows the worker\'s own refusal verbatim and keeps the text', async () => {
+    replyRunMock.mockResolvedValue({ kind: 'refused', reason: 'crew: session terminal' })
+    render(<ReplyComposer runId="run-1" />)
+    await typeAndSend()
+
+    const status = await screen.findByText('crew: session terminal')
+    expect(status.className).toContain('refused')
+    expect((screen.getByLabelText(/reply to the crew/i) as HTMLInputElement).value).toBe('go ahead')
+  })
+
+  it('rejected (400/404/413): shows houston\'s precondition reason', async () => {
+    replyRunMock.mockResolvedValue({ kind: 'rejected', reason: 'no crew for this run' })
+    render(<ReplyComposer runId="run-1" />)
+    await typeAndSend()
+
+    const status = await screen.findByText('no crew for this run')
+    expect(status.className).toContain('rejected')
+  })
+
+  it('failed (502/504/network): shows houston\'s own failure reason', async () => {
+    replyRunMock.mockResolvedValue({ kind: 'failed', reason: 'crew not found on PATH' })
+    render(<ReplyComposer runId="run-1" />)
+    await typeAndSend()
+
+    const status = await screen.findByText('crew not found on PATH')
+    expect(status.className).toContain('failed')
+  })
+})

--- a/ui/src/fleet/ReplyComposer.tsx
+++ b/ui/src/fleet/ReplyComposer.tsx
@@ -1,0 +1,49 @@
+import { useRef, useState } from 'react'
+import { replyRun, type ReplyOutcome } from '../api/runs'
+import './fleet.css'
+
+export function ReplyComposer({ runId }: { runId: string }) {
+  const [text, setText] = useState('')
+  const [sending, setSending] = useState(false)
+  const [outcome, setOutcome] = useState<ReplyOutcome | null>(null)
+  // A ref, not just the `sending` state: two taps can both read `sending`
+  // before either re-render lands. The ref is set synchronously, before the
+  // first await.
+  const inFlight = useRef(false)
+
+  async function send() {
+    const trimmed = text.trim()
+    if (inFlight.current || !trimmed) return
+    inFlight.current = true
+    setSending(true)
+    const result = await replyRun(runId, trimmed)
+    inFlight.current = false
+    setSending(false)
+    setOutcome(result)
+    if (result.kind === 'delivered') setText('')
+  }
+
+  return (
+    <div className="crew-reply">
+      <div className="crew-reply-row">
+        <input
+          type="text"
+          value={text}
+          disabled={sending}
+          placeholder="Reply to the crew…"
+          aria-label="Reply to the crew"
+          onChange={(e) => setText(e.target.value)}
+        />
+        <button type="button" disabled={sending || !text.trim()} onClick={send}>
+          Send
+        </button>
+      </div>
+      {outcome && (
+        <div className={`crew-reply-status ${outcome.kind}`}>
+          {outcome.kind === 'delivered' && 'Delivered — waiting to be picked up.'}
+          {outcome.kind !== 'delivered' && outcome.reason}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/ui/src/fleet/ReplyComposer.tsx
+++ b/ui/src/fleet/ReplyComposer.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react'
+import { useState } from 'react'
 import { replyRun, type ReplyOutcome } from '../api/runs'
 import './fleet.css'
 
@@ -6,18 +6,12 @@ export function ReplyComposer({ runId }: { runId: string }) {
   const [text, setText] = useState('')
   const [sending, setSending] = useState(false)
   const [outcome, setOutcome] = useState<ReplyOutcome | null>(null)
-  // A ref, not just the `sending` state: two taps can both read `sending`
-  // before either re-render lands. The ref is set synchronously, before the
-  // first await.
-  const inFlight = useRef(false)
 
   async function send() {
     const trimmed = text.trim()
-    if (inFlight.current || !trimmed) return
-    inFlight.current = true
+    if (!trimmed) return
     setSending(true)
     const result = await replyRun(runId, trimmed)
-    inFlight.current = false
     setSending(false)
     setOutcome(result)
     if (result.kind === 'delivered') setText('')

--- a/ui/src/fleet/RunCard.test.tsx
+++ b/ui/src/fleet/RunCard.test.tsx
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import { RunCard } from './RunCard'
+import type { Run } from '../api/runs'
+
+const now = 1_800_000_000_000 // fixed ms
+
+function run(p: Partial<Run> = {}): Run {
+  return {
+    id: 'pane-1', agent: 'claude', state: 'running',
+    activity: {}, tokens: { input: 0, output: 0 },
+    caps: { terminal: true, reply: true, kill: true },
+    updated_at: Math.floor(now / 1000),
+    ...p,
+  } as Run
+}
+
+afterEach(cleanup)
+
+describe('RunCard crew chips', () => {
+  it('shows the codename chip and not the crew id', () => {
+    const r = run({ crew: { name: 'crew-42', codename: 'blush' } })
+    render(<RunCard run={r} now={now} />)
+    expect(screen.getByText('blush')).toBeTruthy()
+    expect(screen.queryByText('crew-42')).toBeNull()
+  })
+
+  it('omits the codename chip when the crew has no codename', () => {
+    const r = run({ crew: { name: 'crew-42' } })
+    const { container } = render(<RunCard run={r} now={now} />)
+    expect(container.querySelector('.run-chip.codename')).toBeNull()
+  })
+
+  it('shows a tier chip only when crew.tier is set', () => {
+    const withTier = run({ crew: { name: 'crew-42', tier: 'lead' } })
+    const { container, rerender } = render(<RunCard run={withTier} now={now} />)
+    expect(container.querySelector('.run-chip.tier')?.textContent).toBe('lead')
+
+    const withoutTier = run({ crew: { name: 'crew-42' } })
+    rerender(<RunCard run={withoutTier} now={now} />)
+    expect(container.querySelector('.run-chip.tier')).toBeNull()
+  })
+})
+
+describe('RunCard accent', () => {
+  it('sets --run-accent when crew.color is present', () => {
+    const r = run({ crew: { name: 'crew-42', color: '#d75f87' } })
+    const { container } = render(<RunCard run={r} now={now} />)
+    const card = container.querySelector('.run-card') as HTMLElement
+    expect(card.style.getPropertyValue('--run-accent')).toBe('#d75f87')
+  })
+
+  it('leaves --run-accent unset when crew.color is empty', () => {
+    const r = run({ crew: { name: 'crew-42', color: '' } })
+    const { container } = render(<RunCard run={r} now={now} />)
+    const card = container.querySelector('.run-card') as HTMLElement
+    expect(card.style.getPropertyValue('--run-accent')).toBe('')
+  })
+
+  it('keeps the attention class on an accented card that is also blocked', () => {
+    const r = run({ state: 'blocked', crew: { name: 'crew-42', color: '#d75f87' } })
+    const { container } = render(<RunCard run={r} now={now} />)
+    const card = container.querySelector('.run-card') as HTMLElement
+    expect(card.classList.contains('attention')).toBe(true)
+    expect(card.style.getPropertyValue('--run-accent')).toBe('#d75f87')
+  })
+})

--- a/ui/src/fleet/RunCard.tsx
+++ b/ui/src/fleet/RunCard.tsx
@@ -18,7 +18,7 @@ export function RunCard({ run, now, onOpen }: { run: Run; now: number; onOpen?: 
       type="button"
       className={`run-card${attentionClass}${history ? ' history' : ''}`}
       onClick={() => onOpen?.(run)}
-      style={run.crew?.color ? ({ '--run-accent': run.crew.color } as React.CSSProperties) : undefined}
+      style={{ '--run-accent': run.crew?.color } as React.CSSProperties}
     >
       <div className="run-head">
         <span className="run-dot" style={{ background: `var(--state-${run.state}, var(--text-faint))` }} />

--- a/ui/src/fleet/RunCard.tsx
+++ b/ui/src/fleet/RunCard.tsx
@@ -18,6 +18,7 @@ export function RunCard({ run, now, onOpen }: { run: Run; now: number; onOpen?: 
       type="button"
       className={`run-card${attentionClass}${history ? ' history' : ''}`}
       onClick={() => onOpen?.(run)}
+      style={run.crew?.color ? ({ '--run-accent': run.crew.color } as React.CSSProperties) : undefined}
     >
       <div className="run-head">
         <span className="run-dot" style={{ background: `var(--state-${run.state}, var(--text-faint))` }} />
@@ -37,7 +38,8 @@ export function RunCard({ run, now, onOpen }: { run: Run; now: number; onOpen?: 
             #{run.pr.number}
           </span>
         )}
-        {run.crew && <span className="run-chip">{run.crew.name}</span>}
+        {run.crew?.codename && <span className="run-chip codename">{run.crew.codename}</span>}
+        {run.crew?.tier && <span className="run-chip tier">{run.crew.tier}</span>}
       </div>
     </button>
   )

--- a/ui/src/fleet/Shell.tsx
+++ b/ui/src/fleet/Shell.tsx
@@ -3,14 +3,14 @@ import { useRuns } from '../hooks/useRuns'
 import { needsYou } from './staleness'
 import { useNow } from './useNow'
 import { FleetView } from './FleetView'
+import { CrewsView } from './CrewsView'
 import { RunDetail } from './RunDetail'
 import '../theme/mocha.css'
 import './fleet.css'
 
 type Tab = 'fleet' | 'crews' | 'workspace' | 'dispatch'
 
-const PLACEHOLDER: Record<Exclude<Tab, 'fleet'>, string> = {
-  crews: 'Crews arrives with the dispatcher milestone — crew grouping, tier and PR badges, and answering a blocked worker from here.',
+const PLACEHOLDER: Record<Exclude<Tab, 'fleet' | 'crews'>, string> = {
   workspace: 'Workspace arrives next — the tmux tree across every host, including panes that are not agents.',
   dispatch: 'Dispatch arrives with the dispatcher milestone — pick a repo, task, tier and engine, and start work from your phone.',
 }
@@ -52,7 +52,15 @@ export function Shell() {
             onOpen={(r) => { window.location.hash = `#/fleet/${r.id}/activity` }}
           />
         </div>
-        {tab !== 'fleet' && <div className="shell-placeholder">{PLACEHOLDER[tab]}</div>}
+        {/* Kept mounted like FleetView, so a half-typed reply survives a tab switch. */}
+        <div hidden={tab !== 'crews'}>
+          <CrewsView
+            runs={runs}
+            now={now}
+            onOpen={(r) => { window.location.hash = `#/fleet/${r.id}/activity` }}
+          />
+        </div>
+        {tab !== 'fleet' && tab !== 'crews' && <div className="shell-placeholder">{PLACEHOLDER[tab]}</div>}
         {/* A stacked overlay, not a `hidden`-swapped replacement of `.fleet` —
             `hidden` maps to display:none, which would collapse `.fleet`'s own
             scroll container and lose its scrollTop on return. */}

--- a/ui/src/fleet/fleet.css
+++ b/ui/src/fleet/fleet.css
@@ -68,6 +68,7 @@
   color: inherit; font: inherit; cursor: pointer;
   min-height: var(--tap);
 }
+.run-card { border-color: var(--run-accent, var(--line)); }
 .run-card.attention { border-color: color-mix(in srgb, var(--state-blocked) 45%, var(--line)); }
 .run-card.attention.muted { border-color: color-mix(in srgb, var(--state-blocked) 22%, var(--line)); }
 .run-card.history { opacity: 0.55; }
@@ -99,6 +100,8 @@
 .run-chip.pr { background: color-mix(in srgb, var(--state-running) 18%, transparent); color: var(--state-running); }
 .run-chip.pr.failing { background: color-mix(in srgb, var(--state-blocked) 18%, transparent); color: var(--state-blocked); }
 .run-chip.issue { background: color-mix(in srgb, var(--accent) 18%, transparent); color: var(--accent); }
+.run-chip.codename { background: var(--fill); color: var(--text-strong); font-weight: 600; }
+.run-chip.tier { background: var(--bg-sunken); color: var(--text-dim); border: 1px solid var(--line); }
 
 .fleet-empty { padding: 40px 20px; text-align: center; color: var(--text-faint); font-size: 13px; }
 
@@ -223,6 +226,54 @@
 .run-detail-back:focus-visible,
 .run-detail-back-cta:focus-visible,
 .run-detail-tabs button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.crews {
+  position: absolute;
+  inset: 0;
+  overflow-y: auto;
+  background: var(--bg);
+  color: var(--text-dim);
+  font-family: var(--font-ui);
+  font-size: 14px;
+  -webkit-tap-highlight-color: transparent;
+  padding-left: env(safe-area-inset-left);
+  padding-right: env(safe-area-inset-right);
+}
+
+.crews-group {
+  display: flex; justify-content: space-between; align-items: baseline;
+  padding: 14px 14px 6px; font-size: 12px; font-weight: 600; color: var(--text-faint);
+}
+.crews-group span:first-child { color: var(--text); font-size: 13px; }
+
+.crew-reply {
+  margin: -2px 10px 12px; padding: 10px 12px; border-radius: 10px;
+  background: var(--bg-sunken); border: 1px solid var(--line);
+}
+.crew-reply-row { display: flex; gap: 8px; margin-top: 8px; }
+.crew-reply-row input {
+  flex: 1; min-height: var(--tap); min-width: 0; padding: 0 10px;
+  border-radius: 8px; border: 1px solid var(--line);
+  background: var(--bg-raised); color: var(--text); font: inherit; font-size: 13px;
+}
+.crew-reply-row input:disabled { opacity: 0.6; }
+.crew-reply-row button {
+  flex: none; min-height: var(--tap); padding: 0 14px; border-radius: 8px;
+  border: 1px solid var(--line-strong); background: var(--fill);
+  color: var(--text); font: inherit; font-size: 13px; font-weight: 600; cursor: pointer;
+}
+.crew-reply-row button:disabled { opacity: 0.5; cursor: default; }
+.crew-reply-status { margin-top: 8px; font-size: 12.5px; line-height: 1.4; }
+.crew-reply-status.delivered { color: var(--state-running); }
+.crew-reply-status.refused { color: var(--state-blocked); }
+.crew-reply-status.rejected,
+.crew-reply-status.failed { color: var(--state-failed); }
+
+.crew-reply-row input:focus-visible,
+.crew-reply-row button:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
 }


### PR DESCRIPTION
Fills the `crews` placeholder in the mobile shell: crew grouping, the branch↔pane
join, and answering a blocked worker from your phone.

Closes #33

## The three pieces

**Crew grouping.** A `CrewsView` groups runs by crew, showing each worker's
codename, tier and PR badge through the existing `RunCard` — same card, chips and
attention border, no second visual language. A run with no crew appears in no
group and is **not shown at all**: the Fleet tab already lists every run, so a
Crews tab that also listed non-crew runs would just be a second fleet list.

**The branch↔pane join.** The crew source now publishes its layer under the tmux
pane id when it can resolve one, so a dispatcher worker is one run instead of two.
State-of-play said only `session:window → pane_id` was missing; it is already in
`ListPaneOptions`, so the join needed no new tmux query, only a resolution over
the two calls the sources already make.

**Answering a blocked worker.** `POST /api/runs/{id}/reply` shells out to
`crew reply`. See the security section below.

## Three things the code disagreed with, found before writing any

**`Crew.Name` carried two incompatible meanings.** The tmux layer wrote lazytmux's
`@crew_name`, which is the *worker's* codename, while the crew bus wrote the crew
id. Codenames are `cksum(branch) % 32` and collide by construction — two live
windows here both read `blush`. Grouping on that field would have merged colliding
codenames and split real crews, so `CrewRef` now separates `name` (crew id, the
grouping key) from `codename` and `color` (the worker's, from tmux).

**The join created a state inversion it also had to fix.** The hooks layer keys on
the same pane id and outranks the crew layer, and a worker blocked on `crew await`
is, to Claude's hooks, inside a running `Bash` tool. Once joined, that composed as
`running` and the blocked worker vanished from the badge — the exact signal this
tab exists to carry. Fixed by enforcing at composition time the invariant
`runs/run.go` already documents: a run with a question is blocked. Precedence is
untouched; an existing test asserts hooks outrank a crew `blocked`, and it still
passes.

**An answered question lingered for minutes.** Measured on this repo's own bus: a
worker's next status arrived **783 s** and **348 s** after the dispatcher replied.
Before the join that staleness sat on a duplicate card; after it, it would hold the
attention badge lit on the canonical one. The crew layer now retires its own
question when it sees a newer dispatcher reply — derived from the bus itself, not
from any memory of what houston sent, since a reply can come from the dispatcher's
own terminal. This also required a fix: a `msg` body is a JSON string while a
`status` body is an object, so every reply line was failing to unmarshal and being
skipped whole. Replies were invisible to houston until now.

## Security — the reply endpoint

It executes a command with user-supplied text, so it was reviewed as a
security-sensitive surface.

- **Argv, never a shell.** `{"crew", "reply", "worker:<branch>", text}` through
  `exec.CommandContext`. There is deliberately **no `--` separator**: `crew reply`
  takes its two operands positionally with no option parsing, so a leading-dash
  answer is already literal, and a `--` would be swallowed as the recipient. Both
  verified by running the CLI, and the end-to-end test sends an answer starting
  with `--` so only the real binary can prove it.
- **The target is server-resolved.** The run comes from the registry snapshot by
  id; no client-supplied branch, worktree or path reaches the exec. A test injects
  a branch and worktree via query string and header and asserts they have no effect.
- **The falsifiable question — "is there a residual path to a state change without
  a valid token?" — was asked and answered: no.** The route is on `apiMux`, inside
  the token, origin and `Host` gates. Unauthenticated is 401, cross-origin 403, a
  rebound `Host` 421, and `GET` is refused by the mux. Each of those tests asserts
  the command runner recorded **zero** invocations, so "no command ran" is observed
  rather than asserted. The query-parameter token stays WebSocket-only.
- **Refusal is surfaced honestly.** `crew reply` exits non-zero when the newest
  session is terminal; that stderr reaches the user verbatim as a `409`, kept
  distinct from a `502` houston failure. Bounds: 64 KiB body, 8 KiB answer, 15 s
  timeout, each with its own status.
- The working directory is the target's own worktree and `CREW_ID` is passed
  explicitly. A fallback root was considered and **removed**: the root set comes
  only from live tmux windows, so with no main-checkout window open the "shortest
  root" would be another worker's worktree — and a `WORKER_TASK.md` outranks
  `CREW_ID` (measured), so the reply would have executed under the wrong crew
  identity. No matching window now means an honest refusal instead.

## Verification

Proven against the live server and the running crew, not just in tests. Before:

```
pane-13     running  feat/33-…  crew.name=blush                 %13
branch-Zm…  running  feat/33-…  crew.name=1789021677-2770173    -
```

After — one run, carrying both halves, and no `branch-*`/`crew-*` id anywhere:

```
pane-13  running  feat/33-…  crew=1789021677-2770173  codename=blush  #d75f87  deep  %13
```

`crew.color` is non-empty on every crew run, which a fixture-only test could not
have shown. The end-to-end reply test ran against the real `crew` binary rather
than skipping. 28 new Go tests and 16 new UI cases; each regression test was shown
to go red against the unfixed code before being kept.

**No browser and no display exist in this environment** — no `DISPLAY`, no
`WAYLAND_DISPLAY`, no browser binary. **The rendering is unverified.** For CSS a
passing build proves nothing here, so the built bundles were grepped instead: all
six new class declarations are in the built CSS and the accent custom property is
in the built JS. That proves the styles ship, not that they look right.

## Accepted consequences

- A run's id changes when its key flips, so an open detail view on the old id
  shows the existing "no longer available" state. Happens once per worker, within
  a poll tick.
- No server-side idempotency on the reply; the composer guards a double tap per
  client, and the bus is append-only.
- `crewDir` caches negative results for the process lifetime (known defect 8). The
  join now depends on it, so a transient `git` failure un-joins that repo until
  restart. Pre-existing and out of scope, but newly load-bearing.
- A crew `working` status still outranks a live `@claude_status` for non-blocked
  states. Created by the join, cosmetic, and recorded rather than fixed.

## Review notes

Four independent reviewers (Go, TypeScript, security, and a deterministic test
runner) found **no high-severity issues**. Acted on: a `CrewsView` test that would
have passed with the sort comparators deleted, a dead CSS rule, a trailing newline
in the surfaced refusal text, and an unvalidated hex passthrough that made a stated
type contract untrue. Not acted on: a suggestion to split `deltasFromCrewLog`,
which the reviewer raised as conditional on future growth.


https://claude.ai/code/session_019eQN3vf1GAZenhDMxyFXqK
