### PR TITLE
fix(tmux): re-seed at the end of a %pause gap, not the start

### DIFF
--- a/docs/superpowers/plans/2026-09-10-pause-gap-reseed.md
+++ b/docs/superpowers/plans/2026-09-10-pause-gap-reseed.md
@@ -1,0 +1,245 @@
+# Re-seeding at the end of a `%pause` gap — Design Record
+
+houston #34. Closes defect 3 of
+`docs/superpowers/2026-09-08-state-of-play.md`, "Known defects and follow-ups".
+
+## What was wrong
+
+`tmux/control_client.go` marked every subscriber of a pane dirty the instant
+`%pause %N` arrived (added in Task 3 of
+`2026-09-07-control-mode-transport-correctness.md`). A `Dirty` event tells
+`server/pane_ws.go` to re-seed from `capture-pane`. That capture ran at the
+**start** of the output gap, not the end:
+
+- tmux discards everything a paused pane paints. On `%continue` it resumes
+  from the pane's current offset — the backlog is dropped, not replayed.
+- A `capture-pane` taken at `%pause` therefore reflects the screen *before*
+  the discarded output existed.
+- When output resumes, houston paints new bytes onto a snapshot that
+  predates the hole. The screen is wrong and stays wrong until the next
+  unrelated re-seed.
+
+A second, independent half of the same defect: nothing resumes a pause
+houston did not issue itself. The seed handshake pauses and continues a pane
+deliberately, but a `%pause` tmux raises on its own — the only kind live
+today, since nothing sets `pause-after` — has no owner, so the pane would
+stay paused forever.
+
+Both halves are dormant in the current deployment: `pause-after` is 0 by
+default and houston never sets it, so the only `%pause` on the wire is
+houston's own handshake, which continues it a moment later. The fix had to be
+correct before flow control could ever turn that dormancy off.
+
+## The tmux facts the fix rests on
+
+Verified against tmux 3.6a's `control.c`:
+
+- `%pause %N` fires only on the not-paused → paused transition; `%continue
+  %N` only on the reverse. Pausing an already-paused pane, or continuing one
+  that isn't paused, emits nothing. The notifications are edge-triggered, so
+  tracking gap state as a per-pane flag is sound and a *count* of anything
+  is not — see "Why not a counter" below.
+- `pause-after` is a client option (`CLIENT_CONTROL_PAUSEAFTER`), set with
+  `refresh-client -f pause-after=N`. It is what would make tmux pause a pane
+  on its own, as flow control against a slow reader; today it is unset, so
+  every `%pause` on the wire is one houston asked for via
+  `refresh-client -A %N:pause`.
+- `capture-pane` runs over the tmux CLI (`exec.Command`, a separate process
+  per call); `RunCommand` runs over the control-mode connection and is
+  answered by `readLoop` itself, via the `%begin`/`%end` block the command
+  produces. `readLoop` is the single reader for every pane on the
+  connection, so it must never block on a round trip it alone can complete —
+  a resume issued from `readLoop` would deadlock the client against itself.
+
+## Mechanism
+
+A `%pause %N` opens a **gap** on pane `N` and arms a **10-second deadline**.
+The gap is closed exactly once, by whichever of two paths claims it first:
+
+- **`%continue %N`** (`closeGap`) — the healthy path. Deletes the gap record
+  and marks dirty only the subscribers that were flagged `inGap` when the
+  gap opened; a subscriber that attached during the gap is left alone.
+- **the deadline expiring** (`expireGap`) — the unhealthy path. Sends one
+  `refresh-client -A %N:continue`, then marks dirty *every* subscriber
+  currently on the pane, including ones that attached mid-gap.
+
+State lives in two places, both guarded by `cc.mu`: `ControlClient.gaps
+map[string]*gap` holds the open gap per pane (just a `*time.Timer`), and each
+`PaneSub.inGap bool` records whether that subscriber predates the gap's
+opening. Putting `inGap` on the subscription handle rather than in a list
+hanging off the gap record means `Unsubscribe` during a gap drops the
+subscriber and its buffered output immediately, instead of the gap retaining
+a reference to a subscriber nobody is reading from anymore.
+
+Deleting the gap record is the claim: `closeGap` and `expireGap` both read
+`cc.gaps[paneID]` and delete it under the same `cc.mu` critical section, so a
+`%continue` racing the deadline produces exactly one marking pass and at
+most one resume. `expireGap` additionally checks `cc.gaps[paneID] == g`
+before deleting — a timer whose `Stop()` lost that race must claim only the
+gap it was armed for, never a newer one that has since opened on the same
+pane.
+
+**The resume precedes the marking, and that ordering is the entire point of
+the change.** On the deadline path the pane is still paused when the timer
+fires. Marking first would send the re-seeding consumer into `capture-pane`
+while tmux is still discarding output — everything painted between that
+capture and the resume actually landing would be lost, and the subscriber,
+having already acked, would never re-seed again. That is defect 3 rebuilt on
+the path that exists to close it. `expireGap` therefore releases `cc.mu`,
+calls `cc.RunCommand("refresh-client -A " + paneID + ":continue")` from the
+timer's own goroutine, and only re-takes the lock to mark subscribers dirty
+once that call returns — successfully or not. `RunCommand` serializes on
+`cmdMu`, so the resume's `%begin`/`%end` block cannot be misdelivered to a
+different pending caller (in particular, not to the handshake's own pause
+command — a misdelivered `%error` there would seed an unpaused pane, exactly
+the corruption this work exists to prevent).
+
+A resume that fails — tmux answering `%error`, or `RunCommand` returning early
+because the connection is gone — leaves the pane possibly still paused, and
+`%pause` is edge-triggered, so tmux will never announce it again. Dropping the
+gap there would rebuild the original defect with no bound at all: the
+subscriber re-seeds once, acks, and waits forever on output tmux is still
+discarding. `expireGap` therefore **re-opens the gap** on failure, arming a
+fresh deadline that retries the resume, and logs the failure at `Warn` — the
+only signal a pane is stuck, so it must be visible without `-debug`. The
+re-arm is gated on the pane still having a subscriber: with nobody watching,
+the retry would loop for the life of the client for no one.
+
+**The failed lap marks nobody**, which is the same rule as on the success path
+— mark only once the resume has landed — applied where it actually bites.
+Marking against a pane that is still paused is not merely a wasted capture, it
+destroys both recovery paths at once: the consumer captures the pre-gap screen,
+and the subscriber's `dirty` flag stays set across the round trip, so the
+`markDirtyLocked` that the re-armed gap's own `closeGap` (or its next
+`expireGap`) performs is a no-op. No gap, no pending `Dirty` — the terminal is
+silently missing everything tmux discarded until the page is reloaded. Not
+marking costs nothing by comparison: the subscriber is still mid-gap, so its
+stream is already stopped, and the mark it is owed arrives from whichever path
+closes the re-armed gap — by construction, against a pane that is live.
+
+Releasing `cc.mu` before the `RunCommand` call, rather than holding it across
+the round trip, keeps a blocked PTY write out of `dispatch` — a `RunCommand`
+call parked behind a stalled write would otherwise stall every pane on the
+connection, not just the one whose gap is expiring.
+
+Gap state is swept in the two places a connection's pause state stops being
+meaningful. `markAllDirty`, called on every reconnect, calls
+`clearGapsLocked()` before its own marking loop: pause state belongs to the
+connection that raised it, so a gap left open by a dead connection must not
+let a `%continue` arriving on the new one re-seed anybody. `Close()` calls
+`clearGaps()` after setting the closed flag; `openGap` itself checks
+`isClosed()` and refuses to open a new gap once closed, because `readLoop`
+keeps parsing already-buffered lines after `Close()` returns, and a `%pause`
+handled after the sweep would otherwise arm a full-length timer that outlives
+the client it belongs to.
+
+### Why not an expected-continue counter
+
+The state-of-play entry that opened this work proposed "an expected-continue
+counter." A count of *issued* pause commands desynchronises from tmux's
+notifications by construction: `%pause`/`%continue` are edge-triggered, so a
+second `refresh-client -A %N:pause` sent while the pane is already paused
+produces no second `%pause` to balance against it, and a counter driven by
+commands sent would overcount relative to the transitions tmux actually
+reports. A counter driven by notifications received degenerates to exactly
+the boolean this design uses — "is there an open gap on this pane" — so the
+counter framing adds a dimension the edge-triggered protocol doesn't have.
+What replaces it is a single gap record per pane plus a per-subscriber
+`inGap` flag, both driven directly off the transitions tmux actually emits.
+
+## The two designs considered
+
+**Chosen: an edge-triggered gap with a deadline**, as described above — a gap
+opens on `%pause`, closes on `%continue`, and a timer bounds how long it can
+stay open before houston resumes it unilaterally.
+
+**Rejected: attribute pauses by recognising the command as it passes through
+`RunCommand`.** The alternative was to have `ControlClient` notice when a
+caller sends `refresh-client -A %N:pause` through `RunCommand`, and treat
+only *that* pause as houston's own — deferring its dirty marking — while
+treating any other `%pause` (one tmux raised on its own, once flow control
+is enabled) as needing no resume tracking at all, on the theory that only
+houston-issued pauses need special handling.
+
+It lost for two reasons:
+
+- It couples `tmux/` to the exact string a caller in `server/pane_ws.go`
+  composes. `tmux/` has no other dependency on how `server/` spells its
+  commands, and the coupling fails silently: a reformatted command string,
+  or a second call site composing the same command slightly differently,
+  stops being recognised with no compile error and no test signal beyond a
+  screen going stale in production.
+- It still needs a separate liveness bound for a gap whose `%continue` never
+  arrives — a stuck handshake, a wedged connection — which is exactly what
+  the deadline already provides. Attribution by string-matching would have
+  to be built *and* a timeout mechanism layered on top of it; the deadline
+  alone does both jobs, since it doesn't care who asked for the pause, only
+  whether it closed in time.
+
+Ownership tracking — "was this `%pause` houston's own?" — is deliberately
+absent from the shipped design for the same reason: houston's own handshake
+pause is continued long before the deadline would ever fire, so the deadline
+never fights it, and on the rare occasion the handshake itself overruns (see
+"What it supersedes" below), the deadline's behaviour — resume, then mark
+everyone — is correct anyway. No part of `tmux/` needs to know who issued a
+pause, which is what keeps this fix inside `tmux/`: the pause command is a
+free-form string composed in `server/pane_ws.go`, and recognising it in
+`tmux/` would couple the two packages through that spelling for no benefit
+the deadline doesn't already provide.
+
+## What it supersedes
+
+This replaces Task 3 of `2026-09-07-control-mode-transport-correctness.md`,
+"`%pause` marks the stream dirty." That task's load-bearing rule — mark on
+`%pause` only, never on `%continue` — is superseded, but its underlying
+concern is not discarded; it moves into `openGap`/`closeGap`: a subscriber
+that attaches mid-gap must not be re-seeded by that gap's `%continue`, or the
+seed handshake (which pauses the pane *before* it subscribes) would earn a
+spurious re-seed immediately after every deliberate seed.
+
+The caveat that rule carried is unchanged and still applies: tmux does not
+guarantee `%pause` precedes the pausing command's `%end`. On the rare reorder
+the handshake's own subscriber exists before its `%pause` is parsed, so that
+subscriber is itself `inGap` when the gap opens and earns one spurious
+re-seed at `%continue` — the same cost the original design paid, on the same
+rare ordering.
+
+## What is left open
+
+- The retry is unbounded. A live pane whose resume keeps erroring re-arms once
+  per deadline, forever; nothing caps the attempts or backs the interval off.
+  That is deliberate — giving up would leave the pane dark, which is the exact
+  failure this change exists to prevent — and since a failed lap marks nobody,
+  each lap costs one `refresh-client` and one `Warn`, not a re-seed. It ends on
+  a successful resume, the last subscriber leaving, a reconnect
+  (`markAllDirty` → `clearGapsLocked`), or `Close()`.
+- A fresh `%pause` arriving while a previous gap's resume is still in flight
+  (i.e. a new pause on the same pane racing `expireGap`'s `RunCommand` call)
+  opens a new gap and waits out a full second deadline of its own. Nothing
+  short-circuits it against the resume already in progress.
+- A deadline goroutine that wins its claim on `cc.gaps[paneID]` *before*
+  `Close()` runs can still be inside `RunCommand` when `Close()` returns, and
+  can still queue a `Dirty` afterward. `clearGaps()` only cancels timers and
+  forgets gap records that exist at sweep time; it cannot recall a goroutine
+  already parked past that point. The `Dirty` lands on a subscriber that is
+  about to be torn down along with the rest of the closed client, so it is
+  inert in practice, but it is not prevented by construction.
+
+## Follow-ups
+
+- **Enable `refresh-client -f pause-after=N`.** This is a product decision,
+  not a mechanical one: it replaces tmux's current behaviour for a slow
+  control client — killing it — with pausing and re-seeding it, which this
+  change now makes safe to do. Turning it on should revisit the 10-second
+  deadline, since at that point it doubles as the backpressure interval, not
+  just a liveness bound on an already-rare stuck pause.
+- **Bound the WebSocket seed write.** The 10-second deadline is a stated
+  bound on the pause→continue window, not a proof of one: the handshake's
+  window contains three `fork`/`exec` tmux round trips and two WebSocket
+  writes, and no write deadline is set anywhere in the repo, so a
+  backgrounded phone on a stalled TCP connection can in principle exceed any
+  finite deadline houston chooses. When that happens the consequence is
+  already benign by construction — the seeding socket is marked dirty by the
+  deadline path and re-seeds once — but making the 10-second figure a proof
+  rather than a statement requires bounding that write, which lives in
+  `server/` and is out of this change's scope.

--- a/tmux/control_client.go
+++ b/tmux/control_client.go
@@ -34,6 +34,11 @@ type ControlClient struct {
 
 	mu   sync.RWMutex
 	subs map[string][]*PaneSub // paneID → subscribers
+	gaps map[string]*gap       // paneID → open pause gap, guarded by mu
+
+	// gapDeadline bounds an open gap: past it the pane is resumed and every
+	// subscriber on it re-seeds. Shortened by tests.
+	gapDeadline time.Duration
 
 	// Synchronous command support: one command at a time.
 	// tmux assigns command numbers server-side, so we serialize
@@ -49,15 +54,24 @@ type commandResponse struct {
 	err    error
 }
 
+// gap represents one open %pause on a pane, from %pause to %continue.
+type gap struct {
+	timer *time.Timer // fires expireGap; guarded by ControlClient.mu
+}
+
 const backoffMax = 10 * time.Second
 
 func NewControlClient(session string) *ControlClient {
 	cc := &ControlClient{
 		session: session,
 		subs:    make(map[string][]*PaneSub),
+		gaps:    make(map[string]*gap),
 		pending: make(chan commandResponse, 1),
 		done:    make(chan struct{}),
 		backoff: 250 * time.Millisecond,
+		// Comfortably beyond a healthy seed handshake, short enough that a
+		// pane nothing resumes is not a minute of frozen screen.
+		gapDeadline: 10 * time.Second,
 	}
 	cc.dial = cc.dialTmux
 	return cc
@@ -200,6 +214,9 @@ func (cc *ControlClient) supervise(r io.ReadCloser, closeConn func() error) {
 func (cc *ControlClient) markAllDirty() {
 	cc.mu.Lock()
 	defer cc.mu.Unlock()
+	// Pause state belongs to the connection that raised it; a gap left open
+	// by a dead connection must not let a later, unrelated %continue re-seed.
+	cc.clearGapsLocked()
 	for _, subs := range cc.subs {
 		for _, s := range subs {
 			cc.markDirtyLocked(s)
@@ -240,17 +257,12 @@ func (cc *ControlClient) readLoop(r *bufio.Reader) {
 			cc.dispatch(event.PaneID, []byte(event.Data))
 
 		case EventPause:
-			// tmux discards output while paused, so resuming without a
-			// re-seed would paint on top of a hole. Only %pause marks:
-			// marking on %continue would re-seed straight after every
-			// deliberate seed. The handshake's own pause usually lands
-			// before its subscriber exists — usually, because tmux does not
-			// guarantee %pause precedes that command's %end; the rare
-			// reorder costs one harmless re-seed.
-			cc.markPaneDirty(event.PaneID)
+			// tmux discards output while paused, so the Dirty belongs at the
+			// end of the gap, not here — see openGap.
+			cc.openGap(event.PaneID)
 
 		case EventContinue:
-			slog.Debug("control mode continue", "session", cc.session, "paneID", event.PaneID)
+			cc.closeGap(event.PaneID)
 
 		case EventBegin:
 			inBlock = true
@@ -297,6 +309,7 @@ type PaneEvent struct {
 type PaneSub struct {
 	ch    chan PaneEvent
 	dirty bool // guarded by ControlClient.mu
+	inGap bool // attached before the pane's open gap closed; guarded by ControlClient.mu
 }
 
 // C returns the event stream. Read it until the subscription is released.
@@ -347,6 +360,125 @@ func (cc *ControlClient) markPaneDirty(paneID string) {
 	for _, s := range cc.subs[paneID] {
 		cc.markDirtyLocked(s)
 	}
+}
+
+// openGap records that paneID has entered a pause. %pause is edge-triggered —
+// tmux emits it only on the not-paused → paused transition — so a gap already
+// open on the pane means this one is a repeat and is a no-op. Every current
+// subscriber is flagged inGap so closeGap knows who was here before the gap,
+// as opposed to a subscriber that attaches during it.
+func (cc *ControlClient) openGap(paneID string) {
+	cc.mu.Lock()
+	defer cc.mu.Unlock()
+	cc.openGapLocked(paneID)
+}
+
+// openGapLocked is openGap's body. Caller must hold cc.mu.
+func (cc *ControlClient) openGapLocked(paneID string) {
+	// readLoop keeps parsing already-buffered lines after Close(), so a late
+	// %pause must not arm a full-length timer that outlives the client.
+	if cc.isClosed() {
+		return
+	}
+	if _, open := cc.gaps[paneID]; open {
+		return
+	}
+	for _, s := range cc.subs[paneID] {
+		s.inGap = true
+	}
+	g := &gap{}
+	// Assigned inside the critical section: clearGapsLocked reads g.timer
+	// under cc.mu from a Close() that can run concurrently with readLoop.
+	g.timer = time.AfterFunc(cc.gapDeadline, func() { cc.expireGap(paneID, g) })
+	cc.gaps[paneID] = g
+}
+
+// closeGap ends paneID's pause. Deleting the gap record is the claim: only
+// the caller that removes it marks anyone dirty. An orphan %continue — no gap
+// open — marks nobody. Skipping mid-gap arrivals is a tradeoff, not a
+// guarantee: it spares every deliberate seed a spurious re-seed at its own
+// handshake's %continue, and costs that subscriber whatever tmux discarded
+// between its capture-pane and the %continue.
+func (cc *ControlClient) closeGap(paneID string) {
+	cc.mu.Lock()
+	defer cc.mu.Unlock()
+	g, open := cc.gaps[paneID]
+	if !open {
+		return
+	}
+	g.timer.Stop()
+	delete(cc.gaps, paneID)
+	for _, s := range cc.subs[paneID] {
+		if s.inGap {
+			s.inGap = false
+			cc.markDirtyLocked(s)
+		}
+	}
+}
+
+// expireGap bounds a gap whose %continue never came: it resumes the pane and,
+// once the resume has landed, marks every current subscriber dirty, mid-gap
+// arrivals included — the pause is per control client and houston runs one per
+// session, so one socket's stuck handshake freezes the pane for every socket
+// on it.
+func (cc *ControlClient) expireGap(paneID string, g *gap) {
+	cc.mu.Lock()
+	// A timer whose Stop lost the race may claim only the gap it armed, never
+	// a newer one that has since opened on the pane.
+	if cc.gaps[paneID] != g {
+		cc.mu.Unlock()
+		return
+	}
+	g.timer.Stop()
+	delete(cc.gaps, paneID)
+	// Cleared inside the claim, so a gap opening while the resume is in flight
+	// owns its own flags and the marking below cannot wipe them.
+	for _, s := range cc.subs[paneID] {
+		s.inGap = false
+	}
+	cc.mu.Unlock()
+
+	// Resume first, mark after. Marked first, the consumer would capture-pane
+	// while tmux is still discarding: everything painted before the resume
+	// lands is lost, and the subscriber, having acked, never re-seeds again.
+	if _, err := cc.RunCommand("refresh-client -A " + paneID + ":continue"); err != nil {
+		slog.Warn("gap deadline resume failed",
+			"session", cc.session, "pane", paneID, "error", err)
+		// The pane may still be paused, and %pause is edge-triggered: tmux
+		// will never announce one it already considers paused. Without a
+		// fresh gap nothing would ever retry, and the pane would stay dark
+		// for good. Nobody subscribed means nobody to retry for.
+		cc.mu.Lock()
+		if len(cc.subs[paneID]) > 0 {
+			cc.openGapLocked(paneID)
+		}
+		cc.mu.Unlock()
+		// Marking here would be worse than not marking: the capture would come
+		// off a still-paused pane, and that stale dirty flag makes the retry's
+		// own mark a no-op — the screen would never recover.
+		return
+	}
+	cc.markPaneDirty(paneID)
+}
+
+// clearGapsLocked cancels every armed deadline and forgets all gap state.
+// Caller must hold cc.mu.
+func (cc *ControlClient) clearGapsLocked() {
+	for _, g := range cc.gaps {
+		g.timer.Stop()
+	}
+	clear(cc.gaps)
+	for _, subs := range cc.subs {
+		for _, s := range subs {
+			s.inGap = false
+		}
+	}
+}
+
+func (cc *ControlClient) clearGaps() {
+	cc.mu.Lock()
+	defer cc.mu.Unlock()
+	cc.clearGapsLocked()
 }
 
 // AckReseed resumes delivery after the subscriber has re-seeded from
@@ -572,6 +704,11 @@ func (cc *ControlClient) Close() error {
 	}
 	cc.closed = true
 	cc.closeMu.Unlock()
+
+	// closeMu must be released first: openGapLocked calls isClosed() (which
+	// takes closeMu) while holding cc.mu, so sweeping under closeMu would
+	// invert that order and deadlock.
+	cc.clearGaps()
 
 	cc.connMu.RLock()
 	closeFn := cc.closeCur

--- a/tmux/control_client_test.go
+++ b/tmux/control_client_test.go
@@ -162,29 +162,61 @@ func feed(cc *ControlClient, transcript string) {
 	cc.readLoop(bufio.NewReader(strings.NewReader(transcript)))
 }
 
-func TestPauseMarksDirty(t *testing.T) {
+// gapCount and gapFor read cc.gaps under cc.mu — the read loop and every
+// armed deadline write that map concurrently with the test goroutine.
+func (cc *ControlClient) gapCount() int {
+	cc.mu.RLock()
+	defer cc.mu.RUnlock()
+	return len(cc.gaps)
+}
+
+func (cc *ControlClient) gapFor(paneID string) *gap {
+	cc.mu.RLock()
+	defer cc.mu.RUnlock()
+	return cc.gaps[paneID]
+}
+
+// TestPauseDefersDirtyUntilContinue proves that %pause alone must queue no
+// Dirty: a capture triggered at %pause predates the output tmux discards
+// during the gap, so re-seeding then paints onto a stale screen. The Dirty
+// belongs at %continue, once the gap has actually closed.
+func TestPauseDefersDirtyUntilContinue(t *testing.T) {
 	cc := NewControlClient("test")
 	sub := cc.Subscribe("%1")
 
 	feed(cc, "%output %1 before\\015\\012\n%pause %1\n")
 
 	ev := <-sub.C()
-	if !ev.Dirty {
-		t.Fatalf("first event after %%pause = %+v, want Dirty", ev)
+	if ev.Dirty {
+		t.Fatalf("got Dirty at %%pause, want the pre-gap data")
+	}
+	if string(ev.Data) != "before\r\n" {
+		t.Fatalf("got %q, want %q", ev.Data, "before\r\n")
 	}
 	if len(sub.C()) != 0 {
-		t.Fatalf("%d events survived the pause, want 0 — the backlog is discarded", len(sub.C()))
+		t.Fatalf("%d events queued after %%pause, want 0", len(sub.C()))
+	}
+
+	feed(cc, "%output %1 during\\015\\012\n%continue %1\n")
+
+	ev = <-sub.C()
+	if !ev.Dirty {
+		t.Fatalf("first event after %%continue = %+v, want Dirty", ev)
+	}
+	if len(sub.C()) != 0 {
+		t.Fatalf("%d events survived the gap, want 0 — the backlog is discarded", len(sub.C()))
 	}
 }
 
-func TestContinueDoesNotMarkDirty(t *testing.T) {
+func TestContinueDoesNotMarkAMidGapSubscriber(t *testing.T) {
 	cc := NewControlClient("test")
-	sub := cc.Subscribe("%1")
 
+	feed(cc, "%pause %1\n")
+	sub := cc.Subscribe("%1")
 	feed(cc, "%continue %1\n")
 
 	if len(sub.C()) != 0 {
-		t.Fatal("continue marked the pane dirty; only pause may")
+		t.Fatal("continue marked a subscriber that attached during the gap")
 	}
 }
 
@@ -193,7 +225,7 @@ func TestPauseOnAnotherPaneIsIgnored(t *testing.T) {
 	other := cc.Subscribe("%2")
 	mine := cc.Subscribe("%1")
 
-	feed(cc, "%pause %2\n")
+	feed(cc, "%pause %2\n%continue %2\n")
 
 	ev := <-other.C()
 	if !ev.Dirty {
@@ -201,6 +233,36 @@ func TestPauseOnAnotherPaneIsIgnored(t *testing.T) {
 	}
 	if len(mine.C()) != 0 {
 		t.Fatalf("a pause on %%2 marked %%1 dirty (%d events)", len(mine.C()))
+	}
+}
+
+func TestRepeatedPauseIsANoOp(t *testing.T) {
+	cc := NewControlClient("test")
+	t.Cleanup(cc.clearGaps) // nothing closes this gap; disarm its deadline
+	sub := cc.Subscribe("%1")
+
+	feed(cc, "%pause %1\n")
+	first := cc.gapFor("%1")
+	feed(cc, "%pause %1\n")
+
+	if len(sub.C()) != 0 {
+		t.Fatalf("%d events queued after a repeated %%pause, want 0", len(sub.C()))
+	}
+	// Identity, not count: overwriting the record leaves one entry too, while
+	// orphaning the first gap's armed timer.
+	if got := cc.gapFor("%1"); got != first {
+		t.Fatalf("repeated %%pause replaced the gap record (%p → %p)", first, got)
+	}
+}
+
+func TestOrphanContinueMarksNobody(t *testing.T) {
+	cc := NewControlClient("test")
+	sub := cc.Subscribe("%1")
+
+	feed(cc, "%continue %1\n")
+
+	if len(sub.C()) != 0 {
+		t.Fatal("continue with no open gap marked a subscriber dirty")
 	}
 }
 
@@ -230,6 +292,366 @@ func (d *scriptedDialer) count() int {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	return d.dials
+}
+
+// recordingDialer hands out a live connection per dial: the test writes
+// control lines into it one at a time and reads back what the client wrote.
+// scriptedDialer can do neither — it replays a fixed transcript to EOF and
+// throws every write away, so it cannot answer a command's %begin/%end, and an
+// unanswered command parks RunCommand until Close().
+type recordingDialer struct {
+	mu    sync.Mutex
+	conns []*recordedConn
+}
+
+type recordedConn struct {
+	pw  *io.PipeWriter
+	mu  sync.Mutex
+	buf strings.Builder
+}
+
+func (d *recordingDialer) dial() (io.ReadCloser, io.Writer, func() error, error) {
+	pr, pw := io.Pipe()
+	c := &recordedConn{pw: pw}
+	d.mu.Lock()
+	d.conns = append(d.conns, c)
+	d.mu.Unlock()
+	return pr, c, func() error { return pw.Close() }, nil
+}
+
+// connAt waits for the i-th dial and returns its connection. Dial i>0 happens
+// on supervise's goroutine, so it cannot simply be indexed.
+func (d *recordingDialer) connAt(t *testing.T, i int) *recordedConn {
+	t.Helper()
+	deadline := time.After(2 * time.Second)
+	for {
+		d.mu.Lock()
+		n := len(d.conns)
+		var c *recordedConn
+		if i < n {
+			c = d.conns[i]
+		}
+		d.mu.Unlock()
+		if c != nil {
+			return c
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("connection %d never dialled; %d dials so far", i, n)
+		case <-time.After(time.Millisecond):
+		}
+	}
+}
+
+func (c *recordedConn) Write(p []byte) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.buf.Write(p)
+}
+
+func (c *recordedConn) written() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.buf.String()
+}
+
+// feedLine delivers one control-mode line. The write returns once readLoop has
+// copied the bytes, which is before it has dispatched them — see sync().
+func (c *recordedConn) feedLine(t *testing.T, line string) {
+	t.Helper()
+	if _, err := io.WriteString(c.pw, line+"\n"); err != nil {
+		t.Fatalf("feed %q: %v", line, err)
+	}
+}
+
+// sync blocks until everything fed before it has been dispatched. readLoop is
+// strictly sequential, so a sentinel on its own pane clearing proves the lines
+// ahead of it were handled. No dialer-fed negative assertion is sound without
+// it.
+func (c *recordedConn) sync(t *testing.T, sentinel *PaneSub) {
+	t.Helper()
+	c.feedLine(t, "%output %9 sync")
+	select {
+	case ev := <-sentinel.C():
+		if ev.Dirty {
+			t.Fatalf("sentinel subscriber went dirty: %+v", ev)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("sentinel never cleared — readLoop is not consuming")
+	}
+}
+
+// waitForWrite blocks until want appears in what the client wrote. On the
+// deadline path this is the only sound barrier: the resume comes from the
+// timer goroutine, not readLoop, and expireGap writes inside RunCommand and
+// marks only after it returns.
+func waitForWrite(t *testing.T, c *recordedConn, want string) {
+	t.Helper()
+	waitForWriteCount(t, c, want, 1)
+}
+
+func waitForWriteCount(t *testing.T, c *recordedConn, want string, n int) {
+	t.Helper()
+	deadline := time.After(2 * time.Second)
+	for {
+		got := strings.Count(c.written(), want)
+		if got >= n {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("connection got %q %d times, want %d; wrote %q", want, got, n, c.written())
+		case <-time.After(time.Millisecond):
+		}
+	}
+}
+
+// answerCommand releases a RunCommand caller parked on its response block.
+func (c *recordedConn) answerCommand(t *testing.T) {
+	t.Helper()
+	c.feedLine(t, "%begin 1700000000 1 0")
+	c.feedLine(t, "%end 1700000000 1 0")
+}
+
+// answerCommandError releases a RunCommand caller with tmux's refusal.
+func (c *recordedConn) answerCommandError(t *testing.T) {
+	t.Helper()
+	c.feedLine(t, "%begin 1700000000 1 0")
+	c.feedLine(t, "can't find pane")
+	c.feedLine(t, "%error 1700000000 1 0")
+}
+
+func expectDirty(t *testing.T, s *PaneSub, who string) {
+	t.Helper()
+	select {
+	case ev := <-s.C():
+		if !ev.Dirty {
+			t.Fatalf("%s got %+v, want Dirty", who, ev)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("%s never got Dirty", who)
+	}
+}
+
+const resume1 = "refresh-client -A %1:continue"
+
+func TestGapDeadlineResumesAndMarksEverySubscriber(t *testing.T) {
+	d := &recordingDialer{}
+	cc := NewControlClient("test")
+	cc.dial = d.dial
+	cc.backoff = time.Millisecond
+	// The late subscriber must land inside the gap. Nothing enforces that
+	// against a running clock, so the deadline is put out of reach and
+	// expireGap invoked by hand; the timer path is covered by the tests below.
+	cc.gapDeadline = time.Hour
+
+	sentinel := cc.Subscribe("%9")
+	early := cc.Subscribe("%1")
+
+	if err := cc.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = cc.Close() }()
+	conn := d.connAt(t, 0)
+
+	conn.feedLine(t, "%pause %1")
+	conn.sync(t, sentinel) // the gap is open
+	late := cc.Subscribe("%1")
+
+	g := cc.gapFor("%1")
+	if g == nil {
+		t.Fatalf("no gap open after %%pause")
+	}
+	// On its own goroutine: expireGap parks in RunCommand until answered.
+	go cc.expireGap("%1", g)
+
+	waitForWrite(t, conn, resume1)
+	conn.answerCommand(t)
+
+	expectDirty(t, early, "subscriber present at %pause")
+	expectDirty(t, late, "subscriber that attached mid-gap")
+
+	if n := strings.Count(conn.written(), resume1); n != 1 {
+		t.Fatalf("wrote %d resumes, want exactly 1: %q", n, conn.written())
+	}
+}
+
+func TestGapDeadlineResumesBeforeMarking(t *testing.T) {
+	d := &recordingDialer{}
+	cc := NewControlClient("test")
+	cc.dial = d.dial
+	cc.backoff = time.Millisecond
+	cc.gapDeadline = 75 * time.Millisecond
+
+	sub := cc.Subscribe("%1")
+
+	if err := cc.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = cc.Close() }()
+	conn := d.connAt(t, 0)
+
+	conn.feedLine(t, "%pause %1")
+	waitForWrite(t, conn, resume1)
+
+	// The resume is on the wire but unanswered, so the pane is still paused.
+	// A Dirty here sends the consumer into capture-pane against a pane tmux is
+	// still discarding output for, and having acked it never re-seeds again.
+	if n := len(sub.C()); n != 0 {
+		t.Fatalf("%d events queued before the resume completed, want 0", n)
+	}
+
+	conn.answerCommand(t)
+	expectDirty(t, sub, "subscriber")
+}
+
+// TestRefusedResumeReArmsTheGap proves a resume tmux refuses does not abandon
+// the pane. %pause is edge-triggered, so tmux never re-announces a pane it
+// already considers paused: drop the gap on a failed resume and nothing is
+// left to retry it, and the pane's output is discarded forever. The refusal
+// must also mark nobody — a Dirty against a still-paused pane both seeds the
+// pre-gap screen and swallows the retry's own mark.
+func TestRefusedResumeReArmsTheGap(t *testing.T) {
+	d := &recordingDialer{}
+	cc := NewControlClient("test")
+	cc.dial = d.dial
+	cc.backoff = time.Millisecond
+	cc.gapDeadline = 75 * time.Millisecond
+
+	sub := cc.Subscribe("%1")
+
+	if err := cc.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = cc.Close() }()
+	conn := d.connAt(t, 0)
+
+	conn.feedLine(t, "%pause %1")
+	waitForWrite(t, conn, resume1)
+	conn.answerCommandError(t)
+
+	waitForWriteCount(t, conn, resume1, 2)
+	if n := len(sub.C()); n != 0 {
+		t.Fatalf("%d events queued off a refused resume, want 0", n)
+	}
+
+	conn.answerCommand(t)
+	expectDirty(t, sub, "subscriber on the refused pane")
+}
+
+// TestRefusedResumeWithNoSubscribersStopsRetrying pins the other half: a
+// retry loop with nobody watching would run for the life of the client.
+func TestRefusedResumeWithNoSubscribersStopsRetrying(t *testing.T) {
+	d := &recordingDialer{}
+	cc := NewControlClient("test")
+	cc.dial = d.dial
+	cc.backoff = time.Millisecond
+	cc.gapDeadline = 20 * time.Millisecond
+
+	if err := cc.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = cc.Close() }()
+	conn := d.connAt(t, 0)
+
+	conn.feedLine(t, "%pause %1")
+	waitForWrite(t, conn, resume1)
+	conn.answerCommandError(t)
+
+	time.Sleep(5 * cc.gapDeadline)
+	if n := cc.gapCount(); n != 0 {
+		t.Fatalf("%d gaps armed for a pane nobody subscribes to, want 0", n)
+	}
+	if n := strings.Count(conn.written(), resume1); n != 1 {
+		t.Fatalf("wrote %d resumes with no subscribers, want exactly 1", n)
+	}
+}
+
+func TestContinueWithinDeadlineSendsNoResume(t *testing.T) {
+	d := &recordingDialer{}
+	cc := NewControlClient("test")
+	cc.dial = d.dial
+	cc.backoff = time.Millisecond
+	// Default gapDeadline: the %continue below is what must close this gap.
+
+	sentinel := cc.Subscribe("%9")
+	sub := cc.Subscribe("%1")
+
+	if err := cc.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = cc.Close() }()
+	conn := d.connAt(t, 0)
+
+	conn.feedLine(t, "%pause %1")
+	conn.feedLine(t, "%continue %1")
+	conn.sync(t, sentinel)
+
+	expectDirty(t, sub, "subscriber present at %pause")
+	if strings.Contains(conn.written(), resume1) {
+		t.Fatalf("fought houston's own handshake with a resume: %q", conn.written())
+	}
+}
+
+func TestReadLoopKeepsDispatchingWhileResumeOutstanding(t *testing.T) {
+	d := &recordingDialer{}
+	cc := NewControlClient("test")
+	cc.dial = d.dial
+	cc.backoff = time.Millisecond
+	cc.gapDeadline = 75 * time.Millisecond
+
+	other := cc.Subscribe("%2")
+
+	if err := cc.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = cc.Close() }()
+	conn := d.connAt(t, 0)
+
+	conn.feedLine(t, "%pause %1")
+	waitForWrite(t, conn, resume1)
+
+	conn.feedLine(t, `%output %2 live\015\012`)
+	select {
+	case ev := <-other.C():
+		if string(ev.Data) != "live\r\n" {
+			t.Fatalf("got %+v, want %q", ev, "live\r\n")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("readLoop stalled while a resume was in flight")
+	}
+
+	conn.answerCommand(t)
+}
+
+// TestIgnoreSizeIsFirstWriteOnEveryAttach characterizes a rule the CC client
+// already keeps: it must never influence the session's window size. The
+// assertion that server/pane_ws_protocol_test.go says lives in tmux/.
+func TestIgnoreSizeIsFirstWriteOnEveryAttach(t *testing.T) {
+	d := &recordingDialer{}
+	cc := NewControlClient("test")
+	cc.dial = d.dial
+	cc.backoff = time.Millisecond
+
+	if err := cc.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = cc.Close() }()
+
+	first := d.connAt(t, 0)
+	assertIgnoreSizeFirst(t, first)
+
+	_ = first.pw.Close() // drop the connection; supervise re-dials
+	assertIgnoreSizeFirst(t, d.connAt(t, 1))
+}
+
+func assertIgnoreSizeFirst(t *testing.T, c *recordedConn) {
+	t.Helper()
+	const want = "refresh-client -f ignore-size\n"
+	waitForWrite(t, c, want)
+	if got := c.written(); !strings.HasPrefix(got, want) {
+		t.Fatalf("first write on the connection = %q, want %q first", got, want)
+	}
 }
 
 func TestReconnectMarksSubscribersDirty(t *testing.T) {
@@ -263,6 +685,108 @@ func TestReconnectMarksSubscribersDirty(t *testing.T) {
 		case <-deadline:
 			t.Fatalf("no Dirty event after reconnect; dials=%d", d.count())
 		}
+	}
+}
+
+// TestReattachClearsGapState covers R12: a gap outstanding on a connection
+// that has since died must not let an unrelated %continue on the new
+// connection re-seed anybody.
+func TestReattachClearsGapState(t *testing.T) {
+	d := &recordingDialer{}
+	cc := NewControlClient("test")
+	cc.dial = d.dial
+	cc.backoff = time.Millisecond
+
+	sub := cc.Subscribe("%1")
+
+	if err := cc.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = cc.Close() }()
+
+	first := d.connAt(t, 0)
+	first.feedLine(t, "%pause %1")
+	_ = first.pw.Close() // drop the connection; supervise re-dials
+
+	// markAllDirty fires on every re-attach, so sub is already dirty and a
+	// second Dirty from the stale gap would be invisible behind it. Drain and
+	// ack before looking for one.
+	expectDirty(t, sub, "subscriber after re-attach")
+	cc.AckReseed(sub)
+
+	second := d.connAt(t, 1)
+	// Subscribed only now: one subscribed before the re-attach would itself
+	// be marked dirty by markAllDirty, and dispatch skips dirty subscribers —
+	// the barrier could never clear.
+	sentinel := cc.Subscribe("%9")
+
+	second.feedLine(t, "%continue %1")
+	second.sync(t, sentinel)
+
+	if len(sub.C()) != 0 {
+		t.Fatal("continue on the new connection re-seeded a subscriber left over from the dropped connection's gap")
+	}
+}
+
+// TestCloseRefusesALatePause covers R13: readLoop keeps parsing buffered
+// lines after Close() returns, so a %pause handled after close must not arm
+// a timer that outlives the client.
+func TestCloseRefusesALatePause(t *testing.T) {
+	cc := NewControlClient("test")
+	cc.gapDeadline = 10 * time.Millisecond
+
+	sub := cc.Subscribe("%1")
+
+	if err := cc.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	feed(cc, "%pause %1\n")
+
+	if n := cc.gapCount(); n != 0 {
+		t.Fatalf("%d gaps open after a %%pause following Close(), want 0", n)
+	}
+
+	time.Sleep(3 * cc.gapDeadline)
+	if len(sub.C()) != 0 {
+		t.Fatal("Dirty queued after Close() from a pause that should never have armed a timer")
+	}
+}
+
+// TestCloseSweepsAnOpenGap is the other half of R13: TestCloseRefusesALatePause
+// covers the guard against a pause arriving after Close, this covers the sweep
+// of one already open when Close runs.
+func TestCloseSweepsAnOpenGap(t *testing.T) {
+	d := &recordingDialer{}
+	cc := NewControlClient("test")
+	cc.dial = d.dial
+	cc.backoff = time.Millisecond
+	cc.gapDeadline = 20 * time.Millisecond
+
+	sentinel := cc.Subscribe("%9")
+	sub := cc.Subscribe("%1")
+
+	if err := cc.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	conn := d.connAt(t, 0)
+
+	conn.feedLine(t, "%pause %1")
+	conn.sync(t, sentinel)
+
+	if err := cc.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if n := cc.gapCount(); n != 0 {
+		t.Fatalf("%d gaps survived Close(), want 0", n)
+	}
+
+	// The gap count above is what bites; this is a tripwire, since after Close
+	// a surviving timer's RunCommand returns before it can write or mark.
+	time.Sleep(3 * cc.gapDeadline)
+	if len(sub.C()) != 0 {
+		t.Fatal("a swept gap still marked its subscriber dirty")
 	}
 }
 


### PR DESCRIPTION
Closes #34

Defect 3 of `docs/superpowers/2026-09-08-state-of-play.md`.

## The bug

`%pause` marked every subscriber of a pane dirty immediately, so `server/pane_ws.go` ran `capture-pane` at the **start** of the output gap. tmux discards everything a paused pane paints and, on resume, restarts from the pane's current offset — the backlog is dropped, never replayed. So the snapshot predated the discarded output, and the terminal then painted new bytes onto a screen with a hole in it.

A second half: nothing resumed a pause houston did not issue. A pane tmux paused on its own had no owner and would stay paused forever.

## The fix

`%pause` opens a **gap**; `%continue` closes it and marks dirty only the subscribers attached when it opened. A subscriber that arrives mid-gap is skipped — that is what keeps the seed handshake, which pauses the pane *before* it subscribes, from earning a spurious re-seed after every deliberate seed. It supersedes Task 3 of `2026-09-07-control-mode-transport-correctness.md`, whose "mark on `%pause` only" rule this replaces.

A gap is bounded by a **10-second deadline**. On expiry houston sends one `refresh-client -A %N:continue` and *then* marks — that order is the point of the change, since marking first captures while tmux is still discarding and rebuilds the original bug on the path meant to cure it. The resume runs off `readLoop` (which cannot block on a `RunCommand` only it can answer) and goes through `RunCommand`, so its `%begin`/`%end` cannot be mis-delivered to another pending caller. A refused resume re-arms the gap instead of abandoning the pane: `%pause` is edge-triggered, so tmux never re-announces one it already considers paused.

Gap state is swept on reconnect and on `Close()`, and a closed client opens no new gap. `refresh-client -f ignore-size` stays the first write on every attach — now asserted from a `tmux/` test, which is the IOU the comment at `server/pane_ws_protocol_test.go:220` claimed already existed.

No `server/`, `ui/` or `runs/` change: the design deliberately needs no knowledge of *who* issued a pause, which is what keeps it inside `tmux/`. `docs/superpowers/plans/2026-09-10-pause-gap-reseed.md` records the design, including the rejected alternative (attribute pauses by recognising the command string as it passes through `RunCommand`) and why it lost.

## Proving it

The defect is dormant — nothing sets `pause-after` — so the reproduction is synthetic and came first. `TestPauseDefersDirtyUntilContinue` was written against the unfixed code and failed on it:

```
--- FAIL: TestPauseDefersDirtyUntilContinue
    control_client_test.go:177: got Dirty at %pause, want the pre-gap data
```

Then every guard was mutation-tested — the fix was broken six ways and each time the intended test went red:

| Mutation | Test that bit |
|---|---|
| `EventPause` marks dirty inline again | `TestPauseDefersDirtyUntilContinue` |
| `expireGap` returns before the resume | `TestGapDeadlineResumesAndMarksEverySubscriber` |
| `expireGap` marks before resuming | `TestGapDeadlineResumesBeforeMarking` |
| `clearGapsLocked` dropped from `markAllDirty` | `TestReattachClearsGapState` |
| `closeGap` marks every subscriber | `TestContinueDoesNotMarkAMidGapSubscriber` |
| `openGap`'s `isClosed()` guard dropped | `TestCloseRefusesALatePause` |

Two review rounds added three more (`Close()`'s sweep, the refused-resume re-arm, its no-subscriber gate), each confirmed red without its fix.

`go test ./tmux/... -race -count=5` green across repeated runs; `go vet`, `gofmt -l`, `golangci-lint` clean; `./server/...` unaffected.

## Escalated

The spec and plan gates each hit the 2-revision cap with the critic still returning `revise`. Both times the remaining findings were localized and were applied before execution, not waved through — but they never got a clean verdict, so they are recorded here rather than treated as accepted.

**Spec, final round** — three findings, all applied:
- The deadline path marked dirty before sending the resume, which re-created defect 3 on the path meant to cure it. Fixed by making the resume precede the marking (this later turned out to matter again on the failure branch).
- `Close()` cancelled only the deadlines that existed at sweep time; a `%pause` parsed afterwards could still arm one. Fixed by refusing to open a gap on a closed client.
- An acceptance criterion said `readLoop` keeps *delivering* output for a paused pane, which is unsatisfiable — a dirty subscriber correctly receives nothing. Reworded to a different pane's subscriber.

**Plan, final round** — two findings, both applied:
- The re-attach test's sentinel subscriber would itself be marked dirty by `markAllDirty`, so its barrier could never clear. Fixed by subscribing the sentinel after the re-attach drain.
- The close test's ordering was a coin flip and the mutation would have survived the likely side. Replaced with a deterministic construction (close first, then deliver the late `%pause` synchronously).

## Review notes

Carried forward rather than fixed, all confirmed non-blocking:

- **The retry is unbounded.** A live pane whose resume keeps erroring retries once per deadline forever. It is deliberately uncapped — giving up would leave the pane dark, which is the failure this change exists to prevent — and now costs one command plus one log line per lap, since a failed lap marks nobody. It ends on a successful resume, the last subscriber leaving, a reconnect, or `Close()`. Documented in the design record.
- **`clearGapsLocked`'s `timer.Stop()` loop and `expireGap`'s pointer-identity check are not covered by tests.** Deleting either leaves the suite green: the identity check neutralises a late fire, so each is the other's only guard. Both are load-bearing now that a refused resume can put a second gap on the same pane.
- **`Unsubscribe` does not close a gap.** If the last subscriber leaves mid-gap the gap stays armed; the deadline then resumes a pane nobody watches and marks nobody. Harmless, and `server/pane_ws.go` normally sends `:continue` before unsubscribing.
- **No test races an in-flight `%pause` against a concurrent `Close()`.** The guard is mutex-correct by inspection and the sequential ordering is tested, but true concurrency there is unproven.
- **`parsePaneNotification` takes the whole line remainder as the pane ID** rather than the first field, unlike its siblings. Unreachable today — only a conformant tmux server writes those lines, and pane content cannot forge one — and unchanged by this PR, but the security review flagged it as worth tightening.
- **`state-of-play` defect 3 is not struck.** That file is outside this task's scope fence.

## Follow-ups

- **Enable `refresh-client -f pause-after=N`.** A product decision: it swaps tmux's current treatment of a slow control client — killing it — for pausing and re-seeding it, which this change makes safe. It should revisit the 10s deadline, which would then double as the backpressure interval.
- **Bound the WebSocket seed write.** The handshake's pause→continue window holds three tmux round trips and two WebSocket writes with no write deadline anywhere in the repo, so it can in principle exceed any finite gap deadline. The consequence is already benign — the seeding socket is marked dirty and re-seeds once — but that makes 10s a statement rather than a proof. Lives in `server/`.

https://claude.ai/code/session_01K8Zma6WtS5jZxQuP42cFbw
