### PR TITLE
fix(tmux): attribute every control-mode reply to its own command

### DIFF
--- a/docs/superpowers/plans/2026-09-10-pause-gap-reseed.md
+++ b/docs/superpowers/plans/2026-09-10-pause-gap-reseed.md
@@ -25,10 +25,23 @@ deliberately, but a `%pause` tmux raises on its own — the only kind live
 today, since nothing sets `pause-after` — has no owner, so the pane would
 stay paused forever.
 
-Both halves are dormant in the current deployment: `pause-after` is 0 by
-default and houston never sets it, so the only `%pause` on the wire is
-houston's own handshake, which continues it a moment later. The fix had to be
-correct before flow control could ever turn that dormancy off.
+Both halves are dormant in the current deployment, for **two** independent
+reasons — the first round of this work recorded only one.
+
+- `pause-after` is 0 by default and houston never sets it, so tmux raises no
+  `%pause` of its own.
+- The seed handshake's pause does not parse either. `server/pane_ws.go:120`,
+  `:132` and `:178` build `refresh-client -A %N:pause` / `:continue` as bare
+  tokens, which tmux's command-string lexer rejects (see "The tmux facts"
+  below); `:121` swallows the `%error` at `slog.Debug` and proceeds with
+  `paused = false`. So houston's own handshake has never paused a pane either,
+  and there is no `%pause` on the wire at all.
+
+The second reason means this design had not been exercised against a live
+`%pause` before the review that found it. The `server/` half is pre-existing and
+outside this change's scope fence; it is flagged on the PR rather than fixed
+here. The fix had to be correct before flow control could ever turn that
+dormancy off.
 
 ## The tmux facts the fix rests on
 
@@ -41,9 +54,67 @@ Verified against tmux 3.6a's `control.c`:
   is not — see "Why not a counter" below.
 - `pause-after` is a client option (`CLIENT_CONTROL_PAUSEAFTER`), set with
   `refresh-client -f pause-after=N`. It is what would make tmux pause a pane
-  on its own, as flow control against a slow reader; today it is unset, so
-  every `%pause` on the wire is one houston asked for via
-  `refresh-client -A %N:pause`.
+  on its own, as flow control against a slow reader; today it is unset, so the
+  only `%pause` houston could see is one it asked for via
+  `refresh-client -A '%N:pause'` — and the one call site that asks,
+  `server/pane_ws.go`, still sends the bare unquoted form, which is the second
+  dormancy reason above.
+- **tmux's command-string lexer rejects a bare token that starts with `%` and
+  contains `:`.** So the pane-state argument must be quoted. Measured in
+  control mode with `-f /dev/null`, each row against a pane whose pause state
+  made the outcome meaningful — `%pause`/`%continue` are edge-triggered, so a
+  resume aimed at a running pane emits nothing and looks the same as a no-op:
+
+  | command | result |
+  |---|---|
+  | `refresh-client -A '%0:pause'` | `%pause %0`, `%end` |
+  | `refresh-client -A '%0:continue'` | `%continue %0`, `%end` |
+  | `refresh-client -A "%0:continue"` | `%continue %0`, `%end` |
+  | `refresh-client -A %0:pause` | `parse error: syntax error`, `%error` |
+  | `refresh-client -A %0:continue` | `parse error: syntax error`, `%error` |
+  | `refresh-client -A %0` | `%end`, **no** `%continue` |
+  | `refresh-client -A x%0:continue` | `%end`, **no** `%continue` |
+
+  Three outcome classes, not two: parses and resumes (either quoting), parses
+  and does **not** resume, and does not parse. The last two classes are why a
+  test that only checks for a successful `%end` proves nothing.
+- **Each command produces exactly one block, and blocks arrive in the order
+  tmux received the commands.** `%begin`'s third argument is the command
+  number; its fourth is flags, documented "currently not used", so flags cannot
+  classify a block. The number is a **server-global** counter — a fresh client
+  saw `678835` — so houston can never predict the number tmux will assign its
+  own write.
+- **A real `tmux -CC attach-session` answers the attach command itself with one
+  block, before houston writes anything**, and that block's `%begin` carries
+  tmux's control-mode DCS introducer. Raw bytes off a pty:
+
+  ```
+  FIRST 120 BYTES: b'\x1bP1000p%begin 1789033623 812527 0\r\n%end 1789033623 812527 0\r\n%session-changed $761 ...'
+  AFTER WRITE:     b'%begin 1789033624 812704 1\r\n%end 1789033624 812704 1\r\n'
+  ```
+
+  So exactly one block per connection is owed to no stdin write — and until this
+  round `ParseControlLine` matched on a bare `%begin ` prefix, so **houston
+  misparsed the first line of every connection it ever opened** and saw only that
+  block's orphan `%end`. That is where `RunCommand`'s old "drain any stale
+  response from a previous unsolicited `%begin`/`%end`" hack came from: the hack
+  was the symptom, not a precaution. `ParseControlLine` now strips the
+  introducer, which is a plain parsing fix independent of the attribution work.
+- **A notification can appear inside a block**, despite the man page saying it
+  never does, and **which side of `%end` it lands on depends on the pane**.
+  Measured on 3.6a: against a pane actively producing output,
+  `refresh-client -A '%0:pause'` emits `%pause %0` *between* its own `%begin`
+  and `%end`; against an idle pane, eight of eight pauses emitted it *after*
+  `%end`. tmux raises the notification when it next goes to write output for the
+  pane, so a busy pane gets it inside the command's own processing.
+
+  `readLoop` classifies **before** consulting `inBlock`, which is what makes
+  both orderings work. That ordering is load-bearing, not an accident: a
+  security review of this change proposed gating the notification cases on
+  `!inBlock` for symmetry with `EventData`, and it was rejected on this
+  evidence. The gate would drop `%pause` for exactly the busy panes the gap
+  machinery exists to protect, silently — and no test would catch it, because a
+  test driving an idle pane sees the after-`%end` ordering and stays green.
 - `capture-pane` runs over the tmux CLI (`exec.Command`, a separate process
   per call); `RunCommand` runs over the control-mode connection and is
   answered by `readLoop` itself, via the `%begin`/`%end` block the command
@@ -60,7 +131,7 @@ The gap is closed exactly once, by whichever of two paths claims it first:
   and marks dirty only the subscribers that were flagged `inGap` when the
   gap opened; a subscriber that attached during the gap is left alone.
 - **the deadline expiring** (`expireGap`) — the unhealthy path. Sends one
-  `refresh-client -A %N:continue`, then marks dirty *every* subscriber
+  `refresh-client -A '%N:continue'`, then marks dirty *every* subscriber
   currently on the pane, including ones that attached mid-gap.
 
 State lives in two places, both guarded by `cc.mu`: `ControlClient.gaps
@@ -86,24 +157,81 @@ while tmux is still discarding output — everything painted between that
 capture and the resume actually landing would be lost, and the subscriber,
 having already acked, would never re-seed again. That is defect 3 rebuilt on
 the path that exists to close it. `expireGap` therefore releases `cc.mu`,
-calls `cc.RunCommand("refresh-client -A " + paneID + ":continue")` from the
-timer's own goroutine, and only re-takes the lock to mark subscribers dirty
-once that call returns — successfully or not. `RunCommand` serializes on
-`cmdMu`, so the resume's `%begin`/`%end` block cannot be misdelivered to a
-different pending caller (in particular, not to the handshake's own pause
-command — a misdelivered `%error` there would seed an unpaused pane, exactly
-the corruption this work exists to prevent).
+calls `cc.RunCommand` with the quoted resume from the timer's own goroutine, and
+only re-takes the lock to mark subscribers dirty once that call returns —
+successfully or not.
 
-A resume that fails — tmux answering `%error`, or `RunCommand` returning early
-because the connection is gone — leaves the pane possibly still paused, and
-`%pause` is edge-triggered, so tmux will never announce it again. Dropping the
-gap there would rebuild the original defect with no bound at all: the
-subscriber re-seeds once, acks, and waits forever on output tmux is still
-discarding. `expireGap` therefore **re-opens the gap** on failure, arming a
-fresh deadline that retries the resume, and logs the failure at `Warn` — the
-only signal a pane is stuck, so it must be visible without `-debug`. The
-re-arm is gated on the pane still having a subscriber: with nobody watching,
-the retry would loop for the life of the client for no one.
+The first round of this record claimed that `RunCommand`'s `cmdMu` made the
+resume's block impossible to misdeliver. **That was wrong**, and the review
+demonstrated it: `cmdMu` holds only between *pending* callers, and four writers
+reach stdin without ever taking it — `sendLiteral`, `sendControl`'s hex branch,
+`SendSpecialKey`, and `attach`'s own `refresh-client -f ignore-size`. tmux
+answers each with its own block, and the drain `RunCommand` performed before its
+write could not catch a block that arrived after it. Measured with a concurrent
+`SendSpecialKey` writer: 15169 of 187405 calls took another command's reply.
+`paneWSReadLoop` runs for the whole socket lifetime, so a user pressing a key at
+a frozen pane was exactly who triggered it. The flaw was pre-existing in
+`RunCommand`; routing the resume through it is what made it load-bearing, since
+a stolen `%end` turns a guaranteed `%error` into a believed success and
+`markPaneDirty` then fires against a still-paused pane whose gap record is
+already gone.
+
+### How a block is attributed now
+
+Binding is by **order**, with the command number as the begin/end consistency
+check. It is not a command-number-keyed lookup, because that is not
+constructible: the number is assigned server-side from a global counter and
+houston never learns the one its own write received.
+
+- Every write to `cc.stdin` enrolls a queue entry **inside the same `stdinMu`
+  critical section that performs the write**, so enrollment order is write order
+  by construction. A waiterless writer enrols a `nil` entry; skipping it would
+  put the connection permanently one block out of step.
+- The **first block of every connection is dropped unbound** — it answers the
+  `attach-session` command the dialer ran. Its command number is still recorded,
+  so its `%end` is a match and not a mismatch. The marker lives in `readLoop`'s
+  own frame, which is entered once per connection: as a field on the client it
+  would misalign every connection after the first.
+- Each later `%begin` binds to the oldest entry still awaiting a block, and
+  `%end`/`%error` is delivered only when its command number equals the open
+  `%begin`'s. A `%begin` that finds an empty queue binds to nothing and is
+  dropped; a block houston did not write owns no queue position.
+- A failed write, or a terminator whose number does not match, **desynchronises**
+  the connection: every enrolled waiter is released with an error and the
+  connection is torn down so `supervise` re-dials. A failed write may have
+  delivered a partial command line, so no cheaper recovery is sound — and the
+  teardown is what keeps the state from being terminal. Without it a
+  desynchronised but transport-healthy connection would leave `readLoop`
+  reading, `connOK` true, `supervise` never re-dialling, and every later command
+  failing for the life of the client while the paused pane stayed dark. The
+  reconnect is the recovery: `attach` resets the queue and `markAllDirty`
+  re-seeds every subscriber.
+
+`cmdMu` is kept, because concurrent `RunCommand` callers are not what this
+design needs to support, but it is no longer load-bearing for correctness: it
+serializes callers and nothing more.
+
+A resume **tmux refused** leaves the pane possibly still paused, and `%pause` is
+edge-triggered, so tmux will never announce it again. Dropping the gap there
+would rebuild the original defect with no bound at all: the subscriber re-seeds
+once, acks, and waits forever on output tmux is still discarding. `expireGap`
+therefore **re-opens the gap** on a refusal, arming a fresh deadline that
+retries the resume, and logs it at `Warn` — the only signal a pane is stuck, so
+it must be visible without `-debug`. The re-arm is gated on the pane still
+having a subscriber: with nobody watching, the retry would loop for the life of
+the client for no one.
+
+**Only a refusal tmux actually sent re-arms.** The first round re-armed on any
+error, including `control connection lost`, where `RunCommand` returned without
+writing anything — so the lap cost a warning and no resume, and `markAllDirty`
+discarded the gap at reconnect regardless. Measured over a 300 ms outage with a
+stalled re-dial at a 20 ms deadline: 14 warnings, **0 resumes written**, gap
+still armed. At the production 10 s deadline that is roughly 6 warnings a
+minute of pure noise. `RunCommand` now returns distinguishable sentinels, and
+`expireGap` re-arms and warns only on `errTmuxRefused`; nothing written, a
+failed write, a dead connection, a closed client and a desynchronised stream all
+return without re-arming and log at `Debug`. Reconnect is the recovery on those
+paths, and it sweeps the gap itself.
 
 **The failed lap marks nobody**, which is the same rule as on the success path
 — mark only once the resume has landed — applied where it actually bites.
@@ -138,7 +266,7 @@ the client it belongs to.
 The state-of-play entry that opened this work proposed "an expected-continue
 counter." A count of *issued* pause commands desynchronises from tmux's
 notifications by construction: `%pause`/`%continue` are edge-triggered, so a
-second `refresh-client -A %N:pause` sent while the pane is already paused
+second `refresh-client -A '%N:pause'` sent while the pane is already paused
 produces no second `%pause` to balance against it, and a counter driven by
 commands sent would overcount relative to the transitions tmux actually
 reports. A counter driven by notifications received degenerates to exactly
@@ -155,7 +283,8 @@ stay open before houston resumes it unilaterally.
 
 **Rejected: attribute pauses by recognising the command as it passes through
 `RunCommand`.** The alternative was to have `ControlClient` notice when a
-caller sends `refresh-client -A %N:pause` through `RunCommand`, and treat
+caller sends `refresh-client -A %N:pause` through `RunCommand` (the bare form
+`server/pane_ws.go` composes, which does not parse), and treat
 only *that* pause as houston's own — deferring its dirty marking — while
 treating any other `%pause` (one tmux raised on its own, once flow control
 is enabled) as needing no resume tracking at all, on the theory that only
@@ -206,13 +335,48 @@ rare ordering.
 
 ## What is left open
 
-- The retry is unbounded. A live pane whose resume keeps erroring re-arms once
-  per deadline, forever; nothing caps the attempts or backs the interval off.
-  That is deliberate — giving up would leave the pane dark, which is the exact
-  failure this change exists to prevent — and since a failed lap marks nobody,
-  each lap costs one `refresh-client` and one `Warn`, not a re-seed. It ends on
-  a successful resume, the last subscriber leaving, a reconnect
-  (`markAllDirty` → `clearGapsLocked`), or `Close()`.
+- The refusal retry is unbounded. A live pane tmux keeps refusing to resume
+  re-arms once per deadline, forever; nothing caps the attempts or backs the
+  interval off. That is deliberate — giving up would leave the pane dark, which
+  is the exact failure this change exists to prevent — and since a failed lap
+  marks nobody, each lap costs one `refresh-client` and one `Warn`, not a
+  re-seed. It ends on a successful resume, the last subscriber leaving, a
+  reconnect (`markAllDirty` → `clearGapsLocked`), or `Close()`. A refusal is now
+  the **only** path that laps at all: the first round's claim that this was the
+  per-lap cost was wrong precisely because the connection-lost path also re-armed
+  and cost a warning per deadline while writing nothing.
+- **"Enroll before the write" is argued structurally, not witnessed by a test.**
+  Moving the enrollment after the write leaves the whole suite green, including a
+  concurrent-writer reproduction at `-race -count=20`. The reason is the fake, not
+  the test's shape: `recordedConn`'s `Write` and `written()` share one mutex, so an
+  in-test answerer cannot see the command line until the write has already
+  returned, and it then has to format a block and have `readLoop` reach
+  `claimCommand` inside the few nanoseconds before the writing goroutine appends.
+  `-race` slows both sides equally, so the window does not widen. It is real
+  against a PTY, where tmux answers on a separate fd. Catching it would need a
+  probe writer that synchronously feeds a block from inside `Write` — a test whose
+  only purpose is to kill that mutation — so the ordering rests on the code being
+  read, not on a red test.
+- **The scheme assumes exactly one block per stdin write and has no detector for
+  a stray one.** A block tmux emits that no write produced, beyond the one
+  baseline block per connection, would shift the queue for the life of that
+  connection and still pass the command-number check, since its own `%begin` and
+  `%end` agree. Nothing enforces the assumption; it rests on the documented
+  protocol plus the fact that houston writes one command per line.
+- **`paneID` is interpolated unquoted by the three send paths** (`sendLiteral`,
+  `sendControl`'s hex branch, `SendSpecialKey`). That is safe today only because
+  pane IDs reach them from tmux via `GetPaneID` and `SendSpecialKey`'s key name
+  comes from a fixed table, not from a client. The shape check below narrows the
+  notification path but does not cover these.
+- **The pane-ID shape check narrows the command sink rather than removing it.**
+  `parsePaneNotification` now takes the first field and requires `%` followed by
+  digits, so a notification carrying `;` or a quote is not treated as a
+  notification at all. What made that worth doing is that the previous guard was
+  not the one the record implied: "only a conformant tmux server writes those
+  lines" is not what protects it, because `readLoop` classifies before consulting
+  `inBlock`, so a command response *body* line beginning `%pause ` would dispatch
+  as a notification. What actually protects it is that houston issues only
+  `refresh-client`, whose response bodies are empty.
 - A fresh `%pause` arriving while a previous gap's resume is still in flight
   (i.e. a new pause on the same pane racing `expireGap`'s `RunCommand` call)
   opens a new gap and waits out a full second deadline of its own. Nothing

--- a/tmux/control.go
+++ b/tmux/control.go
@@ -34,8 +34,14 @@ type ControlEvent struct {
 	Data      string // unescaped output, window name, etc.
 }
 
+// controlModeIntroducer is the DCS sequence tmux emits on entering control
+// mode. It is glued to the front of the stream's very first line, which is the
+// %begin of the block answering the attach command itself.
+const controlModeIntroducer = "\x1bP1000p"
+
 // ParseControlLine parses a single line from tmux control mode stdout.
 func ParseControlLine(line string) ControlEvent {
+	line = strings.TrimPrefix(line, controlModeIntroducer)
 	switch {
 	case strings.HasPrefix(line, "%output "):
 		return parseOutput(line)
@@ -58,9 +64,9 @@ func ParseControlLine(line string) ControlEvent {
 	case strings.HasPrefix(line, "%pane-mode-changed "):
 		return parsePaneModeChanged(line)
 	case strings.HasPrefix(line, "%pause "):
-		return parsePaneNotification(line, "%pause ", EventPause)
+		return parsePaneNotification(line, EventPause)
 	case strings.HasPrefix(line, "%continue "):
-		return parsePaneNotification(line, "%continue ", EventContinue)
+		return parsePaneNotification(line, EventContinue)
 	case strings.HasPrefix(line, "%extended-output "):
 		return parseExtendedOutput(line)
 	default:
@@ -130,10 +136,35 @@ func parsePaneModeChanged(line string) ControlEvent {
 	return ControlEvent{Type: EventPaneModeChanged, PaneID: paneID}
 }
 
-func parsePaneNotification(line, prefix string, eventType ControlEventType) ControlEvent {
+func parsePaneNotification(line string, eventType ControlEventType) ControlEvent {
 	// "%pause %0" or "%continue %0"
-	rest := strings.TrimSpace(line[len(prefix):])
-	return ControlEvent{Type: eventType, PaneID: rest}
+	fields := strings.Fields(line)
+	var paneID string
+	if len(fields) >= 2 {
+		paneID = fields[1]
+	}
+	// This pane ID ends up in a tmux command string (ControlClient.expireGap's
+	// refresh-client -A), where ';' separates commands — quoting alone can't
+	// neutralize a field that itself contains a quote. A field that isn't
+	// shaped like a pane ID isn't a pause/continue notification at all.
+	if !isPaneID(paneID) {
+		return ControlEvent{Type: EventData, Data: line}
+	}
+	return ControlEvent{Type: eventType, PaneID: paneID}
+}
+
+// isPaneID reports whether s has tmux's pane-ID shape: '%' followed by one or
+// more digits.
+func isPaneID(s string) bool {
+	if len(s) < 2 || s[0] != '%' {
+		return false
+	}
+	for _, c := range s[1:] {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 func parseExtendedOutput(line string) ControlEvent {

--- a/tmux/control_client.go
+++ b/tmux/control_client.go
@@ -2,6 +2,7 @@ package tmux
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -40,11 +41,23 @@ type ControlClient struct {
 	// subscriber on it re-seeds. Shortened by tests.
 	gapDeadline time.Duration
 
-	// Synchronous command support: one command at a time.
-	// tmux assigns command numbers server-side, so we serialize
-	// and route the next %begin/%end to the pending caller.
-	cmdMu   sync.Mutex
-	pending chan commandResponse
+	// Synchronous command support. tmux answers every write with exactly one
+	// block, in the order it received the writes, so a reply is bound to its
+	// command by queue position. The command number cannot be a lookup key:
+	// it is a server-global counter, so houston never knows in advance what
+	// its own write will be assigned.
+	//
+	// Lock order is stdinMu → cmdQMu. readLoop must never take stdinMu, or a
+	// blocked PTY write and a blocked reader deadlock against each other.
+	//
+	// cmdMu only serializes RunCommand callers; it is cmdQ, not this lock, that
+	// binds a block to the command that asked for it. An unwaited writer never
+	// takes cmdMu, so a caller holding it can still be handed that writer's
+	// block.
+	cmdMu     sync.Mutex
+	cmdQMu    sync.Mutex
+	cmdQ      []chan commandResponse // commands awaiting their block; a nil entry is a writer that is not waiting
+	cmdDesync bool
 
 	done chan struct{}
 }
@@ -61,12 +74,24 @@ type gap struct {
 
 const backoffMax = 10 * time.Second
 
+// Exclude this CC client from window size calculations so it never overrides
+// kitty's dimensions (window-size=latest).
+const ignoreSizeCmd = "refresh-client -f ignore-size"
+
+var (
+	errConnLost     = errors.New("control connection lost")
+	errClientClosed = errors.New("control client closed")
+	// errTmuxRefused wraps a refusal tmux actually sent, which callers branch
+	// on to tell it apart from every other way a command can fail.
+	errTmuxRefused = errors.New("tmux refused the command")
+	errCmdDesync   = errors.New("control command stream desynchronised")
+)
+
 func NewControlClient(session string) *ControlClient {
 	cc := &ControlClient{
 		session: session,
 		subs:    make(map[string][]*PaneSub),
 		gaps:    make(map[string]*gap),
-		pending: make(chan commandResponse, 1),
 		done:    make(chan struct{}),
 		backoff: 250 * time.Millisecond,
 		// Comfortably beyond a healthy seed handshake, short enough that a
@@ -128,23 +153,117 @@ func (cc *ControlClient) Start() error {
 
 // attach installs a freshly dialled connection and re-asserts client options.
 func (cc *ControlClient) attach(w io.Writer, closeFn func() error) {
-	// Every send path reads cc.stdin under stdinMu, so the assignment must be
-	// guarded by the same lock, not connMu.
-	cc.stdinMu.Lock()
-	cc.stdin = w
-	// Exclude this CC client from window size calculations so it never
-	// overrides kitty's dimensions (window-size=latest).
-	_, err := io.WriteString(w, "refresh-client -f ignore-size\n")
-	cc.stdinMu.Unlock()
-	if err != nil {
-		slog.Warn("failed to set ignore-size on CC client", "error", err)
-	}
-
+	// Installed before the first enrolled write: a desync raised by that write
+	// tears down whatever closeCur names, and the previous connection's is a
+	// spent sync.Once — or nil on the first attach — which would leave this
+	// connection installed and terminal. Write order is unaffected, since the
+	// stdinMu section below spans both the cc.stdin assignment and the write.
 	cc.connMu.Lock()
 	cc.closeCur = closeFn
 	cc.connOK = true
 	cc.gone = make(chan struct{})
 	cc.connMu.Unlock()
+
+	// Every send path reads cc.stdin under stdinMu, so the assignment must be
+	// guarded by the same lock, not connMu.
+	cc.stdinMu.Lock()
+	cc.stdin = w
+	cc.cmdQMu.Lock()
+	cc.cmdQ = nil
+	cc.cmdDesync = false
+	cc.cmdQMu.Unlock()
+	err := cc.writeCommandLocked(ignoreSizeCmd, nil)
+	cc.stdinMu.Unlock()
+	if err != nil {
+		slog.Warn("failed to set ignore-size on CC client", "error", err)
+		cc.dropConnection("ignore-size write failed")
+	}
+}
+
+// writeCommandLocked enrolls reply and writes command. The caller must hold
+// stdinMu, which is what makes enrollment order equal write order.
+func (cc *ControlClient) writeCommandLocked(command string, reply chan commandResponse) error {
+	cc.cmdQMu.Lock()
+	if cc.cmdDesync {
+		cc.cmdQMu.Unlock()
+		return errCmdDesync
+	}
+	// Enrolled before the write: tmux can answer the instant the bytes land,
+	// and a block that finds an empty queue has nothing to bind to.
+	cc.cmdQ = append(cc.cmdQ, reply)
+	cc.cmdQMu.Unlock()
+
+	_, err := io.WriteString(cc.stdin, command+"\n")
+	if err != nil {
+		// The entry is left in place: a short write may have delivered part of
+		// a command line, so the queue can no longer be reasoned about, which
+		// is exactly what cmdDesync records. Set inside the stdinMu section,
+		// or a write failing against a dying connection could mark the
+		// freshly-installed one desynchronised.
+		cc.cmdQMu.Lock()
+		cc.cmdDesync = true
+		cc.cmdQMu.Unlock()
+	}
+	return err
+}
+
+func (cc *ControlClient) writeCommand(command string, reply chan commandResponse) error {
+	cc.stdinMu.Lock()
+	err := cc.writeCommandLocked(command, reply)
+	cc.stdinMu.Unlock()
+	// errCmdDesync means the stream was already desynchronised, and whoever
+	// desynchronised it already dropped the connection; dropping again would log
+	// a teardown per send for the whole window before the reconnect lands.
+	if err != nil && !errors.Is(err, errCmdDesync) {
+		cc.dropConnection("control command write failed")
+	}
+	return err
+}
+
+// claimCommand pops the command the next block answers.
+func (cc *ControlClient) claimCommand() chan commandResponse {
+	cc.cmdQMu.Lock()
+	defer cc.cmdQMu.Unlock()
+	if cc.cmdDesync || len(cc.cmdQ) == 0 {
+		return nil
+	}
+	reply := cc.cmdQ[0]
+	cc.cmdQ = cc.cmdQ[1:]
+	return reply
+}
+
+// desync abandons the queue once its alignment stops being knowable, failing
+// every enrolled waiter rather than answering it from another command's block.
+// A false return means someone got here first, so the teardown runs once.
+func (cc *ControlClient) desync() bool {
+	cc.cmdQMu.Lock()
+	defer cc.cmdQMu.Unlock()
+	if cc.cmdDesync {
+		return false
+	}
+	cc.cmdDesync = true
+	for _, reply := range cc.cmdQ {
+		if reply != nil {
+			reply <- commandResponse{err: errCmdDesync}
+		}
+	}
+	cc.cmdQ = nil
+	return true
+}
+
+// dropConnection ends the current connection so supervise re-dials, attach
+// resets the queue and markAllDirty re-seeds every subscriber. Without it a
+// desynchronised but transport-healthy connection is terminal: readLoop keeps
+// reading, connOK stays true, nothing re-dials, and every later command fails
+// for the life of the client while a paused pane stays dark.
+func (cc *ControlClient) dropConnection(reason string) {
+	slog.Warn("dropping control connection", "session", cc.session, "reason", reason)
+	// No nil guard: attach installs closeCur before any path that can drop
+	// the connection exists.
+	cc.connMu.RLock()
+	closeFn := cc.closeCur
+	cc.connMu.RUnlock()
+	_ = closeFn()
 }
 
 // minHealthyConn is how long a connection must last to count as healthy. A
@@ -241,6 +360,47 @@ func (cc *ControlClient) Connected() bool {
 func (cc *ControlClient) readLoop(r *bufio.Reader) {
 	var cmdBuf strings.Builder
 	inBlock := false
+	blockNum := 0
+	var blockReply chan commandResponse
+	// A real tmux -CC answers the dialer's own attach-session command before
+	// houston has written anything, so exactly one block per connection is
+	// owed to no write of ours. Per-connection state, not a field: a once-only
+	// field would leave every connection after the first permanently one block
+	// out of step.
+	sawBaseline := false
+
+	// endBlock hands a terminator to whoever asked for the block.
+	endBlock := func(cmdNum int, resp commandResponse) {
+		if !inBlock {
+			// Binding happens at %begin, so a block whose %begin never reached
+			// us claimed no queue entry: the queue is untouched and still
+			// aligned, and dropping the orphan is all this case asks for. The
+			// one %begin that can go missing is the baseline's — it is the only
+			// line tmux glues its control-mode introducer onto — so absorb the
+			// baseline here too, which keeps a stream introduced some other way
+			// merely odd instead of permanently one block out of step.
+			slog.Debug("control block terminator outside a block", "session", cc.session, "cmd", cmdNum)
+			sawBaseline = true
+			return
+		}
+		if cmdNum != blockNum {
+			// Unlike the orphan above, this block was bound at its %begin and
+			// then answered under a different command number, so which entry
+			// the queue head now belongs to is unknowable and delivering would
+			// answer the wrong caller.
+			if cc.desync() {
+				cc.dropConnection("block terminator does not match its %begin")
+			}
+			inBlock = false
+			blockReply = nil
+			return
+		}
+		if blockReply != nil {
+			blockReply <- resp
+		}
+		inBlock = false
+		blockReply = nil
+	}
 
 	for {
 		line, err := r.ReadString('\n')
@@ -267,20 +427,24 @@ func (cc *ControlClient) readLoop(r *bufio.Reader) {
 		case EventBegin:
 			inBlock = true
 			cmdBuf.Reset()
+			// Recorded for the baseline too, so its own terminator is a match
+			// rather than a desynchronising mismatch.
+			blockNum = event.CmdNumber
+			if !sawBaseline {
+				sawBaseline = true
+				blockReply = nil
+				break
+			}
+			// A block that finds an empty queue is one houston did not write:
+			// it owns no queue position, so dropping it keeps the queue
+			// aligned where desynchronising would not.
+			blockReply = cc.claimCommand()
 
 		case EventEnd:
-			inBlock = false
-			select {
-			case cc.pending <- commandResponse{output: cmdBuf.String()}:
-			default:
-			}
+			endBlock(event.CmdNumber, commandResponse{output: cmdBuf.String()})
 
 		case EventError:
-			inBlock = false
-			select {
-			case cc.pending <- commandResponse{err: fmt.Errorf("tmux error: %s", cmdBuf.String())}:
-			default:
-			}
+			endBlock(event.CmdNumber, commandResponse{err: fmt.Errorf("%w: %s", errTmuxRefused, cmdBuf.String())})
 
 		case EventData:
 			if inBlock {
@@ -441,8 +605,22 @@ func (cc *ControlClient) expireGap(paneID string, g *gap) {
 	// Resume first, mark after. Marked first, the consumer would capture-pane
 	// while tmux is still discarding: everything painted before the resume
 	// lands is lost, and the subscriber, having acked, never re-seeds again.
-	if _, err := cc.RunCommand("refresh-client -A " + paneID + ":continue"); err != nil {
-		slog.Warn("gap deadline resume failed",
+	//
+	// paneID must be quoted: tmux's command-string lexer rejects a bare token
+	// that starts with '%' and contains ':', so %0:continue is a parse error.
+	if _, err := cc.RunCommand(fmt.Sprintf("refresh-client -A '%s:continue'", paneID)); err != nil {
+		// Only a refusal tmux sent means the pane may still be paused with
+		// tmux still willing to talk. Every other failure — the connection
+		// already gone before the write, dying after it, or a desynchronised
+		// queue — ends in a re-attach, and that sweeps the gaps and re-seeds
+		// every subscriber anyway. Re-arming there would retry against a
+		// connection that cannot carry the write.
+		if !errors.Is(err, errTmuxRefused) {
+			slog.Debug("gap deadline resume abandoned to the reconnect",
+				"session", cc.session, "pane", paneID, "error", err)
+			return
+		}
+		slog.Warn("gap deadline resume refused",
 			"session", cc.session, "pane", paneID, "error", err)
 		// The pane may still be paused, and %pause is edge-triggered: tmux
 		// will never announce one it already considers paused. Without a
@@ -579,11 +757,7 @@ func isPrintable(s string) bool {
 
 func (cc *ControlClient) sendLiteral(paneID, text string) error {
 	escaped := strings.ReplaceAll(text, "'", "'\\''")
-	cmd := fmt.Sprintf("send-keys -t %s -l '%s'\n", paneID, escaped)
-	cc.stdinMu.Lock()
-	_, err := io.WriteString(cc.stdin, cmd)
-	cc.stdinMu.Unlock()
-	return err
+	return cc.writeCommand(fmt.Sprintf("send-keys -t %s -l '%s'", paneID, escaped), nil)
 }
 
 func (cc *ControlClient) sendControl(paneID string, b byte) error {
@@ -602,11 +776,7 @@ func (cc *ControlClient) sendControl(paneID string, b byte) error {
 			name = fmt.Sprintf("C-%c", 'a'+rune(b)-1)
 		} else {
 			// Rare control char — send as hex
-			cmd := fmt.Sprintf("send-keys -t %s -H %02x\n", paneID, b)
-			cc.stdinMu.Lock()
-			_, err := io.WriteString(cc.stdin, cmd)
-			cc.stdinMu.Unlock()
-			return err
+			return cc.writeCommand(fmt.Sprintf("send-keys -t %s -H %02x", paneID, b), nil)
 		}
 	}
 	return cc.SendSpecialKey(paneID, name)
@@ -635,24 +805,15 @@ func matchEscSeq(s string) (int, string) {
 
 // SendSpecialKey sends a named key (Enter, Escape, C-c, etc.) to a pane.
 func (cc *ControlClient) SendSpecialKey(paneID, key string) error {
-	cmd := fmt.Sprintf("send-keys -t %s %s\n", paneID, key)
-	cc.stdinMu.Lock()
-	_, err := io.WriteString(cc.stdin, cmd)
-	cc.stdinMu.Unlock()
-	return err
+	return cc.writeCommand(fmt.Sprintf("send-keys -t %s %s", paneID, key), nil)
 }
 
-// RunCommand sends a command and waits for its response.
-// Only one command runs at a time (serialized via cmdMu).
+// RunCommand sends a command and waits for the block tmux answers it with.
+// cmdMu only serializes callers; what binds the reply to this command is its
+// position in cmdQ.
 func (cc *ControlClient) RunCommand(command string) (string, error) {
 	cc.cmdMu.Lock()
 	defer cc.cmdMu.Unlock()
-
-	// Drain any stale response from a previous unsolicited %begin/%end
-	select {
-	case <-cc.pending:
-	default:
-	}
 
 	// Captured before the write, so a nil here means the connection was
 	// already dead and the command cannot have landed.
@@ -660,23 +821,23 @@ func (cc *ControlClient) RunCommand(command string) (string, error) {
 	gone := cc.gone
 	cc.connMu.RUnlock()
 	if gone == nil {
-		return "", fmt.Errorf("control connection lost")
+		return "", errConnLost
 	}
 
-	cc.stdinMu.Lock()
-	_, err := io.WriteString(cc.stdin, command+"\n")
-	cc.stdinMu.Unlock()
-	if err != nil {
+	// Buffered and sent exactly once, so readLoop never blocks on a waiter
+	// that has already left via gone or done.
+	reply := make(chan commandResponse, 1)
+	if err := cc.writeCommand(command, reply); err != nil {
 		return "", err
 	}
 
 	select {
-	case resp := <-cc.pending:
+	case resp := <-reply:
 		return resp.output, resp.err
 	case <-gone:
-		return "", fmt.Errorf("control connection lost")
+		return "", errConnLost
 	case <-cc.done:
-		return "", fmt.Errorf("control client closed")
+		return "", errClientClosed
 	}
 }
 

--- a/tmux/control_client.go
+++ b/tmux/control_client.go
@@ -17,6 +17,12 @@ type ControlClient struct {
 	session string
 	stdin   io.Writer
 	stdinMu sync.Mutex // serialize writes to stdin
+	// curClose is the close fn for the connection cc.stdin currently writes to.
+	// Guarded by stdinMu, not connMu, and set in the same critical section as
+	// cc.stdin: a writer holding stdinMu can then rely on curClose naming the
+	// connection its write is actually going out on, even if connMu's closeCur
+	// has already moved on to a newer connection.
+	curClose func() error
 
 	// dial opens one control-mode connection. Overridable in tests.
 	dial    func() (io.ReadCloser, io.Writer, func() error, error)
@@ -41,11 +47,17 @@ type ControlClient struct {
 	// subscriber on it re-seeds. Shortened by tests.
 	gapDeadline time.Duration
 
-	// Synchronous command support. tmux answers every write with exactly one
-	// block, in the order it received the writes, so a reply is bound to its
-	// command by queue position. The command number cannot be a lookup key:
-	// it is a server-global counter, so houston never knows in advance what
-	// its own write will be assigned.
+	// Synchronous command support. Each write is bound to its reply by queue
+	// position, which requires each command to draw exactly one block from
+	// tmux. That is a precondition on the caller, not a guaranteed property of
+	// tmux: a command string containing a top-level `;` draws two blocks
+	// (tmux draws one block per top-level command), and a command string
+	// containing a newline is written to tmux's control-mode stdin as more
+	// than one line, which draws more than one block the same way. See
+	// writeCommandLocked's doc comment for this precondition and the matching
+	// one on a command's response body. The command number cannot be a lookup
+	// key: it is a server-global counter, so houston never knows in advance
+	// what its own write will be assigned.
 	//
 	// Lock order is stdinMu → cmdQMu. readLoop must never take stdinMu, or a
 	// blocked PTY write and a blocked reader deadlock against each other.
@@ -153,11 +165,12 @@ func (cc *ControlClient) Start() error {
 
 // attach installs a freshly dialled connection and re-asserts client options.
 func (cc *ControlClient) attach(w io.Writer, closeFn func() error) {
-	// Installed before the first enrolled write: a desync raised by that write
-	// tears down whatever closeCur names, and the previous connection's is a
-	// spent sync.Once — or nil on the first attach — which would leave this
-	// connection installed and terminal. Write order is unaffected, since the
-	// stdinMu section below spans both the cc.stdin assignment and the write.
+	// Installed before the first enrolled write: that write can fail, and
+	// gone is what RunCommand reads to decide whether a connection is live
+	// (connOK is Connected()'s field, with no production reader today). Left
+	// stale, it would advertise the previous connection as current for the
+	// length of this write. Write order is unaffected, since the stdinMu
+	// section below spans both the cc.stdin assignment and the write.
 	cc.connMu.Lock()
 	cc.closeCur = closeFn
 	cc.connOK = true
@@ -168,6 +181,7 @@ func (cc *ControlClient) attach(w io.Writer, closeFn func() error) {
 	// guarded by the same lock, not connMu.
 	cc.stdinMu.Lock()
 	cc.stdin = w
+	cc.curClose = closeFn
 	cc.cmdQMu.Lock()
 	cc.cmdQ = nil
 	cc.cmdDesync = false
@@ -176,12 +190,27 @@ func (cc *ControlClient) attach(w io.Writer, closeFn func() error) {
 	cc.stdinMu.Unlock()
 	if err != nil {
 		slog.Warn("failed to set ignore-size on CC client", "error", err)
-		cc.dropConnection("ignore-size write failed")
+		cc.dropConnection("ignore-size write failed", closeFn)
 	}
 }
 
 // writeCommandLocked enrolls reply and writes command. The caller must hold
 // stdinMu, which is what makes enrollment order equal write order.
+//
+// Two preconditions on command, neither enforced here:
+//   - It must not contain a top-level `;` or a newline (see the struct-level
+//     "Synchronous command support" comment on ControlClient) — either makes
+//     tmux draw more than one block for what this queue treats as a single
+//     write.
+//   - Whatever response body tmux sends back for it must be empty. tmux does
+//     not escape response body lines, so a body line starting with `%begin `
+//     or `%end ` forges a block opener/terminator: it desynchronises the
+//     reply-attribution queue, or, for a forged `%begin `, silently
+//     misattributes a reply. Unreachable today — every call site's response
+//     body is empty — but binds any future caller, e.g. a seeding call built
+//     on RunCommand("capture-pane ...") (sketched in
+//     docs/plans/2026-03-01-control-mode-io-refactor.md), whose body is pane
+//     screen content and could legitimately contain such a line.
 func (cc *ControlClient) writeCommandLocked(command string, reply chan commandResponse) error {
 	cc.cmdQMu.Lock()
 	if cc.cmdDesync {
@@ -210,12 +239,17 @@ func (cc *ControlClient) writeCommandLocked(command string, reply chan commandRe
 func (cc *ControlClient) writeCommand(command string, reply chan commandResponse) error {
 	cc.stdinMu.Lock()
 	err := cc.writeCommandLocked(command, reply)
+	// Captured under stdinMu, because the write above can stall long enough for
+	// this connection to be retired and a new one attached: read after the
+	// unlock, the teardown would name that new connection. Non-nil whenever
+	// cc.stdin is — attach assigns both in one stdinMu section — so no guard.
+	closeFn := cc.curClose
 	cc.stdinMu.Unlock()
 	// errCmdDesync means the stream was already desynchronised, and whoever
 	// desynchronised it already dropped the connection; dropping again would log
 	// a teardown per send for the whole window before the reconnect lands.
 	if err != nil && !errors.Is(err, errCmdDesync) {
-		cc.dropConnection("control command write failed")
+		cc.dropConnection("control command write failed", closeFn)
 	}
 	return err
 }
@@ -256,13 +290,12 @@ func (cc *ControlClient) desync() bool {
 // desynchronised but transport-healthy connection is terminal: readLoop keeps
 // reading, connOK stays true, nothing re-dials, and every later command fails
 // for the life of the client while a paused pane stays dark.
-func (cc *ControlClient) dropConnection(reason string) {
+// closeFn names the connection to end, and the caller must have determined it
+// while still holding whatever lock pins it to the failure being reported: read
+// from a field afterwards it can name a newer connection, which would kill a
+// healthy one and leave the dead one installed.
+func (cc *ControlClient) dropConnection(reason string, closeFn func() error) {
 	slog.Warn("dropping control connection", "session", cc.session, "reason", reason)
-	// No nil guard: attach installs closeCur before any path that can drop
-	// the connection exists.
-	cc.connMu.RLock()
-	closeFn := cc.closeCur
-	cc.connMu.RUnlock()
 	_ = closeFn()
 }
 
@@ -389,7 +422,15 @@ func (cc *ControlClient) readLoop(r *bufio.Reader) {
 			// the queue head now belongs to is unknowable and delivering would
 			// answer the wrong caller.
 			if cc.desync() {
-				cc.dropConnection("block terminator does not match its %begin")
+				// Read fresh under connMu rather than captured under stdinMu,
+				// which readLoop must never take. Safe here because supervise
+				// calls readLoop and attach strictly in sequence and there is
+				// one supervise goroutine per client, so no newer connection
+				// can have been installed while this readLoop is still live.
+				cc.connMu.RLock()
+				closeFn := cc.closeCur
+				cc.connMu.RUnlock()
+				cc.dropConnection("block terminator does not match its %begin", closeFn)
 			}
 			inBlock = false
 			blockReply = nil

--- a/tmux/control_client_test.go
+++ b/tmux/control_client_test.go
@@ -344,6 +344,14 @@ type recordedConn struct {
 	buf      strings.Builder
 	blocks   int   // command numbers for the blocks this connection answers
 	writeErr error // when set, every stdin write fails; nothing else here can
+
+	// parkWrite, when set, blocks the next Write until the channel is closed,
+	// then writeErr is returned. parked is closed once Write is blocked on it,
+	// so a test can observe the write is genuinely parked before proceeding.
+	// Both are read-and-cleared under mu the instant Write enters the park
+	// branch, so a second Write can never re-enter it and double-close parked.
+	parkWrite chan struct{}
+	parked    chan struct{}
 }
 
 // baselineBlock is what a real tmux -CC answers its own attach-session command
@@ -400,6 +408,18 @@ func (d *recordingDialer) connAt(t *testing.T, i int) *recordedConn {
 }
 
 func (c *recordedConn) Write(p []byte) (int, error) {
+	c.mu.Lock()
+	park, parked := c.parkWrite, c.parked
+	if park != nil {
+		c.parkWrite, c.parked = nil, nil
+	}
+	c.mu.Unlock()
+	if park != nil {
+		if parked != nil {
+			close(parked)
+		}
+		<-park
+	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.writeErr != nil {
@@ -522,12 +542,21 @@ const resume1 = "refresh-client -A '%1:continue'"
 
 // pinnedDial hands out d's first connection and fails every later dial.
 //
-// Every negative assertion about gap state needs this pin. Unpinned, supervise
-// re-dials inside its backoff and the re-attach runs markAllDirty →
-// clearGapsLocked, which deletes the very gap the test is examining: gapCount()
-// then reads 0 whether the re-arm under test happened or not, and a gap that
+// Three re-arm tests use this pin. Unpinned, against CORRECT code, the three
+// pass at rates 22/40, 40/40, 40/40 over repeated runs — one of them flakes,
+// because supervise's re-dial inside its backoff re-attaches, and the
+// re-attach's markAllDirty call queues an extra Dirty event into a test that
+// asserts "0 events received". Against the MUTANT (the re-arm guard actually
+// removed), all three already pass 0/40 — every run fails, so the mutant is
+// always caught — identical whether pinned or unpinned. So the pin does not
+// change whether the mutant is detected; the gapCount()-style assertions
+// catch it either way, pinned or not. What the pin actually buys is
+// eliminating that one flake source against correct code, which is unrelated
+// to the mutant. Separately, and still true regardless of the pin: a gap that
 // did get re-armed fires its deadline against a connection the test no longer
-// holds. Tests that want the re-dial say so and use d.dial directly.
+// holds, once a re-dial has happened. TestStaleDeadlineDoesNotClaimANewerGap
+// never reaches RunCommand at all, so the pin buys it nothing measurable.
+// Tests that want the re-dial say so and use d.dial directly.
 func pinnedDial(d *recordingDialer) func() (io.ReadCloser, io.Writer, func() error, error) {
 	first := true
 	return func() (io.ReadCloser, io.Writer, func() error, error) {
@@ -549,6 +578,21 @@ func waitRetired(t *testing.T, cc *ControlClient) {
 		select {
 		case <-deadline:
 			t.Fatal("connection was never retired")
+		case <-time.After(time.Millisecond):
+		}
+	}
+}
+
+// waitConnected blocks until supervise has re-attached. attach installs connOK
+// in the same critical section as closeCur and gone, so this is the barrier for
+// "a new connection is now the current one".
+func waitConnected(t *testing.T, cc *ControlClient) {
+	t.Helper()
+	deadline := time.After(2 * time.Second)
+	for !cc.Connected() {
+		select {
+		case <-deadline:
+			t.Fatal("connection was never re-established")
 		case <-time.After(time.Millisecond):
 		}
 	}
@@ -1536,16 +1580,17 @@ func assertIgnoreSizeFirst(t *testing.T, c *recordedConn) {
 	}
 }
 
-// TestAttachWriteFailureTearsDownItsOwnConnection pins why attach installs
-// closeCur, connOK and gone before its own ignore-size write. That write can
-// fail, and the teardown behind it must close the connection being installed;
-// reached through the previous connection's closeCur it would close a spent
-// sync.Once — nil on the very first attach — and leave this connection
-// installed, connOK true, and nothing ever re-dialling.
+// TestAttachWriteFailureTearsDownItsOwnConnection pins that attach's own
+// ignore-size write, when it fails, tears down the connection attach just
+// installed. It has that connection's close fn in scope as a parameter and
+// hands it to the teardown, rather than letting the teardown pick a connection
+// out of a field — which, on the first attach, holds nothing yet, and later
+// holds whichever connection is current by then. Closed through the wrong one,
+// this connection would stay installed with connOK true and nothing ever
+// re-dialling.
 //
 // What tells the two apart is a second connection appearing at all, with
-// ignore-size written on it — though on the very first attach the wrong order
-// does not get that far: closeCur is still nil and the teardown panics on it.
+// ignore-size written on it.
 func TestAttachWriteFailureTearsDownItsOwnConnection(t *testing.T) {
 	d := &recordingDialer{
 		onDial: func(i int, c *recordedConn) {
@@ -1567,6 +1612,78 @@ func TestAttachWriteFailureTearsDownItsOwnConnection(t *testing.T) {
 		t.Fatalf("the failing connection recorded %q, want nothing", got)
 	}
 	assertIgnoreSizeFirst(t, d.connAt(t, 1))
+}
+
+// TestFailedWriteTearsDownTheConnectionItActuallyWroteTo pins that a write
+// failure closes the connection the bytes were going out on, not whichever
+// connection happens to be current when the write finally returns. A write
+// stalls inside the PTY while holding stdinMu; nothing about retiring that
+// connection and attaching the next one needs stdinMu, so the whole
+// EOF → retire → backoff → dial → attach cycle can complete underneath it —
+// attach installs the new closeCur under connMu long before it reaches its own
+// stdinMu section. Reading the teardown target from a field after unlocking
+// therefore names the *new* connection, and the stale write kills a healthy
+// one. What tells the two apart is a third dial: the wrongly-closed connection
+// EOFs at once and supervise re-dials.
+func TestFailedWriteTearsDownTheConnectionItActuallyWroteTo(t *testing.T) {
+	d := &recordingDialer{}
+	cc := NewControlClient("test")
+	cc.dial = d.dial
+	cc.backoff = time.Millisecond
+
+	if err := cc.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = cc.Close() }()
+
+	conn0 := d.connAt(t, 0)
+	conn0.ackAttach(t)
+
+	// Driven through local channels only: Write nils the fields the instant it
+	// parks, so reading them back would find nil and close(nil) panics.
+	park, parked := make(chan struct{}), make(chan struct{})
+	conn0.mu.Lock()
+	conn0.parkWrite, conn0.parked, conn0.writeErr = park, parked, errors.New("stdin is gone")
+	conn0.mu.Unlock()
+
+	go func() { _ = cc.SendSpecialKey("%1", "C-c") }()
+
+	select {
+	case <-parked:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the send never reached the parked write")
+	}
+
+	// Connection 0's read side dies, so readLoop EOFs and supervise retires it
+	// and re-dials — none of which needs the stdinMu the parked write holds.
+	_ = conn0.pw.Close()
+
+	// Not waitRetired: with a 1ms backoff the retired window can close before a
+	// poll ever sees it. The second dial is the sound barrier — supervise
+	// clears connOK before dialling — and Connected() after it means attach's
+	// connMu section has completed for connection 1 while its own stdinMu
+	// section is still queued behind the parked write. That is the window the
+	// bug needs.
+	d.connAt(t, 1)
+	waitConnected(t, cc)
+
+	close(park)
+
+	deadline := time.After(200 * time.Millisecond)
+	for {
+		d.mu.Lock()
+		n := len(d.conns)
+		d.mu.Unlock()
+		if n >= 3 {
+			t.Fatal("a third connection was dialled: connection 1 was torn down through a stale closeCur")
+		}
+		select {
+		case <-deadline:
+			assertIgnoreSizeFirst(t, d.connAt(t, 1))
+			return
+		case <-time.After(time.Millisecond):
+		}
+	}
 }
 
 func TestReconnectMarksSubscribersDirty(t *testing.T) {

--- a/tmux/control_client_test.go
+++ b/tmux/control_client_test.go
@@ -2,7 +2,11 @@ package tmux
 
 import (
 	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
 	"io"
+	"log/slog"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -176,6 +180,16 @@ func (cc *ControlClient) gapFor(paneID string) *gap {
 	return cc.gaps[paneID]
 }
 
+// isDirty reports whether a subscriber is currently withholding delivery. A
+// test asserting that nothing reaches a subscriber needs it: dispatch drops
+// everything for a dirty subscriber, so silence alone cannot tell "tmux sent
+// nothing" apart from "we refused to deliver it".
+func (cc *ControlClient) isDirty(s *PaneSub) bool {
+	cc.mu.RLock()
+	defer cc.mu.RUnlock()
+	return s.dirty
+}
+
 // TestPauseDefersDirtyUntilContinue proves that %pause alone must queue no
 // Dirty: a capture triggered at %pause predates the output tmux discards
 // during the gap, so re-seeding then paints onto a stale screen. The Dirty
@@ -266,6 +280,21 @@ func TestOrphanContinueMarksNobody(t *testing.T) {
 	}
 }
 
+// TestPauseWithAQuotedPaneIDOpensNoGap proves the injection is closed
+// upstream of expireGap's command string: a %pause whose pane-ID field isn't
+// shaped like a real pane ID must not be treated as a notification at all, or
+// that field would reach refresh-client -A '<id>:continue' verbatim.
+func TestPauseWithAQuotedPaneIDOpensNoGap(t *testing.T) {
+	cc := NewControlClient("test")
+	t.Cleanup(cc.clearGaps) // a failed fix would open a gap nothing closes
+
+	feed(cc, "%pause %0';kill-server;'x\n")
+
+	if n := cc.gapCount(); n != 0 {
+		t.Fatalf("%d gaps open after a malformed %%pause, want 0", n)
+	}
+}
+
 // scriptedDialer hands out one canned transcript per dial, so a test can drive
 // the client through a disconnect and a re-attach without running tmux.
 type scriptedDialer struct {
@@ -302,21 +331,48 @@ func (d *scriptedDialer) count() int {
 type recordingDialer struct {
 	mu    sync.Mutex
 	conns []*recordedConn
+	// onDial arms a connection before it is handed out. It takes the index
+	// because arming every connection hot-loops the dialer.
+	onDial func(i int, c *recordedConn)
+	// baseline replaces baselineBlock on every connection.
+	baseline string
 }
 
 type recordedConn struct {
-	pw  *io.PipeWriter
-	mu  sync.Mutex
-	buf strings.Builder
+	pw       *io.PipeWriter
+	mu       sync.Mutex
+	buf      strings.Builder
+	blocks   int   // command numbers for the blocks this connection answers
+	writeErr error // when set, every stdin write fails; nothing else here can
 }
+
+// baselineBlock is what a real tmux -CC answers its own attach-session command
+// with, before houston has written anything. The fake owes it because blocks
+// bind to commands by order: without it every block on the connection answers
+// the command one place ahead of the right one. Byte-faithful down to the
+// control-mode introducer and the CRLFs, because the introducer is exactly what
+// decides whether the baseline's %begin parses at all.
+const baselineBlock = "\x1bP1000p%begin 1700000000 1 0\r\n%end 1700000000 1 0\r\n"
 
 func (d *recordingDialer) dial() (io.ReadCloser, io.Writer, func() error, error) {
 	pr, pw := io.Pipe()
 	c := &recordedConn{pw: pw}
 	d.mu.Lock()
+	if d.onDial != nil {
+		// Called before the connection is visible to connAt, so a test can arm
+		// it ahead of attach's own write.
+		d.onDial(len(d.conns), c)
+	}
 	d.conns = append(d.conns, c)
+	baseline := d.baseline
 	d.mu.Unlock()
-	return pr, c, func() error { return pw.Close() }, nil
+	if baseline == "" {
+		baseline = baselineBlock
+	}
+	// Prefixed onto the reader rather than written into pw: readLoop does not
+	// run until attach returns, so a write here would deadlock Start().
+	return io.NopCloser(io.MultiReader(strings.NewReader(baseline), pr)),
+		c, func() error { return pw.Close() }, nil
 }
 
 // connAt waits for the i-th dial and returns its connection. Dial i>0 happens
@@ -346,7 +402,18 @@ func (d *recordingDialer) connAt(t *testing.T, i int) *recordedConn {
 func (c *recordedConn) Write(p []byte) (int, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if c.writeErr != nil {
+		return 0, c.writeErr
+	}
 	return c.buf.Write(p)
+}
+
+// nextBlock numbers the next block this connection emits.
+func (c *recordedConn) nextBlock() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.blocks++
+	return c.blocks
 }
 
 func (c *recordedConn) written() string {
@@ -407,18 +474,36 @@ func waitForWriteCount(t *testing.T, c *recordedConn, want string, n int) {
 }
 
 // answerCommand releases a RunCommand caller parked on its response block.
-func (c *recordedConn) answerCommand(t *testing.T) {
+func (c *recordedConn) answerCommand(t *testing.T, body ...string) {
 	t.Helper()
-	c.feedLine(t, "%begin 1700000000 1 0")
-	c.feedLine(t, "%end 1700000000 1 0")
+	c.emitBlock(t, "%end", body)
 }
 
 // answerCommandError releases a RunCommand caller with tmux's refusal.
-func (c *recordedConn) answerCommandError(t *testing.T) {
+func (c *recordedConn) answerCommandError(t *testing.T, body string) {
 	t.Helper()
-	c.feedLine(t, "%begin 1700000000 1 0")
-	c.feedLine(t, "can't find pane")
-	c.feedLine(t, "%error 1700000000 1 0")
+	c.emitBlock(t, "%error", []string{body})
+}
+
+// emitBlock writes one block. Both ends carry the same command number: a
+// mismatch desynchronises the connection instead of delivering.
+func (c *recordedConn) emitBlock(t *testing.T, terminator string, body []string) {
+	t.Helper()
+	num := c.nextBlock()
+	c.feedLine(t, fmt.Sprintf("%%begin 1700000000 %d 0", num))
+	for _, line := range body {
+		c.feedLine(t, line)
+	}
+	c.feedLine(t, fmt.Sprintf("%s 1700000000 %d 0", terminator, num))
+}
+
+// ackAttach answers the ignore-size command attach writes. Every block is
+// bound in order to the command it answers, so a test that leaves ignore-size
+// outstanding binds its own command's reply to the attach write and parks.
+func (c *recordedConn) ackAttach(t *testing.T) {
+	t.Helper()
+	waitForWrite(t, c, ignoreSizeCmd)
+	c.answerCommand(t)
 }
 
 func expectDirty(t *testing.T, s *PaneSub, who string) {
@@ -433,7 +518,88 @@ func expectDirty(t *testing.T, s *PaneSub, who string) {
 	}
 }
 
-const resume1 = "refresh-client -A %1:continue"
+const resume1 = "refresh-client -A '%1:continue'"
+
+// pinnedDial hands out d's first connection and fails every later dial.
+//
+// Every negative assertion about gap state needs this pin. Unpinned, supervise
+// re-dials inside its backoff and the re-attach runs markAllDirty →
+// clearGapsLocked, which deletes the very gap the test is examining: gapCount()
+// then reads 0 whether the re-arm under test happened or not, and a gap that
+// did get re-armed fires its deadline against a connection the test no longer
+// holds. Tests that want the re-dial say so and use d.dial directly.
+func pinnedDial(d *recordingDialer) func() (io.ReadCloser, io.Writer, func() error, error) {
+	first := true
+	return func() (io.ReadCloser, io.Writer, func() error, error) {
+		if !first {
+			return nil, nil, nil, errors.New("pinned to one connection")
+		}
+		first = false // Start()'s own call; every later one runs in supervise's goroutine, so the two never race
+		return d.dial()
+	}
+}
+
+// waitRetired blocks until supervise has retired the live connection. connOK
+// and gone are cleared in the same critical section, so this is the barrier for
+// "the next RunCommand cannot even write".
+func waitRetired(t *testing.T, cc *ControlClient) {
+	t.Helper()
+	deadline := time.After(2 * time.Second)
+	for cc.Connected() {
+		select {
+		case <-deadline:
+			t.Fatal("connection was never retired")
+		case <-time.After(time.Millisecond):
+		}
+	}
+}
+
+// logCapture collects slog output. The buffer carries its own lock: the lines
+// under test are written from expireGap's goroutine and from supervise's.
+type logCapture struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (l *logCapture) Write(p []byte) (int, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.buf.Write(p)
+}
+
+func (l *logCapture) String() string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.buf.String()
+}
+
+// captureLogs routes slog to a buffer for the rest of the test. slog.SetDefault
+// is process-global, so a test using it must never call t.Parallel(): it would
+// clobber, and be clobbered by, anything logging beside it. Debug is enabled so
+// a test can prove the quiet path ran at all instead of reading an empty buffer
+// as success.
+func captureLogs(t *testing.T) *logCapture {
+	t.Helper()
+	lc := &logCapture{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(lc, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return lc
+}
+
+// assertNoWarn proves a failure was logged quietly. The positive half carries
+// the test: an empty buffer satisfies "no warning" even when expireGap never
+// ran at all.
+func assertNoWarn(t *testing.T, logs *logCapture, wantDebug string) {
+	t.Helper()
+	got := logs.String()
+	if !strings.Contains(got, wantDebug) {
+		t.Fatalf("no %q line logged; got %q", wantDebug, got)
+	}
+	if strings.Contains(got, "level=WARN") {
+		t.Fatalf("warned about a failure the reconnect already recovers from: %q", got)
+	}
+}
 
 func TestGapDeadlineResumesAndMarksEverySubscriber(t *testing.T) {
 	d := &recordingDialer{}
@@ -453,6 +619,7 @@ func TestGapDeadlineResumesAndMarksEverySubscriber(t *testing.T) {
 	}
 	defer func() { _ = cc.Close() }()
 	conn := d.connAt(t, 0)
+	conn.ackAttach(t)
 
 	conn.feedLine(t, "%pause %1")
 	conn.sync(t, sentinel) // the gap is open
@@ -490,6 +657,7 @@ func TestGapDeadlineResumesBeforeMarking(t *testing.T) {
 	}
 	defer func() { _ = cc.Close() }()
 	conn := d.connAt(t, 0)
+	conn.ackAttach(t)
 
 	conn.feedLine(t, "%pause %1")
 	waitForWrite(t, conn, resume1)
@@ -525,10 +693,11 @@ func TestRefusedResumeReArmsTheGap(t *testing.T) {
 	}
 	defer func() { _ = cc.Close() }()
 	conn := d.connAt(t, 0)
+	conn.ackAttach(t)
 
 	conn.feedLine(t, "%pause %1")
 	waitForWrite(t, conn, resume1)
-	conn.answerCommandError(t)
+	conn.answerCommandError(t, "can't find pane")
 
 	waitForWriteCount(t, conn, resume1, 2)
 	if n := len(sub.C()); n != 0 {
@@ -553,10 +722,11 @@ func TestRefusedResumeWithNoSubscribersStopsRetrying(t *testing.T) {
 	}
 	defer func() { _ = cc.Close() }()
 	conn := d.connAt(t, 0)
+	conn.ackAttach(t)
 
 	conn.feedLine(t, "%pause %1")
 	waitForWrite(t, conn, resume1)
-	conn.answerCommandError(t)
+	conn.answerCommandError(t, "can't find pane")
 
 	time.Sleep(5 * cc.gapDeadline)
 	if n := cc.gapCount(); n != 0 {
@@ -564,6 +734,226 @@ func TestRefusedResumeWithNoSubscribersStopsRetrying(t *testing.T) {
 	}
 	if n := strings.Count(conn.written(), resume1); n != 1 {
 		t.Fatalf("wrote %d resumes with no subscribers, want exactly 1", n)
+	}
+}
+
+// The three tests below fix the other half of the refusal rule: only a refusal
+// tmux actually sent may re-arm the gap. Every other failure is already on its
+// way to a re-attach, and that sweeps the gaps and re-seeds every subscriber,
+// so a deadline re-armed there resumes nothing and only logs about it.
+
+// TestUnwritableResumeDoesNotReArm covers the failure that never reached tmux:
+// the connection was retired before the write, so RunCommand returns without
+// writing. Nothing is paused as far as tmux is concerned that a retry could fix.
+func TestUnwritableResumeDoesNotReArm(t *testing.T) {
+	logs := captureLogs(t) // process-global: never t.Parallel() this test
+	d := &recordingDialer{}
+	cc := NewControlClient("test")
+	cc.dial = pinnedDial(d)
+	cc.backoff = time.Millisecond
+	// Out of reach, so the gap under test is the one the test opened and
+	// expireGap runs exactly once, by hand.
+	cc.gapDeadline = time.Hour
+
+	sentinel := cc.Subscribe("%9")
+	sub := cc.Subscribe("%1")
+
+	if err := cc.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = cc.Close() }()
+	conn := d.connAt(t, 0)
+	conn.ackAttach(t)
+
+	conn.feedLine(t, "%pause %1")
+	conn.sync(t, sentinel)
+	g := cc.gapFor("%1")
+	if g == nil {
+		t.Fatalf("no gap open after %%pause")
+	}
+
+	_ = conn.pw.Close()
+	waitRetired(t, cc)
+
+	cc.expireGap("%1", g) // returns without parking: RunCommand finds gone nil
+
+	if n := cc.gapCount(); n != 0 {
+		t.Fatalf("%d gaps armed after a resume that was never written, want 0", n)
+	}
+	if strings.Contains(conn.written(), resume1) {
+		t.Fatalf("wrote a resume onto a retired connection: %q", conn.written())
+	}
+	if n := len(sub.C()); n != 0 {
+		t.Fatalf("%d events queued off a failed resume, want 0", n)
+	}
+	assertNoWarn(t, logs, "gap deadline resume abandoned")
+}
+
+// TestResumeLostWithItsConnectionDoesNotReArm covers the other connection-lost
+// shape: the resume was written, tmux may well have acted on it, and only the
+// reply is missing. The re-attach is what recovers the pane either way.
+func TestResumeLostWithItsConnectionDoesNotReArm(t *testing.T) {
+	logs := captureLogs(t) // process-global: never t.Parallel() this test
+	d := &recordingDialer{}
+	cc := NewControlClient("test")
+	cc.dial = pinnedDial(d)
+	cc.backoff = time.Millisecond
+	cc.gapDeadline = time.Hour
+
+	sentinel := cc.Subscribe("%9")
+	sub := cc.Subscribe("%1")
+
+	if err := cc.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = cc.Close() }()
+	conn := d.connAt(t, 0)
+	conn.ackAttach(t)
+
+	conn.feedLine(t, "%pause %1")
+	conn.sync(t, sentinel)
+	g := cc.gapFor("%1")
+	if g == nil {
+		t.Fatalf("no gap open after %%pause")
+	}
+
+	// On its own goroutine, and the channel is the barrier: expireGap parks in
+	// RunCommand until the connection dies and re-arms only after it returns.
+	// Asserting any earlier reads the window where the gap is legitimately
+	// deleted, and passes with the re-arm still in place.
+	returned := make(chan struct{})
+	go func() { defer close(returned); cc.expireGap("%1", g) }()
+
+	waitForWrite(t, conn, resume1) // on the wire, unanswered
+	_ = conn.pw.Close()
+
+	select {
+	case <-returned:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expireGap stayed parked after its connection died")
+	}
+
+	if n := cc.gapCount(); n != 0 {
+		t.Fatalf("%d gaps armed after the resume's connection died, want 0", n)
+	}
+	if n := len(sub.C()); n != 0 {
+		t.Fatalf("%d events queued off a failed resume, want 0", n)
+	}
+	assertNoWarn(t, logs, "gap deadline resume abandoned")
+}
+
+// TestDesynchronisedResumeDoesNotReArm covers the queue refusing the write.
+// cmdDesync is set directly because every way of provoking it for real — a
+// mismatched terminator, a failed stdin write — also tears the connection down,
+// which lands expireGap on the connection-lost path the tests above already
+// cover. The window being modelled is real: desync() sets the flag, then
+// dropConnection starts a teardown supervise has not observed yet, so gone is
+// still live and the write is refused by the queue rather than by the transport.
+func TestDesynchronisedResumeDoesNotReArm(t *testing.T) {
+	d := &recordingDialer{}
+	cc := NewControlClient("test")
+	cc.dial = pinnedDial(d)
+	cc.backoff = time.Millisecond
+	cc.gapDeadline = time.Hour
+
+	sentinel := cc.Subscribe("%9")
+	sub := cc.Subscribe("%1")
+
+	if err := cc.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = cc.Close() }()
+	conn := d.connAt(t, 0)
+	conn.ackAttach(t)
+
+	conn.feedLine(t, "%pause %1")
+	conn.sync(t, sentinel)
+	g := cc.gapFor("%1")
+	if g == nil {
+		t.Fatalf("no gap open after %%pause")
+	}
+
+	cc.cmdQMu.Lock()
+	cc.cmdDesync = true
+	cc.cmdQMu.Unlock()
+
+	cc.expireGap("%1", g) // returns without parking: the queue refuses the write
+
+	if n := cc.gapCount(); n != 0 {
+		t.Fatalf("%d gaps armed after a resume the queue refused, want 0", n)
+	}
+	if strings.Contains(conn.written(), resume1) {
+		t.Fatalf("a desynchronised queue still let a resume onto the wire: %q", conn.written())
+	}
+	if n := len(sub.C()); n != 0 {
+		t.Fatalf("%d events queued off a failed resume, want 0", n)
+	}
+}
+
+// TestStaleDeadlineDoesNotClaimANewerGap covers expireGap's pointer-identity
+// check. A deadline whose Stop lost the race wakes up holding the gap it armed;
+// without the check it resumes a pane a newer handshake legitimately paused,
+// deletes the newer record so nothing bounds it any more, and marks every
+// subscriber — a re-seed storm off a gap that was never its own.
+//
+// Losing a Stop race is not something a test can arrange on a real clock, so
+// the two gaps are driven by %pause/%continue and the stale deadline is fired
+// by hand.
+func TestStaleDeadlineDoesNotClaimANewerGap(t *testing.T) {
+	d := &recordingDialer{}
+	cc := NewControlClient("test")
+	cc.dial = pinnedDial(d)
+	cc.backoff = time.Millisecond
+	cc.gapDeadline = time.Hour
+
+	sentinel := cc.Subscribe("%9")
+	sub := cc.Subscribe("%1")
+
+	if err := cc.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = cc.Close() }()
+	conn := d.connAt(t, 0)
+	conn.ackAttach(t)
+
+	conn.feedLine(t, "%pause %1")
+	conn.sync(t, sentinel)
+	stale := cc.gapFor("%1")
+	if stale == nil {
+		t.Fatalf("no gap open after the first %%pause")
+	}
+
+	conn.feedLine(t, "%continue %1")
+	conn.sync(t, sentinel)
+	expectDirty(t, sub, "subscriber at the first %continue")
+	cc.AckReseed(sub)
+
+	conn.feedLine(t, "%pause %1")
+	conn.sync(t, sentinel)
+	newer := cc.gapFor("%1")
+	if newer == nil || newer == stale {
+		t.Fatalf("the second %%pause opened no fresh gap: %p", newer)
+	}
+
+	// With the identity check this returns at once. Without it the stale
+	// deadline writes a resume nothing will ever answer and parks inside
+	// RunCommand, which is the first thing the failure looks like.
+	returned := make(chan struct{})
+	go func() { defer close(returned); cc.expireGap("%1", stale) }()
+	select {
+	case <-returned:
+	case <-time.After(2 * time.Second):
+		t.Fatal("a stale deadline resumed a pane whose gap it never armed")
+	}
+
+	if g := cc.gapFor("%1"); g != newer {
+		t.Fatalf("stale deadline dropped the newer gap: have %p, want %p", g, newer)
+	}
+	if strings.Contains(conn.written(), resume1) {
+		t.Fatalf("stale deadline wrote a resume: %q", conn.written())
+	}
+	if n := len(sub.C()); n != 0 {
+		t.Fatalf("%d events queued by a stale deadline, want 0", n)
 	}
 }
 
@@ -607,6 +997,7 @@ func TestReadLoopKeepsDispatchingWhileResumeOutstanding(t *testing.T) {
 	}
 	defer func() { _ = cc.Close() }()
 	conn := d.connAt(t, 0)
+	conn.ackAttach(t)
 
 	conn.feedLine(t, "%pause %1")
 	waitForWrite(t, conn, resume1)
@@ -622,6 +1013,497 @@ func TestReadLoopKeepsDispatchingWhileResumeOutstanding(t *testing.T) {
 	}
 
 	conn.answerCommand(t)
+}
+
+// TestReplyGoesToTheCommandThatAskedForIt pins which command a block answers.
+// tmux answers every write with a block of its own, waited on or not, so a
+// caller that takes the next block to arrive takes whatever the last unwaited
+// writer provoked — and a resume that tmux refused reads back as a success.
+func TestReplyGoesToTheCommandThatAskedForIt(t *testing.T) {
+	d := &recordingDialer{}
+	cc := NewControlClient("test")
+	cc.dial = d.dial
+	cc.backoff = time.Millisecond
+
+	sentinel := cc.Subscribe("%9")
+
+	if err := cc.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = cc.Close() }()
+	conn := d.connAt(t, 0)
+	conn.ackAttach(t)
+
+	if err := cc.SendSpecialKey("%1", "C-c"); err != nil {
+		t.Fatalf("SendSpecialKey: %v", err)
+	}
+	waitForWrite(t, conn, "send-keys -t %1 C-c")
+
+	const command = "display-message -p mine"
+	type result struct {
+		out string
+		err error
+	}
+	got := make(chan result, 1)
+	go func() {
+		out, err := cc.RunCommand(command)
+		got <- result{out: out, err: err}
+	}()
+	waitForWrite(t, conn, command)
+
+	// The send-keys above is on nobody's hook, but tmux still answers it.
+	conn.answerCommand(t, "theirs")
+	conn.sync(t, sentinel)
+
+	select {
+	case r := <-got:
+		t.Fatalf("RunCommand returned (%q, %v) off another writer's block", r.out, r.err)
+	default:
+	}
+
+	conn.answerCommand(t, "mine")
+
+	select {
+	case r := <-got:
+		if r.err != nil {
+			t.Fatalf("RunCommand: %v", r.err)
+		}
+		if r.out != "mine" {
+			t.Fatalf("RunCommand = %q, want %q", r.out, "mine")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("RunCommand never got the block its own write provoked")
+	}
+}
+
+// TestOrphanBaselineTerminatorKeepsTheQueueAligned covers a stream introduced
+// by something ParseControlLine does not strip, so the baseline's %begin parses
+// as data and only its terminator arrives. Nothing was bound, so the right
+// answer is to drop the orphan; treating it as a desync instead failed every
+// command and re-dialled forever.
+func TestOrphanBaselineTerminatorKeepsTheQueueAligned(t *testing.T) {
+	d := &recordingDialer{baseline: "\x1bP1001p%begin 1700000000 1 0\r\n%end 1700000000 1 0\r\n"}
+	cc := NewControlClient("test")
+	cc.dial = d.dial
+	cc.backoff = time.Millisecond
+
+	sentinel := cc.Subscribe("%9")
+
+	if err := cc.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = cc.Close() }()
+	conn := d.connAt(t, 0)
+	conn.ackAttach(t)
+
+	const command = "display-message -p mine"
+	got := make(chan commandResponse, 1)
+	go func() {
+		out, err := cc.RunCommand(command)
+		got <- commandResponse{output: out, err: err}
+	}()
+	waitForWrite(t, conn, command)
+	conn.answerCommand(t, "mine")
+
+	select {
+	case r := <-got:
+		if r.err != nil {
+			t.Fatalf("RunCommand: %v", r.err)
+		}
+		if r.output != "mine" {
+			t.Fatalf("RunCommand = %q, want %q", r.output, "mine")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("RunCommand never got the block its own write provoked")
+	}
+
+	conn.sync(t, sentinel)
+	d.mu.Lock()
+	dials := len(d.conns)
+	d.mu.Unlock()
+	if dials != 1 {
+		t.Fatalf("dialled %d times; the orphan terminator dropped the connection", dials)
+	}
+}
+
+// TestFirstBlockOfAConnectionBindsToNoCommand proves a fresh connection owes
+// three blocks and that the first of them answers nobody: tmux replies to the
+// dialer's own attach-session before houston has written a byte. Every block
+// carries a body naming the command it belongs to, because bodiless %ends are
+// interchangeable — with empty bodies an off-by-one delivers the wrong block and
+// still reads as a pass.
+func TestFirstBlockOfAConnectionBindsToNoCommand(t *testing.T) {
+	d := &recordingDialer{baseline: "\x1bP1000p%begin 1700000000 1 0\r\nbaseline\r\n%end 1700000000 1 0\r\n"}
+	cc := NewControlClient("test")
+	cc.dial = d.dial
+	cc.backoff = time.Millisecond
+
+	if err := cc.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = cc.Close() }()
+
+	conn := d.connAt(t, 0)
+	waitForWrite(t, conn, ignoreSizeCmd)
+
+	// Enrolled while ignore-size is still outstanding, so all three blocks are
+	// owed at once. Answering ignore-size first would empty the queue ahead of
+	// this write, and then a baseline that wrongly claimed an entry would
+	// still leave every later block on the right one.
+	const command = "display-message -p mine"
+	got := make(chan commandResponse, 1)
+	go func() {
+		out, err := cc.RunCommand(command)
+		got <- commandResponse{output: out, err: err}
+	}()
+	waitForWrite(t, conn, command)
+
+	conn.answerCommand(t, "ignore-size")
+	conn.answerCommand(t, "mine")
+
+	select {
+	case r := <-got:
+		if r.err != nil {
+			t.Fatalf("RunCommand: %v", r.err)
+		}
+		if r.output != "mine" {
+			t.Fatalf("RunCommand = %q, want %q — the connection's unowed first block was bound to a command", r.output, "mine")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("RunCommand never got the block its own write provoked")
+	}
+}
+
+// TestSecondConnectionAlsoDropsItsBaselineBlock runs the same three-block drive
+// against connection 1. It is the only test that fails when the baseline marker
+// is a ControlClient field rather than a readLoop local — a per-client marker is
+// already set by connection 0, so every connection after the first stays one
+// block out of step while every other test in this file still passes. Connection
+// 0 is dropped holding two unanswered enrollments, so this also proves the new
+// connection's queue starts empty instead of inheriting them.
+func TestSecondConnectionAlsoDropsItsBaselineBlock(t *testing.T) {
+	d := &recordingDialer{baseline: "\x1bP1000p%begin 1700000000 1 0\r\nbaseline\r\n%end 1700000000 1 0\r\n"}
+	cc := NewControlClient("test")
+	cc.dial = d.dial
+	cc.backoff = time.Millisecond
+
+	if err := cc.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = cc.Close() }()
+
+	first := d.connAt(t, 0)
+	waitForWrite(t, first, ignoreSizeCmd)
+	if err := cc.SendSpecialKey("%1", "C-c"); err != nil {
+		t.Fatalf("SendSpecialKey: %v", err)
+	}
+	waitForWrite(t, first, "send-keys -t %1 C-c")
+	_ = first.pw.Close() // neither block answered; supervise re-dials
+
+	conn := d.connAt(t, 1)
+	waitForWrite(t, conn, ignoreSizeCmd)
+
+	// Enrolled while ignore-size is still outstanding, so the queue holds two
+	// entries when the blocks arrive. Answering ignore-size first would empty
+	// the queue ahead of this write and let an off-by-one pass.
+	const command = "display-message -p mine"
+	got := make(chan commandResponse, 1)
+	go func() {
+		out, err := cc.RunCommand(command)
+		got <- commandResponse{output: out, err: err}
+	}()
+	waitForWrite(t, conn, command)
+
+	conn.answerCommand(t, "ignore-size")
+	conn.answerCommand(t, "mine")
+
+	select {
+	case r := <-got:
+		if r.err != nil {
+			t.Fatalf("RunCommand: %v", r.err)
+		}
+		if r.output != "mine" {
+			t.Fatalf("RunCommand = %q, want %q — connection 1 bound its baseline block to a command", r.output, "mine")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("RunCommand never got its own block — connection 1 carried connection 0's queue over")
+	}
+}
+
+// TestMismatchedTerminatorReleasesTheWaiter feeds a block whose %end disagrees
+// with its %begin, which makes the queue head's owner unknowable. The waiter
+// must come back with an error rather than stay parked: parked here is
+// expireGap's timer goroutine never returning, so the gap is never re-armed and
+// never marked, and the pane stays dark — the failure this whole change exists
+// to prevent. The connection has to go too, since a desynchronised stream is
+// terminal until a re-attach resets the queue.
+func TestMismatchedTerminatorReleasesTheWaiter(t *testing.T) {
+	d := &recordingDialer{}
+	cc := NewControlClient("test")
+	cc.dial = d.dial
+	cc.backoff = time.Millisecond
+
+	if err := cc.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = cc.Close() }()
+
+	conn := d.connAt(t, 0)
+	conn.ackAttach(t)
+
+	const command = "display-message -p mine"
+	got := make(chan commandResponse, 1)
+	go func() {
+		out, err := cc.RunCommand(command)
+		got <- commandResponse{output: out, err: err}
+	}()
+	waitForWrite(t, conn, command)
+
+	num := conn.nextBlock()
+	conn.feedLine(t, fmt.Sprintf("%%begin 1700000000 %d 0", num))
+	conn.feedLine(t, "mine")
+	conn.feedLine(t, fmt.Sprintf("%%end 1700000000 %d 0", num+1))
+
+	select {
+	case r := <-got:
+		if r.err == nil {
+			t.Fatalf("RunCommand returned (%q, nil) off a block whose terminator did not match its %%begin", r.output)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("RunCommand stayed parked on a mismatched block")
+	}
+
+	d.connAt(t, 1) // the desynchronised connection must be torn down and re-dialled
+}
+
+// TestDesyncRecoversOnTheNextConnection follows that teardown through to the
+// end: a desynchronised stream is terminal until a re-attach resets the queue,
+// so the subscribers must re-seed and the fresh connection must accept commands
+// again.
+//
+// The desync is driven through a plain command rather than a paused pane on
+// purpose. A paused pane would put expireGap's re-arm in a race with
+// markAllDirty's sweep and whichever won would decide the assertion, so do not
+// "restore" that variant.
+func TestDesyncRecoversOnTheNextConnection(t *testing.T) {
+	d := &recordingDialer{}
+	cc := NewControlClient("test")
+	cc.dial = d.dial
+	cc.backoff = time.Millisecond
+
+	sub := cc.Subscribe("%1")
+
+	if err := cc.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = cc.Close() }()
+
+	first := d.connAt(t, 0)
+	first.ackAttach(t)
+
+	const command = "display-message -p mine"
+	got := make(chan commandResponse, 1)
+	go func() {
+		out, err := cc.RunCommand(command)
+		got <- commandResponse{output: out, err: err}
+	}()
+	waitForWrite(t, first, command)
+
+	num := first.nextBlock()
+	first.feedLine(t, fmt.Sprintf("%%begin 1700000000 %d 0", num))
+	first.feedLine(t, fmt.Sprintf("%%end 1700000000 %d 0", num+1))
+
+	// Only that it failed: desync() answers the waiter and then drops the
+	// connection, so whether this reads errCmdDesync or errConnLost is a real
+	// race between the reply and the close of gone.
+	select {
+	case r := <-got:
+		if r.err == nil {
+			t.Fatalf("RunCommand returned (%q, nil) off a desynchronised connection", r.output)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("RunCommand stayed parked on a desynchronised connection")
+	}
+
+	expectDirty(t, sub, "subscriber after the desynchronised connection was replaced")
+
+	second := d.connAt(t, 1)
+	second.ackAttach(t)
+
+	go func() {
+		out, err := cc.RunCommand(command)
+		got <- commandResponse{output: out, err: err}
+	}()
+	waitForWrite(t, second, command)
+	second.answerCommand(t, "mine")
+
+	select {
+	case r := <-got:
+		if r.err != nil || r.output != "mine" {
+			t.Fatalf("RunCommand on the fresh connection = (%q, %v), want (%q, nil)", r.output, r.err, "mine")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("the fresh connection never answered a command")
+	}
+}
+
+// TestFailedWriteLeavesNoPhantomEnrollment covers the entry writeCommandLocked
+// deliberately leaves in the queue when the write fails: a short write may have
+// delivered half a command line, so the queue can no longer be reasoned about
+// and every later command must fail instead of being answered from a block it
+// did not provoke.
+//
+// The re-dial is suppressed on purpose. Left alone, the teardown installs a
+// fresh connection with an empty queue, the second command writes to it and
+// parks in RunCommand — which has no timeout — so the test would hang the whole
+// run instead of failing. TestMismatchedTerminatorReleasesTheWaiter wants that
+// re-dial; this one must not have it.
+func TestFailedWriteLeavesNoPhantomEnrollment(t *testing.T) {
+	d := &recordingDialer{}
+	cc := NewControlClient("test")
+	cc.backoff = time.Millisecond
+	first := true
+	cc.dial = func() (io.ReadCloser, io.Writer, func() error, error) {
+		if !first {
+			return nil, nil, nil, errors.New("no reconnect in this test")
+		}
+		first = false // Start()'s own call; every later one runs in supervise's goroutine, so the two never race
+		return d.dial()
+	}
+
+	if err := cc.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = cc.Close() }()
+
+	conn := d.connAt(t, 0)
+	conn.ackAttach(t)
+
+	conn.mu.Lock()
+	conn.writeErr = errors.New("stdin is gone")
+	conn.mu.Unlock()
+
+	if err := cc.SendSpecialKey("%1", "C-c"); err == nil {
+		t.Fatal("SendSpecialKey reported success against a failing stdin")
+	}
+
+	// The entry is only harmless because the queue now reports itself
+	// unreasonable: the next writer is turned away before it can append an entry
+	// the phantom would answer ahead of. A raw stdin error here instead of
+	// errCmdDesync means nothing recorded the failure and the queue is still
+	// being treated as aligned.
+	if err := cc.SendSpecialKey("%1", "C-c"); !errors.Is(err, errCmdDesync) {
+		t.Fatalf("second send after a failed write = %v, want %v", err, errCmdDesync)
+	}
+
+	if out, err := cc.RunCommand("display-message -p mine"); err == nil {
+		t.Fatalf("RunCommand returned (%q, nil) after a failed write left the queue unreasonable", out)
+	}
+}
+
+// TestConcurrentWriterNeverStealsAReply is the reviewer's own reproduction,
+// scaled down: an unwaited writer racing a stream of RunCommand calls, each
+// asserting it got its own body back. cmdMu does not serialize the unwaited
+// writer, so before the queue existed a RunCommand holding cmdMu could be
+// handed a send-keys' block.
+//
+// The answerer owes a block to every line the client wrote, ignore-size
+// included, because replies are bound by order and a skipped line stalls every
+// reply behind it. It tracks a cursor into the buffer rather than diffing
+// written(), and it reports failures over a channel: t.Fatalf from a non-test
+// goroutine does not stop the test.
+func TestConcurrentWriterNeverStealsAReply(t *testing.T) {
+	d := &recordingDialer{}
+	cc := NewControlClient("test")
+	cc.dial = d.dial
+	cc.backoff = time.Millisecond
+
+	if err := cc.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = cc.Close() }()
+	conn := d.connAt(t, 0)
+
+	stop := make(chan struct{})
+	fail := make(chan string, 1)
+	answererDone := make(chan struct{})
+	writerDone := make(chan struct{})
+
+	go func() {
+		defer close(answererDone)
+		cursor := 0
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			buf := conn.written()
+			nl := strings.IndexByte(buf[cursor:], '\n')
+			if nl < 0 {
+				time.Sleep(100 * time.Microsecond)
+				continue
+			}
+			line := buf[cursor : cursor+nl]
+			cursor += nl + 1
+
+			// Only a display-message is waited on, so only it needs a body the
+			// caller can recognise; the rest just need their block.
+			body, _ := strings.CutPrefix(line, "display-message -p ")
+			num := conn.nextBlock()
+			block := fmt.Sprintf("%%begin 1700000000 %d 0\n", num)
+			if body != line {
+				block += body + "\n"
+			}
+			block += fmt.Sprintf("%%end 1700000000 %d 0\n", num)
+			if _, err := io.WriteString(conn.pw, block); err != nil {
+				select {
+				case fail <- fmt.Sprintf("answering %q: %v", line, err):
+				default:
+				}
+				return
+			}
+		}
+	}()
+
+	go func() {
+		defer close(writerDone)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			if err := cc.SendSpecialKey("%1", "C-c"); err != nil {
+				select {
+				case fail <- fmt.Sprintf("SendSpecialKey: %v", err):
+				default:
+				}
+				return
+			}
+			time.Sleep(100 * time.Microsecond)
+		}
+	}()
+
+	for i := range 200 {
+		want := fmt.Sprintf("r%d", i)
+		out, err := cc.RunCommand("display-message -p " + want)
+		if err != nil {
+			t.Fatalf("RunCommand %d: %v", i, err)
+		}
+		if out != want {
+			t.Fatalf("RunCommand %d = %q, want %q — a concurrent writer's block was delivered to it", i, out, want)
+		}
+	}
+
+	close(stop)
+	<-writerDone
+	<-answererDone
+	select {
+	case msg := <-fail:
+		t.Fatal(msg)
+	default:
+	}
 }
 
 // TestIgnoreSizeIsFirstWriteOnEveryAttach characterizes a rule the CC client
@@ -652,6 +1534,39 @@ func assertIgnoreSizeFirst(t *testing.T, c *recordedConn) {
 	if got := c.written(); !strings.HasPrefix(got, want) {
 		t.Fatalf("first write on the connection = %q, want %q first", got, want)
 	}
+}
+
+// TestAttachWriteFailureTearsDownItsOwnConnection pins why attach installs
+// closeCur, connOK and gone before its own ignore-size write. That write can
+// fail, and the teardown behind it must close the connection being installed;
+// reached through the previous connection's closeCur it would close a spent
+// sync.Once — nil on the very first attach — and leave this connection
+// installed, connOK true, and nothing ever re-dialling.
+//
+// What tells the two apart is a second connection appearing at all, with
+// ignore-size written on it — though on the very first attach the wrong order
+// does not get that far: closeCur is still nil and the teardown panics on it.
+func TestAttachWriteFailureTearsDownItsOwnConnection(t *testing.T) {
+	d := &recordingDialer{
+		onDial: func(i int, c *recordedConn) {
+			if i == 0 { // connection 0 only: arming every connection hot-loops the dialer
+				c.writeErr = errors.New("stdin is gone")
+			}
+		},
+	}
+	cc := NewControlClient("test")
+	cc.dial = d.dial
+	cc.backoff = time.Millisecond
+
+	if err := cc.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = cc.Close() }()
+
+	if got := d.connAt(t, 0).written(); got != "" {
+		t.Fatalf("the failing connection recorded %q, want nothing", got)
+	}
+	assertIgnoreSizeFirst(t, d.connAt(t, 1))
 }
 
 func TestReconnectMarksSubscribersDirty(t *testing.T) {
@@ -725,6 +1640,99 @@ func TestReattachClearsGapState(t *testing.T) {
 
 	if len(sub.C()) != 0 {
 		t.Fatal("continue on the new connection re-seeded a subscriber left over from the dropped connection's gap")
+	}
+}
+
+// TestClearGapsDisarmsEveryDeadline is necessarily white-box, because
+// clearGapsLocked's timer.Stop() loop has no behavioural witness and
+// structurally cannot have one: once the map entry is deleted, a surviving
+// timer's *gap can never again equal cc.gaps[paneID] — a later gap on the pane
+// is a fresh allocation — so it loses expireGap's identity check and does
+// nothing observable. Removing the loop costs one leaked timer per swept pane
+// for up to gapDeadline, and that is all this test can speak to.
+//
+// The hour deadline is a precondition, not a style choice: Stop() also reports
+// false for a timer that has already fired, so a short deadline would let a
+// real firing satisfy the assertion.
+func TestClearGapsDisarmsEveryDeadline(t *testing.T) {
+	cc := NewControlClient("test")
+	cc.gapDeadline = time.Hour
+
+	cc.openGap("%1")
+	cc.openGap("%2")
+
+	gaps := []*gap{cc.gapFor("%1"), cc.gapFor("%2")}
+	for i, g := range gaps {
+		if g == nil {
+			t.Fatalf("gap %d never opened", i)
+		}
+	}
+
+	cc.clearGaps()
+
+	if n := cc.gapCount(); n != 0 {
+		t.Fatalf("%d gaps survived clearGaps, want 0", n)
+	}
+	for i, g := range gaps {
+		if g.timer.Stop() {
+			t.Fatalf("gap %d's deadline was still armed after clearGaps", i)
+		}
+	}
+}
+
+// TestReconnectDisarmsAnOpenGapsDeadline is the behavioural tripwire for the
+// two guards in the gap lifecycle, and measurement says it witnesses only their
+// conjunction: removing either one alone leaves it green. Without the Stop()
+// loop the timer does fire, but it loses expireGap's identity check and writes
+// nothing; without the identity check the timer was stopped and never fires at
+// all. Remove both and a deadline the re-attach dropped resumes the pane on the
+// fresh connection, which is what this catches. Neither guard is covered
+// individually here — TestClearGapsDisarmsEveryDeadline and
+// TestStaleDeadlineDoesNotClaimANewerGap are. What it adds over
+// TestReattachClearsGapState is the timer path: that one proves only that a
+// %continue on the new connection re-seeds nobody.
+//
+// The deadline has to be short enough to fire inside the test, or the assertion
+// is about a timer that was never going to do anything.
+func TestReconnectDisarmsAnOpenGapsDeadline(t *testing.T) {
+	d := &recordingDialer{}
+	cc := NewControlClient("test")
+	cc.dial = d.dial // the re-dial is the point here; no pin
+	cc.backoff = time.Millisecond
+	cc.gapDeadline = 150 * time.Millisecond
+
+	sentinel := cc.Subscribe("%9")
+	sub := cc.Subscribe("%1")
+
+	if err := cc.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = cc.Close() }()
+
+	first := d.connAt(t, 0)
+	first.ackAttach(t)
+
+	first.feedLine(t, "%pause %1")
+	first.sync(t, sentinel)
+	if cc.gapFor("%1") == nil {
+		t.Fatalf("no gap open after %%pause")
+	}
+
+	_ = first.pw.Close() // dropped well inside the deadline
+	expectDirty(t, sub, "subscriber after re-attach")
+
+	second := d.connAt(t, 1)
+	second.ackAttach(t)
+
+	time.Sleep(3 * cc.gapDeadline)
+	if n := cc.gapCount(); n != 0 {
+		t.Fatalf("%d gaps survived the re-attach, want 0", n)
+	}
+	if strings.Contains(second.written(), resume1) {
+		t.Fatalf("a gap the re-attach dropped still resumed its pane: %q", second.written())
+	}
+	if strings.Contains(first.written(), resume1) {
+		t.Fatalf("resume written onto the dead connection: %q", first.written())
 	}
 }
 

--- a/tmux/control_integration_test.go
+++ b/tmux/control_integration_test.go
@@ -1,6 +1,7 @@
 package tmux
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -60,6 +61,147 @@ func TestControlClientIntegration(t *testing.T) {
 			}
 		case <-timer.C:
 			t.Fatalf("timeout waiting for output, received so far: %q", received)
+		}
+	}
+}
+
+// drainPane discards anything already queued on a subscriber without
+// blocking, so a later assertion isn't tripped by output left over from an
+// earlier step.
+func drainPane(sub *PaneSub) {
+	for {
+		select {
+		case <-sub.C():
+		default:
+			return
+		}
+	}
+}
+
+// TestGapDeadlineResumeActuallyResumesThePane proves the gap deadline's
+// resume command actually unpauses the pane, not just that it parses. tmux's
+// command lexer rejects a bare %-prefixed token containing ':', which is why
+// refresh-client -A %0:continue used to come back %error while looking
+// like a no-op in anything that only checks for success.
+func TestGapDeadlineResumeActuallyResumesThePane(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	client := NewClient()
+	session := "houston-test-gapresume-" + strconv.Itoa(os.Getpid())
+	err := client.run("new-session", "-d", "-s", session, "-x", "80", "-y", "24")
+	if err != nil {
+		t.Fatalf("failed to create test session: %v", err)
+	}
+	defer func() { _ = client.run("kill-session", "-t", session) }()
+
+	out, err := client.output("display-message", "-t", session, "-p", "#{pane_id}")
+	if err != nil {
+		t.Fatalf("failed to get pane ID: %v", err)
+	}
+	paneID := strings.TrimSpace(string(out))
+
+	cc := NewControlClient(session)
+	// Out of reach, and expireGap driven by hand below — the same
+	// construction TestGapDeadlineResumesAndMarksEverySubscriber uses to keep
+	// the paused arm untimed instead of racing a clock. The timer path itself
+	// is already covered by the fake-dialer tests.
+	cc.gapDeadline = time.Hour
+	if err := cc.Start(); err != nil {
+		t.Fatalf("failed to start control client: %v", err)
+	}
+	defer func() { _ = cc.Close() }()
+
+	sub := cc.Subscribe(paneID)
+	defer cc.Unsubscribe(paneID, sub)
+
+	if _, err := cc.RunCommand(fmt.Sprintf("refresh-client -A '%s:pause'", paneID)); err != nil {
+		t.Fatalf("pause command failed: %v", err)
+	}
+
+	var g *gap
+	for deadline := time.Now().Add(5 * time.Second); g == nil && time.Now().Before(deadline); {
+		g = cc.gapFor(paneID)
+		if g == nil {
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+	if g == nil {
+		t.Fatalf("no gap open after pausing %s", paneID)
+	}
+
+	drainPane(sub)
+
+	// The paused arm below reads a silence, and a dirty subscriber is silent
+	// for an unrelated reason — dispatch withholds everything until it acks.
+	// %pause deliberately marks nobody, so this must hold here; without the
+	// check the arm could pass while proving nothing about the pane.
+	if cc.isDirty(sub) {
+		t.Fatal("subscriber is dirty before the paused arm, so its silence would prove nothing")
+	}
+
+	pid := strconv.Itoa(os.Getpid())
+	pausedMarker := "houston-paused-marker-" + pid
+	if err := cc.SendKeys(paneID, "echo "+pausedMarker); err != nil {
+		t.Fatalf("SendKeys failed: %v", err)
+	}
+	if err := cc.SendSpecialKey(paneID, "Enter"); err != nil {
+		t.Fatalf("SendSpecialKey Enter failed: %v", err)
+	}
+
+	var receivedWhilePaused string
+	idle := time.NewTimer(2 * time.Second)
+	defer idle.Stop()
+paused:
+	for {
+		select {
+		case ev := <-sub.C():
+			receivedWhilePaused += string(ev.Data)
+			if strings.Contains(receivedWhilePaused, pausedMarker) {
+				t.Fatalf("marker reached the subscriber while the pane was paused: %q", receivedWhilePaused)
+			}
+		case <-idle.C:
+			break paused
+		}
+	}
+
+	go cc.expireGap(paneID, g)
+
+	dirtyDeadline := time.NewTimer(5 * time.Second)
+	defer dirtyDeadline.Stop()
+	for gotDirty := false; !gotDirty; {
+		select {
+		case ev := <-sub.C():
+			gotDirty = ev.Dirty
+		case <-dirtyDeadline.C:
+			t.Fatalf("timed out waiting for the Dirty event after expireGap")
+		}
+	}
+	// dispatch withholds all data from a dirty subscriber until it acks, so
+	// without this the resumed arm below can't pass even against correct code.
+	cc.AckReseed(sub)
+
+	resumedMarker := "houston-resumed-marker-" + pid
+	if err := cc.SendKeys(paneID, "echo "+resumedMarker); err != nil {
+		t.Fatalf("SendKeys failed: %v", err)
+	}
+	if err := cc.SendSpecialKey(paneID, "Enter"); err != nil {
+		t.Fatalf("SendSpecialKey Enter failed: %v", err)
+	}
+
+	var receivedAfterResume string
+	timer := time.NewTimer(5 * time.Second)
+	defer timer.Stop()
+	for {
+		select {
+		case ev := <-sub.C():
+			receivedAfterResume += string(ev.Data)
+			if strings.Contains(receivedAfterResume, resumedMarker) {
+				return
+			}
+		case <-timer.C:
+			t.Fatalf("resumed output never reached the subscriber, received so far: %q", receivedAfterResume)
 		}
 	}
 }

--- a/tmux/control_test.go
+++ b/tmux/control_test.go
@@ -19,6 +19,11 @@ func TestParseControlLine(t *testing.T) {
 			ControlEvent{Type: EventBegin, CmdNumber: 258},
 		},
 		{
+			"begin block behind the control-mode introducer",
+			"\x1bP1000p%begin 1789033623 812527 0",
+			ControlEvent{Type: EventBegin, CmdNumber: 812527},
+		},
+		{
 			"end block",
 			"%end 1578920019 258 0",
 			ControlEvent{Type: EventEnd, CmdNumber: 258},
@@ -62,6 +67,36 @@ func TestParseControlLine(t *testing.T) {
 			"unknown line",
 			"some random output",
 			ControlEvent{Type: EventData, Data: "some random output"},
+		},
+		{
+			"pause with trailing field",
+			"%pause %0 junk",
+			ControlEvent{Type: EventPause, PaneID: "%0"},
+		},
+		{
+			"pause with a quoted pane id is not a notification",
+			"%pause %0';kill-server;'x",
+			ControlEvent{Type: EventData, Data: "%pause %0';kill-server;'x"},
+		},
+		{
+			"continue with an embedded command is not a notification",
+			"%continue %0;kill-server",
+			ControlEvent{Type: EventData, Data: "%continue %0;kill-server"},
+		},
+		{
+			"pause multi-digit pane id",
+			"%pause %12",
+			ControlEvent{Type: EventPause, PaneID: "%12"},
+		},
+		{
+			"pause with a non-numeric pane id is not a notification",
+			"%pause abc",
+			ControlEvent{Type: EventData, Data: "%pause abc"},
+		},
+		{
+			"continue",
+			"%continue %3",
+			ControlEvent{Type: EventContinue, PaneID: "%3"},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
**main today cannot resume a paused pane, and can hand a command's reply to a different caller.** #36 was merged before the review that found those two blockers landed, so both are live on `main` right now. This PR fixes them.

Concretely, on `main` as it stands:

- `expireGap`'s `refresh-client -A %N:continue` is a **parse error** on every invocation — tmux's lexer rejects a bare token starting with `%` that contains `:`. So no gap deadline has ever resumed a pane, and the retry's only exit condition cannot fire.
- `RunCommand` returns whatever lands in a shared channel while `readLoop` discards the command number, so a block produced by one of four unwaited stdin writers can satisfy a different caller. Measured: **15169 of 187405 calls misattributed.**

Chained, they are a corruption path: a stolen `%end` turns a guaranteed `%error` into a believed success, the re-seed fires against a still-paused pane, and nothing retries.

Review that found them: https://github.com/noamsto/houston/pull/36#pullrequestreview-5164784664
Original change: #36. Issue: #34.

## The bug #36 set out to fix

`%pause` marked every subscriber of a pane dirty immediately, so `server/pane_ws.go` ran `capture-pane` at the **start** of the output gap. tmux discards everything a paused pane paints and, on resume, restarts from the pane's current offset — the backlog is dropped, never replayed. So the snapshot predated the discarded output, and the terminal then painted new bytes onto a screen with a hole in it.

A second half: nothing resumed a pause houston did not issue. A pane tmux paused on its own had no owner and would stay paused forever.

## What #36 built, and is already on main

`%pause` opens a **gap**; `%continue` closes it and marks dirty only the subscribers attached when it opened. A subscriber that arrives mid-gap is skipped — that is what keeps the seed handshake, which pauses the pane *before* it subscribes, from earning a spurious re-seed after every deliberate seed. It supersedes Task 3 of `2026-09-07-control-mode-transport-correctness.md`, whose "mark on `%pause` only" rule this replaces.

A gap is bounded by a **10-second deadline**. On expiry houston sends one `refresh-client -A '%N:continue'` and *then* marks — that order is the point of the change, since marking first captures while tmux is still discarding and rebuilds the original bug on the path meant to cure it. The resume runs off `readLoop`, which cannot block on a `RunCommand` only it can answer.

Gap state is swept on reconnect and on `Close()`, and a closed client opens no new gap. `refresh-client -f ignore-size` stays the first write on every attach.

`docs/superpowers/plans/2026-09-10-pause-gap-reseed.md` records the design.

## What this PR changes

#36 shipped a resume that could never work and leaned on a guarantee that did not exist. Everything below is measured, not argued.

### 1. The resume command never parses

tmux's command-string lexer rejects a bare token that starts with `%` and contains `:`. Measured against tmux 3.6a in control mode, each row against a pane whose pause state made the outcome meaningful — `%pause`/`%continue` are edge-triggered, so a resume aimed at a running pane emits nothing and looks exactly like a no-op:

| command | result |
|---|---|
| `refresh-client -A '%0:pause'` | `%pause %0`, `%end` |
| `refresh-client -A '%0:continue'` | `%continue %0`, `%end` |
| `refresh-client -A "%0:continue"` | `%continue %0`, `%end` |
| `refresh-client -A %0:pause` | `parse error: syntax error`, `%error` |
| `refresh-client -A %0:continue` | `parse error: syntax error`, `%error` |
| `refresh-client -A %0` | `%end`, **no** `%continue` |
| `refresh-client -A x%0:continue` | `%end`, **no** `%continue` |

Three outcome classes, not two: parses **and** resumes, parses and does **not** resume, and does not parse. So every deadline resume errored, the failure branch always ran, and the retry's stated exit condition — a successful resume — could never fire. The command is now single-quoted.

The last two rows are why a test that only checks for a successful `%end` proves nothing, and they shaped how this is verified. `TestGapDeadlineResumeActuallyResumesThePane` drives a **real tmux**: it pauses a pane, proves a marker echoed while paused never reaches the subscriber, fires the resume, and proves a second marker does. Reverting the quoting reddens it against real tmux with tmux's own words:

```
WARN gap deadline resume failed ... error="tmux refused the command: parse error: syntax error"
    control_integration_test.go:178: timed out waiting for the Dirty event after expireGap
```

The paused arm also asserts the subscriber is **not dirty** before reading that silence. Without it the arm could pass for the wrong reason — `dispatch` withholds everything from a dirty subscriber, so silence alone cannot tell "tmux sent nothing" from "we refused to deliver it". Found by probing the arm with a pause that does not hold, which passed until the precondition was added.

### 2. A reply could belong to a different command

**#36's claim that `cmdMu` made the resume's block impossible to misdeliver was wrong.** `cmdMu` holds only between *pending* callers, and four writers reach stdin without ever taking it — `sendLiteral`, `sendControl`'s hex branch, `SendSpecialKey`, and `attach`'s own `refresh-client -f ignore-size`. tmux answers each with its own block, and the drain `RunCommand` did before its write could not catch a block arriving after it. Measured with a concurrent `SendSpecialKey` writer: **15169 of 187405 calls misattributed, 0 in the control run.** `paneWSReadLoop` runs for the whole socket lifetime, so a user pressing a key at a frozen pane is exactly who triggers it.

Chained with blocker 1 that is the corruption path: a stolen `%end` turns a guaranteed `%error` into a believed success, `markPaneDirty` fires against a still-paused pane, the gap record is already gone, and nothing retries.

**This is a pre-existing flaw in `RunCommand`, not one #36 introduced** — every existing caller could already receive a misattributed reply. It is fixed here because the deadline resume made it load-bearing. The explicit judgment on blast radius: it needs **no separate issue**, because the fix is inside `RunCommand` itself, so every caller gets it and none is left unfixed.

Blocks are now bound by **order**, with the command number as the begin/end consistency check. Order, not a command-number lookup, because the number is assigned server-side from a global counter — a fresh client saw `678835` — so houston can never know in advance what its own write will be assigned. The reviewer's warning against a timeout instead was followed: nothing here abandons a command by time.

- Every write to `cc.stdin` enrols a FIFO entry **inside the same `stdinMu` section that performs the write**, so enrolment order is write order by construction. A waiterless writer enrols a `nil` entry; skipping it would put the connection permanently one block out of step.
- Each `%begin` binds to the oldest entry still awaiting a block; `%end`/`%error` is delivered only when its number matches the open `%begin`'s.
- A failed write, or a mismatched terminator, **desynchronises** the queue: every enrolled waiter is failed and the connection is torn down so `supervise` re-dials. The teardown is not optional — without it a desynchronised but transport-healthy connection is terminal, since `readLoop` keeps reading, nothing re-dials, and every later command fails for the life of the client while the paused pane stays dark. The reconnect is the recovery: `attach` resets the queue and `markAllDirty` re-seeds everyone.

### 3. houston has always misparsed the first line of every connection

Found while building the above, and it is why the first attempt at the above produced a permanent reconnect storm. A real `tmux -CC attach-session` answers **its own attach command** with a block before houston writes anything, and tmux glues the control-mode DCS introducer onto that block's `%begin`. Raw bytes off a pty:

```
FIRST 120 BYTES: b'\x1bP1000p%begin 1789033623 812527 0\r\n%end 1789033623 812527 0\r\n%session-changed $761 ...'
AFTER WRITE:     b'%begin 1789033624 812704 1\r\n%end 1789033624 812704 1\r\n'
```

`ParseControlLine` matched a bare `%begin ` prefix, so that line fell through as unclassified data and houston saw only the block's orphan `%end`. That is where `RunCommand`'s old "drain any stale response from a previous unsolicited `%begin`/`%end`" hack came from: the hack was the symptom. `ParseControlLine` now strips the introducer — a plain parsing fix, independent of the attribution work.

It also corrected a piece of the design's reasoning. An orphan terminator is **not** a desynchronisation: binding happens at `%begin`, so a block whose `%begin` never parsed claimed no queue entry and the alignment is intact. Only a *mismatched* terminator is unknowable. Treating the two alike is what stormed.

Note `%begin`'s fourth argument looks like it would classify these blocks, but the man page documents it as "currently not used", so it is not used here.

### 4. Re-arming on a lost connection was dead work

The re-arm fired on any error, including `control connection lost`, where `RunCommand` returned without writing anything and `markAllDirty` discards the gap at reconnect regardless. Measured over a 300 ms outage with a stalled re-dial at a 20 ms deadline: 14 warnings, **0 resumes written**, gap still armed. At the production 10 s deadline that is about 6 warnings a minute.

So #36's stated per-lap cost of "one command plus one log line" was wrong on that path. `RunCommand` now returns distinguishable sentinels, and `expireGap` re-arms and warns **only** on a refusal tmux actually sent; nothing written, a failed write, a dead connection, a closed client and a desynchronised stream all return without re-arming and log at `Debug`. A refusal is now the only path that laps at all.

### 5. `parsePaneNotification` — the disclosed issue, now fixed

It took the whole line remainder as the pane ID, unlike every sibling parser. This PR routes that value into a tmux command string, where `;` separates commands, so the ceiling was tmux command execution rather than a mislabelled dirty flag. And the guard #36 claimed is not the real one: `readLoop` classifies before consulting `inBlock`, so a command response *body* line beginning `%pause ` would dispatch as a notification. What actually protects it is that houston issues only `refresh-client`, whose response bodies are empty.

It now takes the first field and requires `%` followed by digits; a line that does not match is not a notification at all, so it opens no gap and reaches no command string.

### 6. The two guards disclosed as untested

The review was right that they are **not** equally load-bearing, and #36's "both are load-bearing" overstated one half. `expireGap`'s pointer-identity check is the serious one: remove it and a stale deadline claims a newer gap, resumes a pane a fresh handshake legitimately paused, drops the newer record, and marks everyone. `clearGapsLocked`'s `timer.Stop()` loop is not behaviourally observable and structurally cannot be — once the map entry is deleted a surviving timer's `*gap` can never again equal `cc.gaps[paneID]` — so removing it costs one leaked timer per swept pane, nothing more.

Both are now covered, and one correction to the review's own matrix: `TestReconnectDisarmsAnOpenGapsDeadline` does **not** fail for either guard alone. With the `Stop()` loop present the timer never fires, so the identity check is never reached; with only the loop removed the fired timer still loses the identity check. It reddens solely when **both** are gone, and its comment says so rather than claiming coverage it does not have.

## Proving it

Every new guard was mutation-tested, and an independent pass re-ran all six rather than trusting the implementers' reports. **No mutation survived.**

| Mutation | Test that bit |
|---|---|
| Resume command unquoted again | `TestGapDeadlineResumeActuallyResumesThePane` (real tmux) |
| Terminator's command number not checked | `TestMismatchedTerminatorReleasesTheWaiter`, `TestDesyncRecoversOnTheNextConnection` |
| Baseline marker per-client instead of per-connection | `TestSecondConnectionAlsoDropsItsBaselineBlock` |
| `attach`'s enrolment skipped | `TestFirstBlockOfAConnectionBindsToNoCommand`, `TestSecondConnectionAlsoDropsItsBaselineBlock`, `TestConcurrentWriterNeverStealsAReply` |
| DCS introducer not stripped | `TestParseControlLine/begin_block_behind_the_control-mode_introducer` |
| Orphan terminator desynchronises again | `TestOrphanBaselineTerminatorKeepsTheQueueAligned` |
| Re-arm on every error | `TestUnwritableResumeDoesNotReArm`, `TestResumeLostWithItsConnectionDoesNotReArm`, `TestDesynchronisedResumeDoesNotReArm` |
| Re-arm removed from the refusal path | `TestRefusedResumeReArmsTheGap` |
| `expireGap`'s identity check removed | `TestStaleDeadlineDoesNotClaimANewerGap` |
| `clearGapsLocked`'s `timer.Stop()` loop removed | `TestClearGapsDisarmsEveryDeadline` |
| Pane-ID shape check removed | `TestPauseWithAQuotedPaneIDOpensNoGap` + 3 `TestParseControlLine` cases |

The blocker-2 proof came first and was red against the unfixed dispatch:

```
--- FAIL: TestReplyGoesToTheCommandThatAskedForIt
    control_client_test.go:685: RunCommand returned ("theirs", <nil>) off another writer's block
```

Two tests were caught being **vacuous as first drafted** and strengthened before being counted: the first-block test passed while the baseline wrongly claimed an entry (it answered `ignore-size` before enrolling, draining the queue in lockstep), and the failed-write test passed on the teardown alone rather than on the desync marker. Three negative gap tests also needed the client pinned to one connection — unpinned, `attach` → `markAllDirty` → `clearGapsLocked` deletes the very gap the test looks for, so they read green either way.

`go test ./... -race` green; `./tmux/... ./server/... -race -count=5` green; real-tmux integration tests included, leaving no stray sessions. `gofmt`, `go vet ./...`, `golangci-lint run` clean across the whole repo.

## Outside this PR's scope, but you should know

**`server/pane_ws.go:120`, `:132` and `:178` build the same unquoted `pause`/`continue`, so the seed handshake's pause has never engaged.** `:121` swallows the `%error` at `slog.Debug` and proceeds with `paused = false`. Two facts worth stating plainly:

- `server/pane_ws_protocol_test.go:274-277` asserts those exact unquoted strings against a fake control client that accepts anything, so the defect is test-**enshrined**, not test-covered. The next reader would reasonably assume the strings are verified.
- It is a **second, previously undisclosed reason the gap machinery is dormant**. #36's dormancy argument rested on `pause-after` alone. With the handshake's pause also failing to parse there is no `%pause` on the wire at all, which means this design had not been exercised against a live `%pause` before this review.

Left unfixed deliberately: the scope fence for this task is `tmux/` plus the design record, and this PR does not depend on it. It wants its own issue and a decision about that protocol test.

## Escalated

Both gates hit the 2-revision cap with the critic still returning `revise`. Both times the remaining findings were localized and applied before execution, not waved through — but they never got a clean verdict, so they are recorded rather than treated as accepted.

**Spec, final round** — two findings, both applied:
- The per-connection baseline marker was named in the design but not in the reset rule, and no criterion observed it on a *second* connection. A once-only marker would have satisfied every stated requirement while being permanently one block out of step on every reconnect. Fixed by scoping the marker to `readLoop`'s frame and adding the connection-1 test, which is now the only test that catches it.
- The desync teardown could not close the connection that `attach`'s own failed write desynchronises, because `closeCur` was still the previous connection's spent `sync.Once`. Fixed by installing the connection before its first enrolled write.

**Plan, final round** — two findings, both applied:
- Two of the three F4 negative tests would have passed against unfixed code, because a live re-dial erases the gap they assert on. Fixed by pinning each to a single connection.
- The failed-write test could park the suite instead of failing, since `RunCommand` has no timeout and the teardown's re-dial installs a connection nothing answers. Fixed by suppressing the second dial for that test.

## Review notes

Carried forward rather than fixed:

- **"Enrol before the write" is argued structurally, not witnessed by a test.** Moving the enrolment after the write leaves the whole suite green, including the concurrent-writer reproduction at `-race -count=20`. The reason is the fake, not the test's shape: `recordedConn`'s `Write` and `written()` share one mutex, so the in-test answerer cannot see a command line until the write has already returned, and `-race` slows both sides equally rather than widening the window. It is real against a PTY, where tmux answers on a separate fd. Catching it would need a probe writer that synchronously feeds a block from inside `Write`, which is a test existing only to kill that mutation.
- **The scheme assumes exactly one block per stdin write and has no detector for a stray one.** Beyond the single baseline block, an extra block would shift the queue for the life of the connection and still pass the number check, since its own `%begin` and `%end` agree. It rests on the documented protocol plus houston writing one command per line.
- **The pane-ID shape check narrows the command sink rather than removing it.** `paneID` is still interpolated unquoted by `sendLiteral`, `sendControl` and `SendSpecialKey`, safe today only because those IDs come from tmux and the key name comes from a fixed table.
- **The refusal retry is still unbounded.** A live pane tmux keeps refusing re-arms once per deadline forever. Deliberate — giving up leaves the pane dark — and it is now the only path that laps.
- **`Unsubscribe` does not close a gap.** If the last subscriber leaves mid-gap the gap stays armed; the deadline then resumes a pane nobody watches and marks nobody.
- **No test races an in-flight `%pause` against a concurrent `Close()`.** Mutex-correct by inspection, sequential ordering tested, true concurrency unproven.
- **A notification can appear inside a command block**, despite the man page saying it never does, and which side of `%end` it lands on depends on the pane. Measured on 3.6a: against a pane actively producing output, `refresh-client -A '%0:pause'` emits `%pause %0` *between* its own `%begin` and `%end`; against an idle pane, eight of eight landed *after* `%end`. tmux raises it when it next goes to write output for the pane.

  `readLoop` classifies **before** consulting `inBlock`, and that ordering is load-bearing. This PR's security review proposed gating the notification cases on `!inBlock` for symmetry with `EventData`; **that was rejected on the above evidence.** The gate would silently drop `%pause` for exactly the busy panes the gap machinery protects, and no test would catch it — a test driving an idle pane sees the after-`%end` ordering and stays green. Verified: the gate leaves the real-tmux resume test passing.
- **`state-of-play` defect 3 is not struck.** Outside this task's scope fence.

## Follow-ups

- **Fix `server/pane_ws.go`'s quoting** and the protocol test that enshrines it. See above.
- **Enable `refresh-client -f pause-after=N`.** A product decision: it swaps tmux's current treatment of a slow control client — killing it — for pausing and re-seeding it, which this change makes safe. It should revisit the 10s deadline, which would then double as the backpressure interval.
- **Bound the WebSocket seed write.** The handshake's pause→continue window holds three tmux round trips and two WebSocket writes with no write deadline anywhere in the repo, so it can in principle exceed any finite gap deadline. The consequence is already benign — the seeding socket is marked dirty and re-seeds once — but that makes 10s a statement rather than a proof. Lives in `server/`.

## Corrections from a later review

A follow-up review found two should-fix issues and two clarity issues in the
above — no blockers. Both should-fixes are addressed in a later commit on
this branch; three claims above are now stale as a result:

- **"Escalated → Spec, final round"**, 2nd bullet, above: *"The desync
  teardown could not close the connection that `attach`'s own failed write
  desynchronises, because `closeCur` was still the previous connection's
  spent `sync.Once`. Fixed by installing the connection before its first
  enrolled write."* `dropConnection` re-read `cc.closeCur` fresh after
  `stdinMu` was released, so a write that stalled across a full
  retire→backoff→dial→attach cycle for a *different* connection could still
  tear down the wrong one — install order alone didn't close that window.
  Fixed by adding `curClose`, captured under `stdinMu` in the same critical
  section as the write, and passing it into `dropConnection` explicitly.
  Install order still matters, but now for `connOK`/`gone` (what
  `RunCommand` reads to decide a connection is live), not for the teardown
  target.
- **"What this PR changes" §2**, closing bullet: *"A failed write, or a
  mismatched terminator, desynchronises the queue: every enrolled waiter is
  failed and the connection is torn down so `supervise` re-dials."* Now
  reads: the connection torn down is the one the failed write actually went
  out on, captured under `stdinMu` rather than read fresh afterward.
- **"Review notes"**, "the scheme assumes exactly one block per stdin
  write..." bullet, closing sentence: *"It rests on the documented protocol
  plus houston writing one command per line."* Narrowed: a command string
  containing a top-level `;` draws two blocks from one write (now documented
  as a caller precondition on `writeCommandLocked`), and a response body
  line starting with `%begin `/`%end ` forges a block opener/terminator —
  unreachable today since every caller sends an empty-body command, but also
  now documented as a precondition rather than left implicit.

The two clarity findings corrected a struct comment that stated a caller
precondition as a guaranteed tmux property, and a test comment on
`pinnedDial` whose mutant-detection rationale was backwards (see the
comments themselves for the corrected, measured reasoning).

https://claude.ai/code/session_019SSNY3APJBVkdjnUwwADga
https://claude.ai/code/session_01WHHAPSv93ratBU4Y1cREHa

