### PR TITLE
feat(fleet): Workspace tab — tmux tree with a repo roll-up

### DIFF
--- a/docs/superpowers/plans/2026-09-10-workspace-tab.md
+++ b/docs/superpowers/plans/2026-09-10-workspace-tab.md
@@ -1,0 +1,413 @@
+# Plan — Workspace tab: the tmux tree across hosts, including non-agent panes
+
+Issue #38. Design: `docs/superpowers/specs/2026-09-07-houston-overhaul-design.md`
+(binding). State of play: `docs/superpowers/2026-09-08-state-of-play.md`,
+"B. Crews, Workspace and Dispatch tabs". Closest precedent: PR #35 (Crews tab),
+`docs/superpowers/plans/2026-09-10-crews-tab-and-branch-pane-join.md`.
+
+The work splits into seven components: tmux field harvest (C1), the pure tree
+builder (C2), the HTTP handler (C3), the TS client + poll hook (C4), the
+Workspace view (C5), Shell wiring (C6), and the integration gate (C7).
+`I1`-`I4` are the interfaces held stable across that split, pinned inline in
+the step that owns them.
+
+Order: `C1 ∥ C4`, then `C1 → C2 → C3`, `C4 → C5 → C6`, `{C3, C6} → C7`.
+
+Baseline before any step: Go build, vet and tests green; UI typecheck, lint
+and tests green.
+
+Revised once after plan-critic. Three blocking findings, all verified against
+the code and all adopted: `WorkspaceCrew.Color` had no reachable derivation
+(`tmuxColorToHex` is unexported to `runs`, and the one chip that would have
+used it doesn't render a dynamic colour) — dropped, not exported, since
+nothing in this plan needs it; `Agent`/`RunID` were specified two
+contradictory ways and the gap is a real, reachable case — a pane can carry a
+composed `Run` via `HookSource` alone (`hook/hook.go`'s own `tmuxCoords()`,
+independent of lazytmux's `@claude_status`), so `Agent` is now derived from
+whether a `Run` joined, not from lazytmux's option; and `WorkspaceView`'s
+`now` prop was unused and would fail `tsc -b` under this repo's
+`noUnusedParameters` — removed. Several non-blocking notes were also folded
+in: `tmux/options.go` gains a `Target()` method so C2 does not hand-duplicate
+`windowsByTarget`'s join-key logic, the handler guards a nil `wsTmux`, and the
+UI test step gains a `vi.mock` plan and DOM-distinguishable fixtures.
+
+## Why this is a plain `GET`, not a stream
+
+The design spec's API surface table (line 266) lists `GET /api/workspace` next
+to `GET /api/runs` *and* `GET /api/runs/stream` as separate rows — it lists a
+stream variant explicitly wherever one exists, and does not for `/api/workspace`.
+That is a decision already made, not an oversight to relitigate: the tree is
+polled. `useWorkspace` (C4) fetches on mount and on an interval while the
+Workspace tab is the mounted one; unlike Fleet/Crews, Workspace holds no
+per-tab input state worth preserving across a tab switch (no composer, no
+half-typed anything), so `Shell.tsx` mounts it conditionally instead of
+keeping it mounted-but-`hidden`, and polling stops for free the moment the tab
+is left — no visibility-change plumbing needed.
+
+## Why correlation needs no `runs/` change
+
+The join key is the tmux pane id (already decided, state-of-play). Every
+source that can key an agent run to a pane — `tmuxsource.go`'s own tmux layer,
+`hooksource.go` via `TmuxPane` — keys it as the *same* registry key, so a
+joined agent pane composes into exactly one `Run` whose `Run.Tmux.PaneID`
+equals that pane id, and `Run.ID` is already the externally-routable id the UI
+uses (`#/fleet/<id>/activity`). Both fields are public. The handler builds a
+`paneID → RunID` map by one pass over `s.runs.Snapshot()` and never touches
+`idFor` or any other unexported registry internal — C3 does not import
+anything from `runs/` beyond `runs.Run` and `s.runs.Snapshot()`, both already
+used by `server/runs_reply.go`.
+
+## C1 — tmux field harvest
+
+- [ ] **Step 1: extend the format strings.** In `tmux/options.go` add
+      `#{window_name}` and `#{window_active}` to `windowOptionsFormat` (new
+      trailing fields, indices 12–13, so every existing index keeps its
+      meaning and only the four raw-string fixtures in `options_test.go`
+      change); add `#{pane_current_command}`, `#{pane_index}` and
+      `#{pane_active}` to `paneOptionsFormat` (new trailing fields, indices
+      4–6). These ride the *same* `-a -F` calls `TmuxSource` already issues
+      every tick — no new tmux roundtrip.
+
+      **`I1` — new struct fields**, appended (never inserted, to keep every
+      existing field index stable):
+      ```go
+      type WindowOptions struct {
+          // ...existing 12 fields unchanged...
+          Name   string // #{window_name}
+          Active bool   // #{window_active}
+      }
+      type PaneOptions struct {
+          // ...existing 4 fields unchanged...
+          Command string // #{pane_current_command}
+          Index   int    // #{pane_index}
+          Active  bool   // #{pane_active}
+      }
+
+      // Target is the "session:window" join key PaneOptions.Target already
+      // carries verbatim. Exists so C2 does not hand-duplicate this string
+      // build a second time outside the tmux package.
+      func (w WindowOptions) Target() string {
+          return fmt.Sprintf("%s:%d", w.Session, w.Window)
+      }
+      ```
+      `tmux/options.go` gains a `"fmt"` import for this. Used only from
+      `server/workspace.go` (C2) — `runs/tmuxsource.go`'s own
+      `windowsByTarget` is left as its existing inline `fmt.Sprintf`, not
+      swapped to call it, since that file is outside this plan's scope fence
+      (`WORKER_TASK.md`: `runs/` only for what the tree genuinely needs and
+      does not already expose) and touching it for a same-behaviour rename
+      buys nothing this plan needs.
+- [ ] **Step 2: bump the parsers.** `ParseWindowOptions`'s field-count guard
+      12 → 14; `ParsePaneOptions`'s 4 → 7. Parse `Active` as `f[n] == "1"`
+      (tmux's own boolean convention, matching `parseSessionLine`'s
+      `parts[3] == "1"` elsewhere in this package) and `Index` via
+      `strconv.Atoi`, skipping the line on a parse failure exactly like
+      `Window` already does for `WindowOptions`.
+- [ ] **Step 3: fix the four fixtures this breaks.** `TestParseWindowOptions`'s
+      two lines, `TestParseWindowOptionsSkipsMalformedLines`'s second line, and
+      `TestParseWindowOptionsSurvivesPipeInFreeText`'s line all get two more
+      `\x1f`-separated fields appended. Add explicit assertions for the new
+      `Name`/`Active` values on at least one enriched and one bare window.
+      `TestParsePaneOptions`'s two lines each get three more fields; assert
+      `Command`, `Index` and `Active` on both rows (one active, one not).
+- [ ] **Step 4: verify C1.** `go build ./...`, `go vet ./...`,
+      `go test ./tmux/...`.
+
+## C2 — the pure tree builder
+
+New `server/workspace.go`, tree-shaping logic kept separate from the HTTP
+handler so it is unit-testable with hand-built fixtures — the same split
+`runs/crewjoin.go`'s `resolvePane` uses relative to its own HTTP-adjacent
+caller.
+
+- [ ] **Step 5: the response types.**
+
+      **`I2` — the JSON contract**, pinned once because C4 mirrors it verbatim:
+      ```go
+      type Workspace struct {
+          Host     string             `json:"host"` // "" means local; unset by anything built here — M2's seam
+          Sessions []WorkspaceSession `json:"sessions"`
+      }
+      type WorkspaceSession struct {
+          Name    string            `json:"name"`
+          Windows []WorkspaceWindow `json:"windows"`
+      }
+      type WorkspaceWindow struct {
+          Index        int             `json:"index"`
+          Name         string          `json:"name"`
+          Active       bool            `json:"active"`
+          Branch       string          `json:"branch,omitempty"`
+          Task         string          `json:"task,omitempty"`
+          CrewCodename string          `json:"crew_codename,omitempty"`
+          Panes        []WorkspacePane `json:"panes"`
+      }
+      type WorkspacePane struct {
+          ID      string `json:"id"`      // "%307"
+          Index   int    `json:"index"`
+          Active  bool   `json:"active"`
+          Command string `json:"command"` // #{pane_current_command}; the plain-pane label (spec: never the parser)
+          Agent   bool   `json:"agent"`   // a composed Run joined this pane id — see Step 6
+          RunID   string `json:"run_id,omitempty"` // set whenever Agent is true; the two can never disagree
+      }
+      ```
+      No `WorkspaceCrew`/`Color` field: the only converter from a raw tmux
+      colour name to `#rrggbb` (`tmuxColorToHex`) is unexported to `runs`, and
+      the chip this plan actually renders (`.run-chip.codename`, Step 18) is a
+      flat fill/text colour with no dynamic accent — carrying a `Color` field
+      nothing renders is exactly the "always zero, inviting a reader to
+      wonder why" trap `I2`'s own reasoning warns against. If a future plan
+      wants a coloured accent here, exporting `tmuxColorToHex` is that plan's
+      job, not this one's.
+- [ ] **Step 6: `buildWorkspace`.** Pure function
+      `buildWorkspace(wins []tmux.WindowOptions, panes []tmux.PaneOptions, snap []runs.Run) Workspace`.
+      First pass over `snap`: for every `r` with `r.Tmux != nil`, record
+      `paneToRun[r.Tmux.PaneID] = r.ID`. Index windows by `w.Target()` (`I1`)
+      and group panes onto their window by `p.Target` — the same field name,
+      populated from the same `"session:window"` format string, so this is a
+      direct map lookup, not a re-derivation. Sessions are ordered by name;
+      windows within a session by `Index`; panes within a window by `Index` —
+      all deterministic, never by map iteration order. A pane whose window was
+      not listed is skipped, mirroring `deltasFromTmux`'s own "the two queries
+      raced a window closing" handling.
+
+      Window fields come straight from the matched `tmux.WindowOptions`:
+      `Name`/`Active`/`Index` from `I1`'s new fields, `Branch` from `w.Branch`,
+      `Task` from `w.Task`, and `CrewCodename` from `w.CrewName` — lazytmux's
+      `@crew_name` is already treated as the codename by
+      `runs/tmuxsource.go:126`'s own `Crew.Codename` assignment, so this reuses
+      that same reading rather than inventing a new one.
+
+      `RunID = paneToRun[p.PaneID]`, always, regardless of `p.ClaudeStatus`.
+      `Agent = RunID != ""` — **derived from whether a Run actually joined,
+      not from lazytmux's `@claude_status` option.** The two are not
+      equivalent: `HookSource` can compose a `Run` for a pane from houston's
+      own hook state (`hook/hook.go`'s `tmuxCoords()`) with no dependency on
+      lazytmux at all, so a pane can be a real, routable agent run while
+      `ClaudeStatus == ""`. Keying `Agent` off `ClaudeStatus` instead would
+      make such a pane render as a plain shell — invisible to exactly the
+      "open it as a run rather than duplicating it" requirement this tab
+      exists for (`WORKER_TASK.md`'s correlation clause). Since `RunID` can
+      only ever be non-empty when the registry actually composed a run for
+      that pane id, `Agent` and `RunID` can never disagree by construction —
+      there is no third state to reconcile.
+- [ ] **Step 7: tests.** `server/workspace_test.go`: a session with one plain
+      window (no branch/crew, one pane with `ClaudeStatus == ""` and no
+      matching run — the ordinary shell case, asserts `Agent: false`); a
+      session with a branch + crew window holding a pane that joins a
+      `runs.Run` fixture by pane id where the fixture also sets `ClaudeStatus`
+      (the ordinary lazytmux-enriched case — asserts `Agent: true`, `RunID`
+      set); **a pane whose `ClaudeStatus == ""` but whose id matches a
+      `runs.Run` fixture with `Tmux != nil`** (the hook-only case from Step 6
+      — asserts `Agent: true`, `RunID` set, proving `Agent` is not reading
+      `ClaudeStatus`); **the mirror case: a pane with `ClaudeStatus` set but
+      whose id matches no run in `snap`** (asserts `Agent: false`, `RunID: ""`
+      — pins "can never disagree" from the other direction too: lazytmux
+      opinion alone, with no composed run, still does not make it routable); a
+      pane whose window is absent from `wins` (asserts it is skipped); ordering
+      (sessions/windows/panes out of tmux's own emission order come back
+      sorted). Revert the sort, the "no matching window" skip, and the
+      `Agent = RunID != ""` derivation (swap it for `p.ClaudeStatus != ""`) in
+      turn and confirm each test goes red before restoring — the state-of-play
+      retro requires this, not "it passed."
+
+## C3 — the HTTP handler
+
+- [ ] **Step 8: the injectable seam.**
+
+      **`I3` — `workspaceLister`**, narrow enough to fake in tests, mirroring
+      `runs/tmuxsource.go`'s unexported `lister` (which cannot be imported
+      across packages) and the `replyRunner` field precedent in
+      `server/server.go`:
+      ```go
+      type workspaceLister interface {
+          ListWindowOptions() ([]tmux.WindowOptions, error)
+          ListPaneOptions() ([]tmux.PaneOptions, error)
+      }
+      ```
+      Add `wsTmux workspaceLister` to `Server`, defaulted to the same
+      `tmuxClient` already constructed in `New` (`*tmux.Client` satisfies the
+      interface structurally — no change to the existing `s.tmux` field or its
+      35+ call sites).
+- [ ] **Step 9: `handleWorkspace`.**
+      `GET /api/workspace` → `Workspace`. 503 when `s.runs == nil` or
+      `s.wsTmux == nil` (unstarted registry, or a hand-built `&Server{}` in a
+      test that never set the default — matches `handleRunsSnapshot`'s own
+      guard for the first case; the second exists because server tests
+      construct `&Server{...}` by hand, per `server/runs_reply_test.go`, and a
+      nil interface call panics rather than degrading to 502). On a
+      `ListWindowOptions`/`ListPaneOptions` error, 502 with the tmux error
+      text — no special-casing of "no server running" the way
+      `ListSessions` does: houston's own purpose is monitoring a live tmux, so
+      a dead tmux server is a genuine failure to surface, not a quiet empty
+      tree. Otherwise `buildWorkspace(wins, panes, s.runs.Snapshot())`,
+      `Content-Type: application/json`, 200.
+- [ ] **Step 10: register it.** One line in `server/server.go`:
+      `apiMux.HandleFunc("GET /api/workspace", s.handleWorkspace)` — on
+      `apiMux`, inheriting the token/origin/Host gates unchanged, matching
+      Step 11 of the Crews plan verbatim in shape.
+- [ ] **Step 11: tests.** `server/workspace_handler_test.go`, mirroring
+      `runs_api_test.go`'s shape: 503 without a registry; 200 with a fake
+      `wsTmux` and a registry carrying one composed run, decoding the body and
+      asserting the joined pane's `run_id`; 502 when the fake `wsTmux` errors;
+      `TestWorkspaceRouteIsBehindTheAuthGate` through `s.Handler()` exactly
+      like `TestRunsRoutesAreBehindTheAuthGate` (401 unauthenticated) — a new
+      route registered outside `apiMux` would reopen the hole #4 closed, so
+      this is not optional boilerplate.
+- [ ] **Step 12: verify C3.** `go build ./...`, `go vet ./...`,
+      `go test ./server/... ./runs/... ./tmux/...`.
+
+## C4 — the TS client and poll hook
+
+- [ ] **Step 13: `ui/src/api/workspace.ts`.** `I2`'s mirror:
+      ```ts
+      export interface WorkspacePane { id: string; index: number; active: boolean; command: string; agent: boolean; run_id?: string }
+      export interface WorkspaceWindow { index: number; name: string; active: boolean; branch?: string; task?: string; crew_codename?: string; panes: WorkspacePane[] }
+      export interface WorkspaceSession { name: string; windows: WorkspaceWindow[] }
+      export interface Workspace { host: string; sessions: WorkspaceSession[] }
+      export async function fetchWorkspace(): Promise<Workspace>
+      ```
+      `fetchWorkspace` throws on a non-2xx (the hook below is what turns that
+      into a UI state) — same relative-URL, same-origin-cookie pattern
+      `replyRun` already uses; no explicit `credentials` needed.
+- [ ] **Step 14: `useWorkspace`.** New `ui/src/fleet/useWorkspace.ts`. Fetches
+      once on mount, then on a `setInterval` (poll every 3s — a plain fixed
+      interval, not tied to any registry source's own tick rate; `TmuxSource`'s
+      2s cadence is an internal detail of the background composer, not a
+      promise about API freshness); clears the interval on unmount. State:
+      `{ workspace: Workspace | null, error: string | null, loading: boolean }`.
+      A poll failure sets `error` but keeps the last-known `workspace` rather
+      than blanking the view — the same "don't destroy state that's trivially
+      re-derivable" instinct the design spec states for `Stale` (this is not
+      `Stale` itself; nothing here composes into a `Run`).
+- [ ] **Step 15: tests.** `useWorkspace.test.tsx`. `ui/src/hooks/useRuns.lifecycle.test.ts`
+      is the closest precedent for the *shape* of a lifecycle test (`renderHook`
+      with a named probe function, not an inline arrow — an inline arrow can
+      trip `react-hooks/rules-of-hooks`, which Step 16's `npx eslint .` runs)
+      and for fake timers, but it mocks `EventSource`, not `fetch` — there is
+      no `global.fetch` mock precedent anywhere in `ui/src`. Mock the module
+      instead, `vi.mock('../api/workspace')`, the same way
+      `ui/src/fleet/ReplyComposer.test.tsx` mocks `../api/runs`: mount → one
+      call to the mocked `fetchWorkspace` → state populated; advancing fake
+      timers by the poll interval fires a second call; unmount stops further
+      calls (assert the mock's call count does not grow after unmount); a
+      rejected call sets `error` and leaves a prior `workspace` value in
+      place.
+- [ ] **Step 16: verify C4.** `npx tsc -b`, `npx eslint .`,
+      `npx vitest run` (client + hook only at this point).
+
+## C5 — the Workspace view
+
+Design it twice, on purpose (the task's own instruction) — nesting is real:
+session → window → pane is three levels, names run long (branch names,
+worktree paths), and this has to stay one-thumb usable.
+
+**Option A — collapsible accordion.** Sessions (and optionally windows)
+start collapsed; tapping a header expands it in place. Pro: with many
+sessions, a phone shows more at a glance by default. **Rejected**: this
+codebase has zero existing disclosure-widget precedent — no collapse state,
+no expand/collapse animation, no `aria-expanded` pattern anywhere in
+`ui/src/fleet/` — and Fleet/Crews have already trained the user on one
+interaction model, "scan a flat list under a section header, tap a card."
+Inventing a second interaction primitive on top of that for one tab is a
+second visual *and* interaction language, which the task explicitly forbids.
+It also doesn't earn its complexity at this data's actual scale — a personal
+dev machine carries a handful of tmux sessions, not hundreds — so the
+"more at a glance" win is close to zero in practice.
+
+**Option B — flat grouped scroll (chosen).** No collapse state at all.
+Sessions render as `.fleet-group`-style section headers (exact reuse of the
+class Fleet already uses for its host grouping — same visual weight, same
+place in the eye). Within a session, each window is a compact one-line
+sub-header (index/name, plus a branch chip and a crew-codename chip *only*
+when present, reusing `.run-chip`/`.run-chip.codename` verbatim). Panes render
+as a tight list of one-line rows under their window — `command` as the label,
+a small dot for `active`, and a tap target only when `pane.agent` (which by
+Step 6's construction always carries a `run_id` when true — a plain pane
+renders inert, same "affordance from capability, not from type" rule `Caps`
+already uses for runs). This is a pure scroll, costs zero new CSS interaction
+states, and is legible with long names because nothing needs to fit next to a
+disclosure triangle.
+
+- [ ] **Step 17: `ui/src/fleet/WorkspaceView.tsx`.** Props: `{ onOpen?: (runId: string) => void }`
+      (deliberately takes a bare `run_id` string, not a `Run` — `WorkspaceView`
+      never holds a `Run[]`, only the tree; `Shell.tsx` maps the id to the same
+      hash-navigation `FleetView`/`CrewsView` already use). Uses `useWorkspace`
+      internally. Unlike `FleetView`/`CrewsView`, which take `runs: Run[]` as a
+      prop and correlate live via `useRuns()`, `WorkspaceView` takes no
+      `Run[]` at all — correlation already happened server-side (C3), so this
+      is the one place in `ui/src/fleet/` that does not consume `useRuns()`,
+      and the file's top comment says why in one line, pointing at this plan.
+      Loading state before the first successful fetch; error state on
+      `error && !workspace` (an error *with* a prior workspace renders the
+      tree, stale, same instinct as Step 14); empty state when `sessions.length === 0`.
+- [ ] **Step 18: CSS.** New rules in `ui/src/fleet/fleet.css` (same file every
+      other fleet view already extends — no second stylesheet): `.workspace`
+      (root, mirrors `.crews`/`.fleet`), `.ws-window` (window sub-header row),
+      `.ws-pane` (pane row, plain and inert by default), `.ws-pane.agent`
+      (tappable — cursor/hover per the existing `.run-card:active` scale-down
+      convention). Reuses `.fleet-group`, `.run-chip`, `.run-chip.codename`
+      unmodified.
+- [ ] **Step 19: tests.** `WorkspaceView.test.tsx`, `vi.mock('./useWorkspace')`
+      (the `RunDetail.test.tsx`/`TerminalPane.test.tsx` pattern of mocking the
+      owning hook rather than the network) returning a fixed `Workspace`
+      fixture per case — no interval to fake here, since the hook itself is
+      replaced wholesale. Fixture: two sessions; one window with a branch +
+      `crew_codename` holding one agent pane (`agent: true, run_id: "pane-1"`,
+      `command: "claude"`); a second, plain window holding two non-agent panes
+      that are otherwise distinguishable (different `id`/`command`, e.g. a
+      `"zsh"` pane and a `"vim"` pane, both `agent: false`, no `run_id`) —
+      assert via `container.querySelector('.ws-pane')` (the `CrewsView.test.tsx`
+      style) that clicking the agent pane calls `onOpen` with exactly
+      `"pane-1"`, and that clicking either plain pane does not call `onOpen`
+      at all. Session headers and the crew-codename chip get their own
+      assertions. Loading/error/empty states each get one case (mock the hook
+      to return each state directly).
+- [ ] **Step 20: verify C5.** `npx tsc -b`, `npx eslint .`, `npx vitest run`.
+
+## C6 — Shell wiring
+
+- [ ] **Step 21: wire it in.** In `ui/src/fleet/Shell.tsx`: add
+      `import { WorkspaceView } from './WorkspaceView'`; delete the
+      `workspace:` entry from the `PLACEHOLDER` object literal and narrow its
+      type to `Record<'dispatch', string>` (only one key survives, same move
+      as Step 30 of the Crews plan narrowing it to
+      `Exclude<Tab, 'fleet' | 'crews'>` — both the type and the literal must
+      drop `workspace`, or the literal fails an excess-property check); the
+      existing catch-all render at line 63,
+      `{tab !== 'fleet' && tab !== 'crews' && <div className="shell-placeholder">{PLACEHOLDER[tab]}</div>}`,
+      no longer typechecks once `PLACEHOLDER` only has a `dispatch` key — replace
+      it with `{tab === 'dispatch' && <div className="shell-placeholder">{PLACEHOLDER.dispatch}</div>}`;
+      add, alongside it,
+      `{tab === 'workspace' && <WorkspaceView onOpen={(id) => { window.location.hash = `#/fleet/${id}/activity` }} />}`
+      as a plain conditional mount (not `hidden`-kept, per the "Why this is a
+      plain GET" note above — Workspace has no state worth preserving across a
+      tab switch, so mounting it fresh each time is correct, not a shortcut).
+      Nothing else in this file changes — not the Dispatch tab's copy, not the
+      tab bar markup.
+- [ ] **Step 22: verify C6.** `npx tsc -b`, `npx eslint .`, `npx vitest run`.
+
+## C7 — the proofs no component can give
+
+- [ ] **Step 23: full gate.** Go build, vet, test; UI typecheck, lint, tests;
+      `gofmt -l` clean on touched files.
+- [ ] **Step 24: bundle grep.** `npm run build`, then grep the built CSS for a
+      declaration of `.workspace`, `.ws-window`, `.ws-pane`, `.ws-pane.agent`,
+      and the built JS for the string `/api/workspace`. A passing build proves
+      nothing here — the entire Mocha token file once shipped unimported
+      behind a fully green build, lint, tests and an Opus review.
+- [ ] **Step 25: live before/after, if a tmux server is reachable in this
+      environment.** Hit the built binary's `/api/workspace` against the real
+      local tmux (`curl` is enough — no browser needed for the data-level
+      check). `/api/workspace` sits behind the token gate like every other
+      `/api/` route: read `<state-dir>/token` and pass it as
+      `Authorization: Bearer <token>` (the `?token=` query form is WS-upgrade
+      only), against a `Host` the server recognises (`localhost`/`127.0.0.1`
+      need no `-hostname` flag). Confirm: every currently open pane appears
+      exactly once, an agent pane in the current worktree carries a `run_id`
+      that also appears in `/api/runs`, and a plain shell pane carries
+      `agent: false` and no `run_id`.
+- [ ] **Step 26: PR body.** State plainly whether a browser was available to
+      look at the rendered tree — if not, say so exactly as the Crews-tab PR
+      did, do not claim the rendering is verified. Include the curl evidence
+      from Step 25, the two-design note from C5 verbatim or summarized, and
+      any escalations from plan-critic revisions.

--- a/docs/superpowers/plans/2026-09-10-workspace-tab.md
+++ b/docs/superpowers/plans/2026-09-10-workspace-tab.md
@@ -31,6 +31,34 @@ in: `tmux/options.go` gains a `Target()` method so C2 does not hand-duplicate
 `windowsByTarget`'s join-key logic, the handler guards a nil `wsTmux`, and the
 UI test step gains a `vi.mock` plan and DOM-distinguishable fixtures.
 
+**Revised again mid-execute, per an explicit dispatcher directive (human
+decision, not a suggestion).** A plain session→window→pane mirror was
+rejected: measured live on this machine, one tmux session commonly spans
+several different `@git_root` values (five, in one case), so the session
+level alone does not tell a viewer which windows are "the real checkout" and
+which are throwaway worktrees. A crew-based grouping was rejected too — most
+runs on this machine carry a codename but an empty crew-bus id, so grouping
+by crew would strand the majority of panes in a no-crew bucket. A
+user-toggleable grouping was rejected as unbuilt, untested surface for a
+choice a human does not want to keep making. The fixed shape instead: each
+session groups its windows into **main checkout** (the window(s) whose
+`@git_root` IS a repo's main checkout) and **worktrees** (everything else
+under that repo), derived from repo identity via `git rev-parse
+--path-format=absolute --git-common-dir` — not from the session name, which
+the measurement above already falsifies as a repo proxy. This exact
+git-common-dir technique already exists in this codebase for the same kind of
+per-root keying: `runs/crewsource.go`'s `CrewSource.crewDir` resolves it (with
+a plain `--git-common-dir`, then a manual relative-path fixup this plan's
+`--path-format=absolute` variant skips) once per distinct root and caches the
+result — this plan reuses that discipline, not the function, since `crewDir`
+answers a different question (where the crew bus lives) with a different
+cache lifetime (owned by `CrewSource`, ticking every 3s) than this plan needs
+(owned by the HTTP handler, answering once per request but caching across
+requests). A window with an empty `@git_root` belongs to no repo and must
+stay reachable rather than being silently dropped — it lands in a third,
+unlabelled-by-repo bucket. See the revised `I2` in Step 5 and the new
+`repoClassifier` in Step 8a below for exactly how this composes.
+
 ## Why this is a plain `GET`, not a stream
 
 The design spec's API surface table (line 266) lists `GET /api/workspace` next
@@ -129,8 +157,11 @@ caller.
           Sessions []WorkspaceSession `json:"sessions"`
       }
       type WorkspaceSession struct {
-          Name    string            `json:"name"`
-          Windows []WorkspaceWindow `json:"windows"`
+          Name         string            `json:"name"`
+          WindowCount  int               `json:"window_count"`
+          MainCheckout []WorkspaceWindow `json:"main_checkout,omitempty"`
+          Worktrees    []WorkspaceWindow `json:"worktrees,omitempty"`
+          Other        []WorkspaceWindow `json:"other,omitempty"` // no @git_root — belongs to no repo, still reachable
       }
       type WorkspaceWindow struct {
           Index        int             `json:"index"`
@@ -158,8 +189,30 @@ caller.
       wonder why" trap `I2`'s own reasoning warns against. If a future plan
       wants a coloured accent here, exporting `tmuxColorToHex` is that plan's
       job, not this one's.
+
+      Bucketing a window into `MainCheckout`/`Worktrees`/`Other` is not this
+      function's decision alone — it needs to know, for each distinct
+      non-empty `@git_root`, whether that root is a main checkout. That
+      answer comes from a real `git` subprocess call (Step 8a), which
+      `buildWorkspace` itself must not perform — it stays pure and
+      fixture-testable, per the retro's own "prove it" standard. The caller
+      resolves the map once (one call per **distinct** root, not per pane or
+      per window — `crewDir`'s own discipline) and hands it in.
 - [ ] **Step 6: `buildWorkspace`.** Pure function
-      `buildWorkspace(wins []tmux.WindowOptions, panes []tmux.PaneOptions, snap []runs.Run) Workspace`.
+      `buildWorkspace(wins []tmux.WindowOptions, panes []tmux.PaneOptions, snap []runs.Run, mainCheckouts map[string]bool) Workspace`.
+      `mainCheckouts[root] == true` means that `@git_root` is a repo's main
+      checkout; `false` or an absent key means a linked worktree (this
+      includes a root whose `git rev-parse` lookup failed — the classifier in
+      Step 8a resolves an error to `false` rather than asserting "main" on
+      uncertain information, and caches that like any other answer, mirroring
+      `crewDir`'s own accepted "caches negative results for the process
+      lifetime" trade-off from the state-of-play defect list — not a new
+      problem this plan is introducing). Bucket each window: `w.GitRoot == ""`
+      → `Other`; `mainCheckouts[w.GitRoot]` → `MainCheckout`; else →
+      `Worktrees`. Windows keep their original per-session `Index` ordering
+      within whichever bucket they land in. `WindowCount = len(wins for this session)`,
+      counted before bucketing (a session's total window count regardless of
+      which bucket a window ends up in).
       First pass over `snap`: for every `r` with `r.Tmux != nil`, record
       `paneToRun[r.Tmux.PaneID] = r.ID`. Index windows by `w.Target()` (`I1`)
       and group panes onto their window by `p.Target` — the same field name,
@@ -205,10 +258,19 @@ caller.
       opinion alone, with no composed run, still does not make it routable); a
       pane whose window is absent from `wins` (asserts it is skipped); ordering
       (sessions/windows/panes out of tmux's own emission order come back
-      sorted). Revert the sort, the "no matching window" skip, and the
-      `Agent = RunID != ""` derivation (swap it for `p.ClaudeStatus != ""`) in
-      turn and confirm each test goes red before restoring — the state-of-play
-      retro requires this, not "it passed."
+      sorted). **Bucketing**: one session with three windows sharing session
+      name — one whose `GitRoot` is a key in `mainCheckouts` with value
+      `true` (asserts it lands in `MainCheckout`), one whose `GitRoot` is a
+      key with value `false` (asserts `Worktrees`), one whose `GitRoot` is
+      `""` (asserts `Other`) — plus a fourth window whose `GitRoot` is
+      non-empty but **absent** from `mainCheckouts` entirely (asserts
+      `Worktrees`, the same as an explicit `false`, proving the "absent key"
+      reading from Step 6's spec, not just the explicit-`false` one); assert
+      `WindowCount == 4` regardless of bucket. Revert the sort, the "no
+      matching window" skip, the `Agent = RunID != ""` derivation (swap it for
+      `p.ClaudeStatus != ""`), and the bucketing logic (swap it for "everything
+      goes to `Worktrees`") in turn and confirm each test goes red before
+      restoring — the state-of-play retro requires this, not "it passed."
 
 ## C3 — the HTTP handler
 
@@ -228,27 +290,67 @@ caller.
       `tmuxClient` already constructed in `New` (`*tmux.Client` satisfies the
       interface structurally — no change to the existing `s.tmux` field or its
       35+ call sites).
+- [ ] **Step 8a: the repo classifier.** New `server/workspace_repo.go`.
+
+      **`I4` — `mainCheckoutChecker`**, narrow enough to fake in tests:
+      ```go
+      type mainCheckoutChecker interface {
+          isMainCheckout(root string) bool
+      }
+      ```
+      Real implementation `repoClassifier`, a `sync.Mutex`-guarded
+      `map[string]bool` cache plus one `git` call per cache miss:
+      `exec.CommandContext(ctx, "git", "-C", root, "rev-parse", "--path-format=absolute", "--git-common-dir")`,
+      bounded by a timeout constant (mirror `crewDirTimeout`'s 5s in
+      `runs/crewsource.go`). `root` is a main checkout iff the call succeeds
+      AND `filepath.Dir(strings.TrimSpace(commonDir)) == root` — a linked
+      worktree's common dir resolves to the *original* repo's `.git`,
+      somewhere else entirely, while the main checkout's own `.git` is a
+      direct child of `root`. An error (git missing, root no longer exists)
+      caches `false`, not an error state — Step 6 already documents why
+      "uncertain" reads as "not main" rather than blocking the tree. The
+      cache is keyed on `root` only and never invalidated — a worktree
+      changing identity under a live root without the process restarting is
+      not a case this plan is taking on, matching `crewDir`'s own accepted
+      "caches negative results for the process lifetime" trade-off.
+      Add `wsRepos mainCheckoutChecker` to `Server`, defaulted to
+      `newRepoClassifier()` in `New`.
+      Tests in `server/workspace_repo_test.go`: a real temp dir `git init`'d
+      as the main checkout → `true`; `git worktree add` a second temp dir from
+      it → `false` for the worktree's root, `true` still for the original; a
+      nonexistent path → `false`, not a panic or a hung call; a second call on
+      an already-cached root does not shell out again (assert via a call
+      counter on a fake `exec`-driving seam, or simply time-bound the test and
+      trust the mutex-guarded map — pick whichever this codebase's existing
+      `crewDir` test, if any, already established as the pattern).
 - [ ] **Step 9: `handleWorkspace`.**
-      `GET /api/workspace` → `Workspace`. 503 when `s.runs == nil` or
-      `s.wsTmux == nil` (unstarted registry, or a hand-built `&Server{}` in a
-      test that never set the default — matches `handleRunsSnapshot`'s own
-      guard for the first case; the second exists because server tests
-      construct `&Server{...}` by hand, per `server/runs_reply_test.go`, and a
-      nil interface call panics rather than degrading to 502). On a
-      `ListWindowOptions`/`ListPaneOptions` error, 502 with the tmux error
-      text — no special-casing of "no server running" the way
-      `ListSessions` does: houston's own purpose is monitoring a live tmux, so
-      a dead tmux server is a genuine failure to surface, not a quiet empty
-      tree. Otherwise `buildWorkspace(wins, panes, s.runs.Snapshot())`,
+      `GET /api/workspace` → `Workspace`. 503 when `s.runs == nil`,
+      `s.wsTmux == nil` or `s.wsRepos == nil` (unstarted registry, or a
+      hand-built `&Server{}` in a test that never set the defaults — matches
+      `handleRunsSnapshot`'s own guard for the first case; the rest exist
+      because server tests construct `&Server{...}` by hand, per
+      `server/runs_reply_test.go`, and a nil interface call panics rather than
+      degrading to 502). On a `ListWindowOptions`/`ListPaneOptions` error, 502
+      with the tmux error text — no special-casing of "no server running" the
+      way `ListSessions` does: houston's own purpose is monitoring a live
+      tmux, so a dead tmux server is a genuine failure to surface, not a quiet
+      empty tree. Otherwise: collect the distinct non-empty `w.GitRoot` values
+      across `wins`, call `s.wsRepos.isMainCheckout(root)` once per distinct
+      root (never once per window or per pane — the whole point of the cache),
+      build `mainCheckouts`, then
+      `buildWorkspace(wins, panes, s.runs.Snapshot(), mainCheckouts)`,
       `Content-Type: application/json`, 200.
 - [ ] **Step 10: register it.** One line in `server/server.go`:
       `apiMux.HandleFunc("GET /api/workspace", s.handleWorkspace)` — on
       `apiMux`, inheriting the token/origin/Host gates unchanged, matching
       Step 11 of the Crews plan verbatim in shape.
 - [ ] **Step 11: tests.** `server/workspace_handler_test.go`, mirroring
-      `runs_api_test.go`'s shape: 503 without a registry; 200 with a fake
-      `wsTmux` and a registry carrying one composed run, decoding the body and
-      asserting the joined pane's `run_id`; 502 when the fake `wsTmux` errors;
+      `runs_api_test.go`'s shape: 503 without a registry (and separately,
+      without `wsRepos`); 200 with a fake `wsTmux`, a fake `wsRepos` (returning
+      a canned answer per root — no real `git` call in this test file, that
+      belongs to Step 8a's own test), and a registry carrying one composed
+      run, decoding the body and asserting the joined pane's `run_id` AND that
+      it landed in the right bucket; 502 when the fake `wsTmux` errors;
       `TestWorkspaceRouteIsBehindTheAuthGate` through `s.Handler()` exactly
       like `TestRunsRoutesAreBehindTheAuthGate` (401 unauthenticated) — a new
       route registered outside `apiMux` would reopen the hole #4 closed, so
@@ -262,10 +364,15 @@ caller.
       ```ts
       export interface WorkspacePane { id: string; index: number; active: boolean; command: string; agent: boolean; run_id?: string }
       export interface WorkspaceWindow { index: number; name: string; active: boolean; branch?: string; task?: string; crew_codename?: string; panes: WorkspacePane[] }
-      export interface WorkspaceSession { name: string; windows: WorkspaceWindow[] }
+      export interface WorkspaceSession { name: string; window_count: number; main_checkout?: WorkspaceWindow[]; worktrees?: WorkspaceWindow[]; other?: WorkspaceWindow[] }
       export interface Workspace { host: string; sessions: WorkspaceSession[] }
       export async function fetchWorkspace(): Promise<Workspace>
       ```
+      (This superseded an earlier flat `windows: WorkspaceWindow[]` shape on
+      `WorkspaceSession` — see the mid-execute revision note near the top of
+      this plan for why. `useWorkspace` (Step 14) is unaffected: it only
+      fetches and polls an opaque `Workspace` blob, never inspects
+      `sessions[].*` itself.)
       `fetchWorkspace` throws on a non-2xx (the hook below is what turns that
       into a UI state) — same relative-URL, same-origin-cookie pattern
       `replyRun` already uses; no explicit `credentials` needed.
@@ -298,35 +405,46 @@ caller.
 ## C5 — the Workspace view
 
 Design it twice, on purpose (the task's own instruction) — nesting is real:
-session → window → pane is three levels, names run long (branch names,
-worktree paths), and this has to stay one-thumb usable.
+session → repo-bucket → window → pane is four levels now (the repo roll-up
+added one, mid-execute — see the revision note near the top of this plan),
+names run long (branch names, worktree paths), and this has to stay
+one-thumb usable.
 
-**Option A — collapsible accordion.** Sessions (and optionally windows)
-start collapsed; tapping a header expands it in place. Pro: with many
-sessions, a phone shows more at a glance by default. **Rejected**: this
-codebase has zero existing disclosure-widget precedent — no collapse state,
-no expand/collapse animation, no `aria-expanded` pattern anywhere in
-`ui/src/fleet/` — and Fleet/Crews have already trained the user on one
-interaction model, "scan a flat list under a section header, tap a card."
-Inventing a second interaction primitive on top of that for one tab is a
-second visual *and* interaction language, which the task explicitly forbids.
-It also doesn't earn its complexity at this data's actual scale — a personal
-dev machine carries a handful of tmux sessions, not hundreds — so the
-"more at a glance" win is close to zero in practice.
+**Option A — collapsible accordion.** Sessions (and optionally the
+main-checkout/worktrees buckets) start collapsed; tapping a header expands it
+in place. Pro: with many sessions, a phone shows more at a glance by default.
+**Rejected**: this codebase has zero existing disclosure-widget precedent —
+no collapse state, no expand/collapse animation, no `aria-expanded` pattern
+anywhere in `ui/src/fleet/` — and Fleet/Crews have already trained the user
+on one interaction model, "scan a flat list under a section header, tap a
+card." Inventing a second interaction primitive on top of that for one tab is
+a second visual *and* interaction language, which the task explicitly
+forbids. It also doesn't earn its complexity at this data's actual scale — a
+personal dev machine carries a handful of tmux sessions, not hundreds — so
+the "more at a glance" win is close to zero in practice. The dispatcher's own
+phrase for the `Worktrees` bucket, "collapsed under a count", means labelled
+and de-emphasised under one small header, **not** hidden behind a tap — the
+tab's whole purpose is that every pane stays reachable, and an accordion
+would put the worktree panes (often where the actual agent work lives) behind
+an extra gesture.
 
-**Option B — flat grouped scroll (chosen).** No collapse state at all.
-Sessions render as `.fleet-group`-style section headers (exact reuse of the
-class Fleet already uses for its host grouping — same visual weight, same
-place in the eye). Within a session, each window is a compact one-line
-sub-header (index/name, plus a branch chip and a crew-codename chip *only*
-when present, reusing `.run-chip`/`.run-chip.codename` verbatim). Panes render
-as a tight list of one-line rows under their window — `command` as the label,
-a small dot for `active`, and a tap target only when `pane.agent` (which by
-Step 6's construction always carries a `run_id` when true — a plain pane
-renders inert, same "affordance from capability, not from type" rule `Caps`
-already uses for runs). This is a pure scroll, costs zero new CSS interaction
-states, and is legible with long names because nothing needs to fit next to a
-disclosure triangle.
+**Option B — flat grouped scroll (chosen).** No collapse state at all, one
+extra nesting level over the original two-level design. Sessions render as
+`.fleet-group`-style section headers (exact reuse of the class Fleet already
+uses for its host grouping — same visual weight, same place in the eye),
+carrying the session name and `window_count`. Within a session, up to three
+repo-bucket sub-groups render in a fixed order — Main checkout, Worktrees
+(N), Other — each only when its window list is non-empty (a session with no
+worktree windows shows no `Worktrees` header at all, not an empty one).
+Within a bucket, each window is a compact one-line sub-header (index/name,
+plus a branch chip and a crew-codename chip *only* when present, reusing
+`.run-chip`/`.run-chip.codename` verbatim). Panes render as a tight list of
+one-line rows under their window — `command` as the label, a small dot for
+`active`, and a tap target only when `pane.agent` (which by Step 6's
+construction always carries a `run_id` when true — a plain pane renders
+inert, same "affordance from capability, not from type" rule `Caps` already
+uses for runs). Still a pure scroll, still zero new CSS interaction states —
+the extra level is a heavier section header, not a new gesture.
 
 - [ ] **Step 17: `ui/src/fleet/WorkspaceView.tsx`.** Props: `{ onOpen?: (runId: string) => void }`
       (deliberately takes a bare `run_id` string, not a `Run` — `WorkspaceView`
@@ -337,31 +455,47 @@ disclosure triangle.
       `Run[]` at all — correlation already happened server-side (C3), so this
       is the one place in `ui/src/fleet/` that does not consume `useRuns()`,
       and the file's top comment says why in one line, pointing at this plan.
-      Loading state before the first successful fetch; error state on
-      `error && !workspace` (an error *with* a prior workspace renders the
-      tree, stale, same instinct as Step 14); empty state when `sessions.length === 0`.
+      A small internal helper renders one `[label, windows]` bucket
+      (`("Main checkout", session.main_checkout)`, `("Worktrees (N)",
+      session.worktrees)` with `N = session.worktrees?.length ?? 0` baked into
+      the label, `("Other", session.other)`) and is called up to three times
+      per session, skipping any bucket whose list is empty/undefined — this
+      keeps the "only when non-empty" rule in one place instead of three
+      near-identical `{cond && …}` blocks. Loading state before the first
+      successful fetch; error state on `error && !workspace` (an error *with*
+      a prior workspace renders the tree, stale, same instinct as Step 14);
+      empty state when `sessions.length === 0`.
 - [ ] **Step 18: CSS.** New rules in `ui/src/fleet/fleet.css` (same file every
       other fleet view already extends — no second stylesheet): `.workspace`
-      (root, mirrors `.crews`/`.fleet`), `.ws-window` (window sub-header row),
-      `.ws-pane` (pane row, plain and inert by default), `.ws-pane.agent`
-      (tappable — cursor/hover per the existing `.run-card:active` scale-down
-      convention). Reuses `.fleet-group`, `.run-chip`, `.run-chip.codename`
-      unmodified.
+      (root, mirrors `.crews`/`.fleet`), `.ws-bucket` (the Main
+      checkout/Worktrees/Other sub-header, one visual step lighter than
+      `.fleet-group` so the session header stays the dominant grouping level),
+      `.ws-window` (window sub-header row), `.ws-pane` (pane row, plain and
+      inert by default), `.ws-pane.agent` (tappable — cursor/hover per the
+      existing `.run-card:active` scale-down convention). Reuses
+      `.fleet-group`, `.run-chip`, `.run-chip.codename` unmodified.
 - [ ] **Step 19: tests.** `WorkspaceView.test.tsx`, `vi.mock('./useWorkspace')`
       (the `RunDetail.test.tsx`/`TerminalPane.test.tsx` pattern of mocking the
       owning hook rather than the network) returning a fixed `Workspace`
       fixture per case — no interval to fake here, since the hook itself is
-      replaced wholesale. Fixture: two sessions; one window with a branch +
-      `crew_codename` holding one agent pane (`agent: true, run_id: "pane-1"`,
-      `command: "claude"`); a second, plain window holding two non-agent panes
-      that are otherwise distinguishable (different `id`/`command`, e.g. a
-      `"zsh"` pane and a `"vim"` pane, both `agent: false`, no `run_id`) —
-      assert via `container.querySelector('.ws-pane')` (the `CrewsView.test.tsx`
-      style) that clicking the agent pane calls `onOpen` with exactly
-      `"pane-1"`, and that clicking either plain pane does not call `onOpen`
-      at all. Session headers and the crew-codename chip get their own
-      assertions. Loading/error/empty states each get one case (mock the hook
-      to return each state directly).
+      replaced wholesale. Fixture: one session with `main_checkout` holding one
+      window with a branch + `crew_codename` and one agent pane
+      (`agent: true, run_id: "pane-1"`, `command: "claude"`); the same session's
+      `worktrees` holding a plain window with two non-agent panes that are
+      otherwise distinguishable (different `id`/`command`, e.g. a `"zsh"` pane
+      and a `"vim"` pane, both `agent: false`, no `run_id`); no `other` on this
+      session (asserts no `Other` bucket header renders at all) — plus a
+      *second* session whose only window has an empty `branch`/`GitRoot`
+      surfaced through `other` (asserts an `Other` header DOES render when the
+      data calls for it, closing the "only render when non-empty" claim from
+      both directions). Assert: the `Main checkout` and `Worktrees` bucket
+      headers render for session one with the right window under each (and the
+      worktree count in the `Worktrees` label matches); clicking the agent
+      pane's DOM element (via `container.querySelector('.ws-pane')`, the
+      `CrewsView.test.tsx` style) calls `onOpen` with exactly `"pane-1"`; and
+      clicking either plain pane does not call `onOpen` at all. Loading/error/
+      empty states each get one case (mock the hook to return each state
+      directly).
 - [ ] **Step 20: verify C5.** `npx tsc -b`, `npx eslint .`, `npx vitest run`.
 
 ## C6 — Shell wiring
@@ -391,8 +525,9 @@ disclosure triangle.
 - [ ] **Step 23: full gate.** Go build, vet, test; UI typecheck, lint, tests;
       `gofmt -l` clean on touched files.
 - [ ] **Step 24: bundle grep.** `npm run build`, then grep the built CSS for a
-      declaration of `.workspace`, `.ws-window`, `.ws-pane`, `.ws-pane.agent`,
-      and the built JS for the string `/api/workspace`. A passing build proves
+      declaration of `.workspace`, `.ws-bucket`, `.ws-window`, `.ws-pane`,
+      `.ws-pane.agent`, and the built JS for the string `/api/workspace`. A
+      passing build proves
       nothing here — the entire Mocha token file once shipped unimported
       behind a fully green build, lint, tests and an Opus review.
 - [ ] **Step 25: live before/after, if a tmux server is reachable in this

--- a/server/server.go
+++ b/server/server.go
@@ -97,8 +97,22 @@ type Server struct {
 	// no command ran, which no assertion about the response alone can prove.
 	replyRunner replyRunner
 
+	// wsRepos classifies a @git_root as a main checkout or a linked
+	// worktree for the Workspace tab's bucketing.
+	wsRepos mainCheckoutChecker
+	// wsTmux lists the raw window/pane options the Workspace tab joins
+	// against a run snapshot. Narrow enough to fake in tests.
+	wsTmux workspaceLister
+
 	auth  *authGate
 	hosts *hostGate
+}
+
+// workspaceLister is the tmux surface handleWorkspace needs — narrow enough
+// to fake in tests without shelling out to a real tmux server.
+type workspaceLister interface {
+	ListWindowOptions() ([]tmux.WindowOptions, error)
+	ListPaneOptions() ([]tmux.PaneOptions, error)
 }
 
 // FontController controls terminal font size.
@@ -151,6 +165,8 @@ func New(cfg Config) (*Server, error) {
 		lastActivity: make(map[string]time.Time),
 		hub:          hub.New(cfg.StatusDir, slog.Default()),
 		replyRunner:  execCrewReply,
+		wsRepos:      newRepoClassifier(),
+		wsTmux:       tmuxClient,
 	}
 
 	// Run the hub in the background. It watches <status-dir>/claude/ and the
@@ -247,6 +263,7 @@ func (s *Server) Handler() http.Handler {
 	apiMux.HandleFunc("/api/runs", s.handleRunsSnapshot)
 	apiMux.HandleFunc("/api/runs/stream", s.handleRunsStream)
 	apiMux.HandleFunc("POST /api/runs/{id}/reply", s.handleRunReply)
+	apiMux.HandleFunc("GET /api/workspace", s.handleWorkspace)
 	mux.Handle("/api/", s.auth.middleware(apiMux))
 
 	// The host gate wraps everything, including "/", so a rebound domain is

--- a/server/workspace.go
+++ b/server/workspace.go
@@ -1,0 +1,144 @@
+package server
+
+import (
+	"sort"
+
+	"github.com/noamsto/houston/runs"
+	"github.com/noamsto/houston/tmux"
+)
+
+type Workspace struct {
+	Host     string             `json:"host"` // "" means local; unset by anything built here — M2's seam
+	Sessions []WorkspaceSession `json:"sessions"`
+}
+
+type WorkspaceSession struct {
+	Name         string            `json:"name"`
+	WindowCount  int               `json:"window_count"`
+	MainCheckout []WorkspaceWindow `json:"main_checkout,omitempty"`
+	Worktrees    []WorkspaceWindow `json:"worktrees,omitempty"`
+	Other        []WorkspaceWindow `json:"other,omitempty"` // no @git_root — belongs to no repo, still reachable
+}
+
+type WorkspaceWindow struct {
+	Index        int             `json:"index"`
+	Name         string          `json:"name"`
+	Active       bool            `json:"active"`
+	Branch       string          `json:"branch,omitempty"`
+	Task         string          `json:"task,omitempty"`
+	CrewCodename string          `json:"crew_codename,omitempty"`
+	Panes        []WorkspacePane `json:"panes"`
+}
+
+type WorkspacePane struct {
+	ID      string `json:"id"` // "%307"
+	Index   int    `json:"index"`
+	Active  bool   `json:"active"`
+	Command string `json:"command"`          // #{pane_current_command}; the plain-pane label (spec: never the parser)
+	Agent   bool   `json:"agent"`            // a composed Run joined this pane id — see buildWorkspace
+	RunID   string `json:"run_id,omitempty"` // set whenever Agent is true; the two can never disagree
+}
+
+// windowGroup accumulates a matched window's own panes as buildWorkspace
+// walks the pane list once.
+type windowGroup struct {
+	win   tmux.WindowOptions
+	panes []tmux.PaneOptions
+}
+
+// buildWorkspace joins tmux's window/pane snapshot against the run registry's
+// own snapshot to shape the tree the Workspace tab renders. A pane whose
+// window was not listed is skipped, mirroring deltasFromTmux's own "the two
+// queries raced a window closing" handling.
+//
+// mainCheckouts[root] == true means that @git_root is a repo's main
+// checkout; false or an absent key means a linked worktree (including a root
+// whose git lookup failed — see workspace_repo.go's repoClassifier for why
+// "uncertain" reads as "not main"). buildWorkspace stays pure and
+// fixture-testable: it never performs the git call itself, only buckets by
+// the answers it's handed.
+func buildWorkspace(wins []tmux.WindowOptions, panes []tmux.PaneOptions, snap []runs.Run, mainCheckouts map[string]bool) Workspace {
+	paneToRun := make(map[string]string, len(snap))
+	for _, r := range snap {
+		if r.Tmux != nil {
+			paneToRun[r.Tmux.PaneID] = r.ID
+		}
+	}
+
+	byTarget := make(map[string]tmux.WindowOptions, len(wins))
+	for _, w := range wins {
+		byTarget[w.Target()] = w
+	}
+
+	groups := make(map[string]*windowGroup)
+	for _, p := range panes {
+		w, ok := byTarget[p.Target]
+		if !ok {
+			continue
+		}
+		g, exists := groups[p.Target]
+		if !exists {
+			g = &windowGroup{win: w}
+			groups[p.Target] = g
+		}
+		g.panes = append(g.panes, p)
+	}
+
+	sessions := make(map[string][]*windowGroup)
+	for _, g := range groups {
+		sessions[g.win.Session] = append(sessions[g.win.Session], g)
+	}
+
+	sessionNames := make([]string, 0, len(sessions))
+	for name := range sessions {
+		sessionNames = append(sessionNames, name)
+	}
+	sort.Strings(sessionNames)
+
+	ws := Workspace{Sessions: make([]WorkspaceSession, 0, len(sessionNames))}
+	for _, name := range sessionNames {
+		grps := sessions[name]
+		sort.Slice(grps, func(i, j int) bool { return grps[i].win.Window < grps[j].win.Window })
+
+		session := WorkspaceSession{Name: name, WindowCount: len(grps)}
+		for _, g := range grps {
+			sort.Slice(g.panes, func(i, j int) bool { return g.panes[i].Index < g.panes[j].Index })
+
+			wp := make([]WorkspacePane, 0, len(g.panes))
+			for _, p := range g.panes {
+				runID := paneToRun[p.PaneID]
+				wp = append(wp, WorkspacePane{
+					ID:      p.PaneID,
+					Index:   p.Index,
+					Active:  p.Active,
+					Command: p.Command,
+					Agent:   runID != "",
+					RunID:   runID,
+				})
+			}
+
+			win := WorkspaceWindow{
+				Index:        g.win.Window,
+				Name:         g.win.Name,
+				Active:       g.win.Active,
+				Branch:       g.win.Branch,
+				Task:         g.win.Task,
+				CrewCodename: g.win.CrewName,
+				Panes:        wp,
+			}
+
+			switch {
+			case g.win.GitRoot == "":
+				session.Other = append(session.Other, win)
+			case mainCheckouts[g.win.GitRoot]:
+				session.MainCheckout = append(session.MainCheckout, win)
+			default:
+				session.Worktrees = append(session.Worktrees, win)
+			}
+		}
+
+		ws.Sessions = append(ws.Sessions, session)
+	}
+
+	return ws
+}

--- a/server/workspace_handler.go
+++ b/server/workspace_handler.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"encoding/json"
+	"log/slog"
 	"net/http"
 )
 
@@ -18,11 +19,13 @@ func (s *Server) handleWorkspace(w http.ResponseWriter, _ *http.Request) {
 
 	wins, err := s.wsTmux.ListWindowOptions()
 	if err != nil {
+		slog.Error("workspace: list window options failed", "error", err)
 		http.Error(w, err.Error(), http.StatusBadGateway)
 		return
 	}
 	panes, err := s.wsTmux.ListPaneOptions()
 	if err != nil {
+		slog.Error("workspace: list pane options failed", "error", err)
 		http.Error(w, err.Error(), http.StatusBadGateway)
 		return
 	}

--- a/server/workspace_handler.go
+++ b/server/workspace_handler.go
@@ -1,0 +1,48 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// handleWorkspace returns the full tmux tree across every reachable session,
+// bucketed by repo (main checkout / worktree / no repo) and joined against
+// the run registry so agent panes carry their run_id.
+//
+//	GET /api/workspace → Workspace
+func (s *Server) handleWorkspace(w http.ResponseWriter, _ *http.Request) {
+	if s.runs == nil || s.wsTmux == nil || s.wsRepos == nil {
+		http.Error(w, "workspace not started", http.StatusServiceUnavailable)
+		return
+	}
+
+	wins, err := s.wsTmux.ListWindowOptions()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	panes, err := s.wsTmux.ListPaneOptions()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+
+	// isMainCheckout shells out to git, so ask it once per distinct root
+	// rather than once per window — repoClassifier already caches per root,
+	// but there's no reason to make redundant calls into that cache.
+	mainCheckouts := make(map[string]bool)
+	for _, win := range wins {
+		if win.GitRoot == "" {
+			continue
+		}
+		if _, ok := mainCheckouts[win.GitRoot]; ok {
+			continue
+		}
+		mainCheckouts[win.GitRoot] = s.wsRepos.isMainCheckout(win.GitRoot)
+	}
+
+	ws := buildWorkspace(wins, panes, s.runs.Snapshot(), mainCheckouts)
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(ws)
+}

--- a/server/workspace_handler_test.go
+++ b/server/workspace_handler_test.go
@@ -1,0 +1,156 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/noamsto/houston/runs"
+	"github.com/noamsto/houston/tmux"
+)
+
+// fakeWorkspaceLister satisfies workspaceLister without shelling out to tmux.
+type fakeWorkspaceLister struct {
+	wins    []tmux.WindowOptions
+	panes   []tmux.PaneOptions
+	winErr  error
+	paneErr error
+}
+
+func (f *fakeWorkspaceLister) ListWindowOptions() ([]tmux.WindowOptions, error) {
+	return f.wins, f.winErr
+}
+
+func (f *fakeWorkspaceLister) ListPaneOptions() ([]tmux.PaneOptions, error) {
+	return f.panes, f.paneErr
+}
+
+// fakeRepoClassifier satisfies mainCheckoutChecker with a canned answer per
+// root — no real git call, that belongs to workspace_repo_test.go.
+type fakeRepoClassifier struct {
+	main map[string]bool
+}
+
+func (f *fakeRepoClassifier) isMainCheckout(root string) bool { return f.main[root] }
+
+func TestHandleWorkspaceWithoutRegistryIs503(t *testing.T) {
+	s := &Server{} // registry never started
+	rec := httptest.NewRecorder()
+	s.handleWorkspace(rec, httptest.NewRequest("GET", "/api/workspace", nil))
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status %d, want 503", rec.Code)
+	}
+}
+
+func TestHandleWorkspaceWithoutTmuxOrReposIs503(t *testing.T) {
+	reg := runs.NewRegistry(runs.DefaultOrder)
+
+	cases := []struct {
+		name string
+		s    *Server
+	}{
+		{"no wsTmux", &Server{runs: reg, wsRepos: &fakeRepoClassifier{}}},
+		{"no wsRepos", &Server{runs: reg, wsTmux: &fakeWorkspaceLister{}}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			tc.s.handleWorkspace(rec, httptest.NewRequest("GET", "/api/workspace", nil))
+
+			if rec.Code != http.StatusServiceUnavailable {
+				t.Fatalf("status %d, want 503", rec.Code)
+			}
+		})
+	}
+}
+
+func TestHandleWorkspaceJoinsRunAndBuckets(t *testing.T) {
+	reg := runs.NewRegistry(runs.DefaultOrder)
+	reg.Apply(runs.Delta{
+		Source: "tmux",
+		Key:    "%1",
+		Run: runs.Run{
+			Agent: "claude",
+			Tmux:  &runs.TmuxRef{Session: "houston", Window: 0, PaneID: "%1"},
+		},
+	})
+
+	s := &Server{
+		runs: reg,
+		wsTmux: &fakeWorkspaceLister{
+			wins: []tmux.WindowOptions{
+				{Session: "houston", Window: 0, Name: "win0", Active: true, GitRoot: "/repo/main"},
+			},
+			panes: []tmux.PaneOptions{
+				{PaneID: "%1", Target: "houston:0", Command: "node", Index: 0, Active: true},
+			},
+		},
+		wsRepos: &fakeRepoClassifier{main: map[string]bool{"/repo/main": true}},
+	}
+
+	rec := httptest.NewRecorder()
+	s.handleWorkspace(rec, httptest.NewRequest("GET", "/api/workspace", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d, want 200 — body %s", rec.Code, rec.Body.String())
+	}
+
+	var got Workspace
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v — body %s", err, rec.Body.String())
+	}
+
+	if len(got.Sessions) != 1 {
+		t.Fatalf("got %d sessions, want 1: %+v", len(got.Sessions), got)
+	}
+	session := got.Sessions[0]
+	if len(session.MainCheckout) != 1 || len(session.Worktrees) != 0 || len(session.Other) != 0 {
+		t.Fatalf("got session %+v, want exactly one window in main_checkout", session)
+	}
+
+	panes := session.MainCheckout[0].Panes
+	if len(panes) != 1 {
+		t.Fatalf("got %d panes, want 1: %+v", len(panes), panes)
+	}
+	if !panes[0].Agent || panes[0].RunID != "pane-1" {
+		t.Fatalf("got pane %+v, want agent=true run_id=pane-1", panes[0])
+	}
+}
+
+func TestHandleWorkspaceTmuxErrorIs502(t *testing.T) {
+	reg := runs.NewRegistry(runs.DefaultOrder)
+	s := &Server{
+		runs:    reg,
+		wsTmux:  &fakeWorkspaceLister{winErr: errors.New("no server running on socket")},
+		wsRepos: &fakeRepoClassifier{},
+	}
+
+	rec := httptest.NewRecorder()
+	s.handleWorkspace(rec, httptest.NewRequest("GET", "/api/workspace", nil))
+
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status %d, want 502", rec.Code)
+	}
+}
+
+func TestWorkspaceRouteIsBehindTheAuthGate(t *testing.T) {
+	// A new route registered outside apiMux would reopen the hole closed in #4.
+	dir := t.TempDir()
+	s, err := New(Config{StatusDir: dir, AuthEnabled: true})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "http://127.0.0.1/api/workspace", nil)
+	req.Host = "127.0.0.1"
+	rec := httptest.NewRecorder()
+	s.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status %d, want 401 — /api/workspace must require a token", rec.Code)
+	}
+}

--- a/server/workspace_repo.go
+++ b/server/workspace_repo.go
@@ -1,0 +1,80 @@
+package server
+
+import (
+	"context"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// mainCheckoutChecker answers whether a @git_root is a repo's main checkout,
+// as opposed to a linked worktree. Narrow enough to fake in tests.
+type mainCheckoutChecker interface {
+	isMainCheckout(root string) bool
+}
+
+// repoClassifierTimeout bounds the git call below so a hung git cannot park
+// a request forever. Mirrors runs/crewsource.go's crewDirTimeout.
+const repoClassifierTimeout = 5 * time.Second
+
+// repoClassifier answers isMainCheckout by shelling out to git once per
+// distinct root and caching the result for the process lifetime — the same
+// "cache negative results too" trade-off runs/crewsource.go's crewDir
+// already accepted, but keyed and owned by the HTTP handler rather than a
+// ticking source.
+type repoClassifier struct {
+	mu    sync.Mutex
+	cache map[string]bool
+
+	// commonDir resolves root's git-common-dir. A field, not a direct
+	// exec.CommandContext call, so a test can wrap it to count invocations
+	// and prove the cache actually prevents a second shell-out.
+	commonDir func(root string) (string, error)
+}
+
+func newRepoClassifier() *repoClassifier {
+	return &repoClassifier{cache: make(map[string]bool), commonDir: gitCommonDir}
+}
+
+func gitCommonDir(root string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), repoClassifierTimeout)
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, "git", "-C", root, "rev-parse", "--path-format=absolute", "--git-common-dir").Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// isMainCheckout is true iff root's own .git is a direct child of root — a
+// linked worktree's common dir resolves to the original repo's .git,
+// somewhere else entirely. An error (git missing, root no longer exists)
+// caches false rather than asserting "main" on uncertain information.
+func (c *repoClassifier) isMainCheckout(root string) bool {
+	c.mu.Lock()
+	if v, ok := c.cache[root]; ok {
+		c.mu.Unlock()
+		return v
+	}
+	c.mu.Unlock()
+
+	v := c.classify(root)
+
+	c.mu.Lock()
+	c.cache[root] = v
+	c.mu.Unlock()
+
+	return v
+}
+
+func (c *repoClassifier) classify(root string) bool {
+	commonDir, err := c.commonDir(root)
+	if err != nil {
+		return false
+	}
+
+	return filepath.Dir(commonDir) == root
+}

--- a/server/workspace_repo.go
+++ b/server/workspace_repo.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"log/slog"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -52,7 +53,8 @@ func gitCommonDir(root string) (string, error) {
 // isMainCheckout is true iff root's own .git is a direct child of root — a
 // linked worktree's common dir resolves to the original repo's .git,
 // somewhere else entirely. An error (git missing, root no longer exists)
-// caches false rather than asserting "main" on uncertain information.
+// returns false WITHOUT caching it, so a transient failure gets retried on
+// the next call instead of wedging root into the wrong bucket forever.
 func (c *repoClassifier) isMainCheckout(root string) bool {
 	c.mu.Lock()
 	if v, ok := c.cache[root]; ok {
@@ -61,7 +63,10 @@ func (c *repoClassifier) isMainCheckout(root string) bool {
 	}
 	c.mu.Unlock()
 
-	v := c.classify(root)
+	v, err := c.classify(root)
+	if err != nil {
+		return false
+	}
 
 	c.mu.Lock()
 	c.cache[root] = v
@@ -70,11 +75,12 @@ func (c *repoClassifier) isMainCheckout(root string) bool {
 	return v
 }
 
-func (c *repoClassifier) classify(root string) bool {
+func (c *repoClassifier) classify(root string) (bool, error) {
 	commonDir, err := c.commonDir(root)
 	if err != nil {
-		return false
+		slog.Warn("workspace: git classify failed", "root", root, "error", err)
+		return false, err
 	}
 
-	return filepath.Dir(commonDir) == root
+	return filepath.Dir(commonDir) == root, nil
 }

--- a/server/workspace_repo_test.go
+++ b/server/workspace_repo_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"errors"
 	"os/exec"
 	"testing"
 )
@@ -67,5 +68,28 @@ func TestRepoClassifier_CachesAfterFirstCall(t *testing.T) {
 	}
 	if calls != 1 {
 		t.Errorf("calls after second isMainCheckout = %d, want 1 (cached, no re-shell-out)", calls)
+	}
+}
+
+func TestRepoClassifier_DoesNotCacheOnClassifyError(t *testing.T) {
+	c := newRepoClassifier()
+	calls := 0
+	c.commonDir = func(root string) (string, error) {
+		calls++
+		return "", errors.New("git not found")
+	}
+
+	if c.isMainCheckout("/some/root") {
+		t.Fatalf("first call: isMainCheckout = true, want false on classify error")
+	}
+	if calls != 1 {
+		t.Fatalf("calls after first isMainCheckout = %d, want 1", calls)
+	}
+
+	if c.isMainCheckout("/some/root") {
+		t.Fatalf("second call: isMainCheckout = true, want false on classify error")
+	}
+	if calls != 2 {
+		t.Errorf("calls after second isMainCheckout = %d, want 2 (not cached, retries on error)", calls)
 	}
 }

--- a/server/workspace_repo_test.go
+++ b/server/workspace_repo_test.go
@@ -9,12 +9,10 @@ import (
 
 // runGit runs a git command in dir and fails the test on error, mirroring
 // the setup shape tmux/client_test.go's own worktree fixtures use. HOME and
-// XDG_CONFIG_HOME are pinned to an empty per-test directory (git falls back
-// to $XDG_CONFIG_HOME/git/config for global config when it's set, bypassing
-// a HOME override alone) and the author/committer identity is injected via
-// env, so the commit doesn't depend on the runner having a global git
-// identity — or any other global gitconfig, e.g. commit.gpgsign — configured.
-// See ec46684 for the same fix applied to the host allowlist.
+// XDG_CONFIG_HOME are both pinned to an empty per-test dir — git reads
+// global config from $XDG_CONFIG_HOME/git/config when that's set, so a HOME
+// override alone doesn't isolate it — and the commit identity is injected
+// via env, leaving the commit with no dependency on ambient gitconfig.
 func runGit(t *testing.T, dir string, args ...string) {
 	t.Helper()
 	home := t.TempDir()

--- a/server/workspace_repo_test.go
+++ b/server/workspace_repo_test.go
@@ -1,0 +1,71 @@
+package server
+
+import (
+	"os/exec"
+	"testing"
+)
+
+// runGit runs a git command in dir and fails the test on error, mirroring
+// the setup shape tmux/client_test.go's own worktree fixtures use.
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+func TestRepoClassifier_MainCheckoutAndWorktree(t *testing.T) {
+	mainDir := t.TempDir()
+	runGit(t, mainDir, "init", "-q", "-b", "main")
+	runGit(t, mainDir, "commit", "-q", "--allow-empty", "-m", "init")
+
+	wtDir := t.TempDir()
+	runGit(t, mainDir, "worktree", "add", "-q", "-b", "feature", wtDir)
+
+	c := newRepoClassifier()
+
+	if !c.isMainCheckout(mainDir) {
+		t.Errorf("isMainCheckout(%q) = false, want true for the main checkout", mainDir)
+	}
+	if c.isMainCheckout(wtDir) {
+		t.Errorf("isMainCheckout(%q) = true, want false for a linked worktree", wtDir)
+	}
+}
+
+func TestRepoClassifier_NonexistentPath(t *testing.T) {
+	c := newRepoClassifier()
+
+	if c.isMainCheckout("/nonexistent/path/does/not/exist") {
+		t.Error("isMainCheckout on a nonexistent path = true, want false")
+	}
+}
+
+func TestRepoClassifier_CachesAfterFirstCall(t *testing.T) {
+	mainDir := t.TempDir()
+	runGit(t, mainDir, "init", "-q", "-b", "main")
+	runGit(t, mainDir, "commit", "-q", "--allow-empty", "-m", "init")
+
+	c := newRepoClassifier()
+	calls := 0
+	real := c.commonDir
+	c.commonDir = func(root string) (string, error) {
+		calls++
+		return real(root)
+	}
+
+	if !c.isMainCheckout(mainDir) {
+		t.Fatalf("first call: isMainCheckout(%q) = false, want true", mainDir)
+	}
+	if calls != 1 {
+		t.Fatalf("calls after first isMainCheckout = %d, want 1", calls)
+	}
+
+	if !c.isMainCheckout(mainDir) {
+		t.Fatalf("second call: isMainCheckout(%q) = false, want true", mainDir)
+	}
+	if calls != 1 {
+		t.Errorf("calls after second isMainCheckout = %d, want 1 (cached, no re-shell-out)", calls)
+	}
+}

--- a/server/workspace_repo_test.go
+++ b/server/workspace_repo_test.go
@@ -2,16 +2,33 @@ package server
 
 import (
 	"errors"
+	"os"
 	"os/exec"
 	"testing"
 )
 
 // runGit runs a git command in dir and fails the test on error, mirroring
-// the setup shape tmux/client_test.go's own worktree fixtures use.
+// the setup shape tmux/client_test.go's own worktree fixtures use. HOME and
+// XDG_CONFIG_HOME are pinned to an empty per-test directory (git falls back
+// to $XDG_CONFIG_HOME/git/config for global config when it's set, bypassing
+// a HOME override alone) and the author/committer identity is injected via
+// env, so the commit doesn't depend on the runner having a global git
+// identity — or any other global gitconfig, e.g. commit.gpgsign — configured.
+// See ec46684 for the same fix applied to the host allowlist.
 func runGit(t *testing.T, dir string, args ...string) {
 	t.Helper()
+	home := t.TempDir()
 	cmd := exec.Command("git", args...)
 	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"HOME="+home,
+		"XDG_CONFIG_HOME="+home,
+		"GIT_CONFIG_NOSYSTEM=1",
+		"GIT_AUTHOR_NAME=test",
+		"GIT_AUTHOR_EMAIL=test@example.com",
+		"GIT_COMMITTER_NAME=test",
+		"GIT_COMMITTER_EMAIL=test@example.com",
+	)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("git %v: %v\n%s", args, err, out)
 	}

--- a/server/workspace_test.go
+++ b/server/workspace_test.go
@@ -1,0 +1,199 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/noamsto/houston/runs"
+	"github.com/noamsto/houston/tmux"
+)
+
+func TestBuildWorkspace_PlainPaneNoRun(t *testing.T) {
+	wins := []tmux.WindowOptions{
+		{Session: "main", Window: 0, Name: "shell", Active: true},
+	}
+	panes := []tmux.PaneOptions{
+		{PaneID: "%1", Target: "main:0", ClaudeStatus: "", Index: 0},
+	}
+
+	ws := buildWorkspace(wins, panes, nil, nil)
+
+	if len(ws.Sessions) != 1 || len(ws.Sessions[0].Other) != 1 || len(ws.Sessions[0].Other[0].Panes) != 1 {
+		t.Fatalf("unexpected shape: %+v", ws)
+	}
+	p := ws.Sessions[0].Other[0].Panes[0]
+	if p.Agent {
+		t.Errorf("Agent = true, want false for plain pane with no matching run")
+	}
+	if p.RunID != "" {
+		t.Errorf("RunID = %q, want empty", p.RunID)
+	}
+}
+
+func TestBuildWorkspace_OrdinaryEnrichedAgentPane(t *testing.T) {
+	wins := []tmux.WindowOptions{
+		{Session: "main", Window: 0, Branch: "feat/x", CrewName: "falcon", Name: "agent", Active: true},
+	}
+	panes := []tmux.PaneOptions{
+		{PaneID: "%2", Target: "main:0", ClaudeStatus: "working", Index: 0},
+	}
+	snap := []runs.Run{
+		{ID: "run-1", Tmux: &runs.TmuxRef{Session: "main", Window: 0, PaneID: "%2"}},
+	}
+
+	ws := buildWorkspace(wins, panes, snap, nil)
+
+	w := ws.Sessions[0].Other[0]
+	if w.Branch != "feat/x" || w.CrewCodename != "falcon" {
+		t.Errorf("window fields not carried through: %+v", w)
+	}
+	p := w.Panes[0]
+	if !p.Agent {
+		t.Errorf("Agent = false, want true for pane joined to a run")
+	}
+	if p.RunID != "run-1" {
+		t.Errorf("RunID = %q, want run-1", p.RunID)
+	}
+}
+
+func TestBuildWorkspace_HookOnlyAgentPane(t *testing.T) {
+	// ClaudeStatus is empty (lazytmux never touched this pane), yet the pane
+	// id matches a Run the registry composed via HookSource — Agent must
+	// still read true, since it's derived from RunID, not ClaudeStatus.
+	wins := []tmux.WindowOptions{
+		{Session: "main", Window: 0, Name: "hook-agent", Active: true},
+	}
+	panes := []tmux.PaneOptions{
+		{PaneID: "%3", Target: "main:0", ClaudeStatus: "", Index: 0},
+	}
+	snap := []runs.Run{
+		{ID: "run-2", Tmux: &runs.TmuxRef{Session: "main", Window: 0, PaneID: "%3"}},
+	}
+
+	ws := buildWorkspace(wins, panes, snap, nil)
+
+	p := ws.Sessions[0].Other[0].Panes[0]
+	if !p.Agent {
+		t.Errorf("Agent = false, want true for hook-only composed run (ClaudeStatus empty)")
+	}
+	if p.RunID != "run-2" {
+		t.Errorf("RunID = %q, want run-2", p.RunID)
+	}
+}
+
+func TestBuildWorkspace_ClaudeStatusWithNoJoinedRun(t *testing.T) {
+	// Mirror case: lazytmux opinion alone, with no composed run in snap,
+	// must not make the pane routable.
+	wins := []tmux.WindowOptions{
+		{Session: "main", Window: 0, Name: "orphaned", Active: true},
+	}
+	panes := []tmux.PaneOptions{
+		{PaneID: "%4", Target: "main:0", ClaudeStatus: "working", Index: 0},
+	}
+
+	ws := buildWorkspace(wins, panes, nil, nil)
+
+	p := ws.Sessions[0].Other[0].Panes[0]
+	if p.Agent {
+		t.Errorf("Agent = true, want false when no run joined this pane id")
+	}
+	if p.RunID != "" {
+		t.Errorf("RunID = %q, want empty", p.RunID)
+	}
+}
+
+func TestBuildWorkspace_PaneWithMissingWindowSkipped(t *testing.T) {
+	wins := []tmux.WindowOptions{
+		{Session: "main", Window: 0, Name: "kept", Active: true},
+	}
+	panes := []tmux.PaneOptions{
+		{PaneID: "%5", Target: "main:0", Index: 0},
+		{PaneID: "%6", Target: "main:1", Index: 0}, // window 1 never listed
+	}
+
+	ws := buildWorkspace(wins, panes, nil, nil)
+
+	if len(ws.Sessions) != 1 || len(ws.Sessions[0].Other) != 1 {
+		t.Fatalf("unexpected session/window shape: %+v", ws)
+	}
+	panesOut := ws.Sessions[0].Other[0].Panes
+	if len(panesOut) != 1 || panesOut[0].ID != "%5" {
+		t.Errorf("panes = %+v, want only %%5", panesOut)
+	}
+}
+
+func TestBuildWorkspace_Ordering(t *testing.T) {
+	wins := []tmux.WindowOptions{
+		{Session: "zeta", Window: 0, Name: "z0"},
+		{Session: "alpha", Window: 1, Name: "a1"},
+		{Session: "alpha", Window: 0, Name: "a0"},
+	}
+	panes := []tmux.PaneOptions{
+		{PaneID: "%20", Target: "zeta:0", Index: 0},
+		{PaneID: "%21", Target: "alpha:1", Index: 0},
+		{PaneID: "%12", Target: "alpha:0", Index: 2},
+		{PaneID: "%10", Target: "alpha:0", Index: 0},
+		{PaneID: "%11", Target: "alpha:0", Index: 1},
+	}
+
+	ws := buildWorkspace(wins, panes, nil, nil)
+
+	if len(ws.Sessions) != 2 || ws.Sessions[0].Name != "alpha" || ws.Sessions[1].Name != "zeta" {
+		t.Fatalf("sessions not sorted by name: %+v", ws.Sessions)
+	}
+	alphaWindows := ws.Sessions[0].Other
+	if len(alphaWindows) != 2 || alphaWindows[0].Index != 0 || alphaWindows[1].Index != 1 {
+		t.Fatalf("windows not sorted by index: %+v", alphaWindows)
+	}
+	panesOut := alphaWindows[0].Panes
+	if len(panesOut) != 3 || panesOut[0].ID != "%10" || panesOut[1].ID != "%11" || panesOut[2].ID != "%12" {
+		t.Fatalf("panes not sorted by index: %+v", panesOut)
+	}
+}
+
+// TestBuildWorkspace_Bucketing pins the MainCheckout/Worktrees/Other split:
+// one session, four windows sharing the session name, each landing in a
+// different bucket for a different reason — including the "GitRoot present
+// but absent from mainCheckouts" case, which must read the same as an
+// explicit false, not as "unknown, skip it."
+func TestBuildWorkspace_Bucketing(t *testing.T) {
+	wins := []tmux.WindowOptions{
+		{Session: "s", Window: 0, Name: "main-checkout", GitRoot: "/repo/main"},
+		{Session: "s", Window: 1, Name: "worktree-explicit-false", GitRoot: "/repo/wt1"},
+		{Session: "s", Window: 2, Name: "no-repo", GitRoot: ""},
+		{Session: "s", Window: 3, Name: "worktree-absent-key", GitRoot: "/repo/wt2"},
+	}
+	panes := []tmux.PaneOptions{
+		{PaneID: "%30", Target: "s:0", Index: 0},
+		{PaneID: "%31", Target: "s:1", Index: 0},
+		{PaneID: "%32", Target: "s:2", Index: 0},
+		{PaneID: "%33", Target: "s:3", Index: 0},
+	}
+	mainCheckouts := map[string]bool{
+		"/repo/main": true,
+		"/repo/wt1":  false,
+		// "/repo/wt2" intentionally absent — must still bucket as Worktrees.
+	}
+
+	ws := buildWorkspace(wins, panes, nil, mainCheckouts)
+
+	if len(ws.Sessions) != 1 {
+		t.Fatalf("unexpected session count: %+v", ws.Sessions)
+	}
+	s := ws.Sessions[0]
+
+	if s.WindowCount != 4 {
+		t.Errorf("WindowCount = %d, want 4 regardless of bucket", s.WindowCount)
+	}
+	if len(s.MainCheckout) != 1 || s.MainCheckout[0].Name != "main-checkout" {
+		t.Errorf("MainCheckout = %+v, want just main-checkout", s.MainCheckout)
+	}
+	if len(s.Worktrees) != 2 {
+		t.Fatalf("Worktrees = %+v, want 2 (explicit false + absent key)", s.Worktrees)
+	}
+	if s.Worktrees[0].Name != "worktree-explicit-false" || s.Worktrees[1].Name != "worktree-absent-key" {
+		t.Errorf("Worktrees = %+v, want [worktree-explicit-false, worktree-absent-key] in window-index order", s.Worktrees)
+	}
+	if len(s.Other) != 1 || s.Other[0].Name != "no-repo" {
+		t.Errorf("Other = %+v, want just no-repo", s.Other)
+	}
+}

--- a/tmux/options.go
+++ b/tmux/options.go
@@ -1,6 +1,7 @@
 package tmux
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 )
@@ -15,9 +16,10 @@ const optSep = "\x1f"
 // tmux resolves #{@name} inline, so no per-window show-options loop is needed.
 const windowOptionsFormat = "#{session_name}" + optSep + "#{window_index}" + optSep + "#{@branch}" + optSep + "#{@issue_id}" + optSep +
 	"#{@pr_number}" + optSep + "#{@crew_name}" + optSep + "#{@pr_state}" + optSep + "#{@pr_check_state}" + optSep + "#{@pr_mergeable}" + optSep +
-	"#{@window_task}" + optSep + "#{@git_root}" + optSep + "#{@crew_color}"
+	"#{@window_task}" + optSep + "#{@git_root}" + optSep + "#{@crew_color}" + optSep + "#{window_name}" + optSep + "#{window_active}"
 
-const paneOptionsFormat = "#{pane_id}" + optSep + "#{session_name}:#{window_index}" + optSep + "#{@claude_status}" + optSep + "#{@claude_task}"
+const paneOptionsFormat = "#{pane_id}" + optSep + "#{session_name}:#{window_index}" + optSep + "#{@claude_status}" + optSep + "#{@claude_task}" + optSep +
+	"#{pane_current_command}" + optSep + "#{pane_index}" + optSep + "#{pane_active}"
 
 // WindowOptions is lazytmux's per-window enrichment. Every field may be empty:
 // a window with no linked issue or PR simply has none.
@@ -34,6 +36,15 @@ type WindowOptions struct {
 	Task         string
 	GitRoot      string
 	CrewColor    string
+	Name         string // #{window_name}
+	Active       bool   // #{window_active}
+}
+
+// Target is the "session:window" join key PaneOptions.Target already carries
+// verbatim. Exists so callers outside this package don't hand-duplicate this
+// string build a second time.
+func (w WindowOptions) Target() string {
+	return fmt.Sprintf("%s:%d", w.Session, w.Window)
 }
 
 type PaneOptions struct {
@@ -41,6 +52,9 @@ type PaneOptions struct {
 	Target       string // "session:window"
 	ClaudeStatus string
 	ClaudeTask   string
+	Command      string // #{pane_current_command}
+	Index        int    // #{pane_index}
+	Active       bool   // #{pane_active}
 }
 
 func (c *Client) ListWindowOptions() ([]WindowOptions, error) {
@@ -63,7 +77,7 @@ func ParseWindowOptions(out string) []WindowOptions {
 	var res []WindowOptions
 	for _, line := range strings.Split(out, "\n") {
 		f := strings.Split(line, optSep)
-		if len(f) != 12 {
+		if len(f) != 14 {
 			continue
 		}
 		idx, err := strconv.Atoi(f[1])
@@ -74,6 +88,7 @@ func ParseWindowOptions(out string) []WindowOptions {
 			Session: f[0], Window: idx, Branch: f[2], IssueID: f[3],
 			PRNumber: f[4], CrewName: f[5], PRState: f[6], PRCheckState: f[7],
 			PRMergeable: f[8], Task: f[9], GitRoot: f[10], CrewColor: f[11],
+			Name: f[12], Active: f[13] == "1",
 		})
 	}
 	return res
@@ -83,11 +98,16 @@ func ParsePaneOptions(out string) []PaneOptions {
 	var res []PaneOptions
 	for _, line := range strings.Split(out, "\n") {
 		f := strings.Split(line, optSep)
-		if len(f) != 4 {
+		if len(f) != 7 {
+			continue
+		}
+		idx, err := strconv.Atoi(f[5])
+		if err != nil {
 			continue
 		}
 		res = append(res, PaneOptions{
 			PaneID: f[0], Target: f[1], ClaudeStatus: f[2], ClaudeTask: f[3],
+			Command: f[4], Index: idx, Active: f[6] == "1",
 		})
 	}
 	return res

--- a/tmux/options_test.go
+++ b/tmux/options_test.go
@@ -4,8 +4,8 @@ import "testing"
 
 func TestParseWindowOptions(t *testing.T) {
 	// Real output shape, including the common all-empty-options case.
-	out := "lazytmux\x1f2\x1ffeat/320-relay\x1f#320\x1f565\x1fmauve\x1fopen\x1fpassing\x1fMERGEABLE\x1f\x1f\x1fcolour168\n" +
-		"houston\x1f1\x1fmain\x1f\x1f\x1f\x1f\x1f\x1f\x1f\x1f\x1f\n"
+	out := "lazytmux\x1f2\x1ffeat/320-relay\x1f#320\x1f565\x1fmauve\x1fopen\x1fpassing\x1fMERGEABLE\x1f\x1f\x1fcolour168\x1frelay\x1f1\n" +
+		"houston\x1f1\x1fmain\x1f\x1f\x1f\x1f\x1f\x1f\x1f\x1f\x1f\x1fhouston\x1f0\n"
 
 	got := ParseWindowOptions(out)
 	if len(got) != 2 {
@@ -25,15 +25,21 @@ func TestParseWindowOptions(t *testing.T) {
 	if w.CrewColor != "colour168" {
 		t.Errorf("CrewColor = %q, want colour168", w.CrewColor)
 	}
+	if w.Name != "relay" || !w.Active {
+		t.Errorf("got name=%q active=%v, want relay/true", w.Name, w.Active)
+	}
 
 	bare := got[1]
 	if bare.Branch != "main" || bare.IssueID != "" || bare.PRNumber != "" {
 		t.Errorf("a window with no enrichment should carry only its branch, got %+v", bare)
 	}
+	if bare.Name != "houston" || bare.Active {
+		t.Errorf("got name=%q active=%v, want houston/false", bare.Name, bare.Active)
+	}
 }
 
 func TestParseWindowOptionsSkipsMalformedLines(t *testing.T) {
-	got := ParseWindowOptions("too\x1ffew\x1ffields\n\nhouston\x1f1\x1fmain\x1f\x1f\x1f\x1f\x1f\x1f\x1f\x1f\x1f\n")
+	got := ParseWindowOptions("too\x1ffew\x1ffields\n\nhouston\x1f1\x1fmain\x1f\x1f\x1f\x1f\x1f\x1f\x1f\x1f\x1f\x1fhouston\x1f0\n")
 	if len(got) != 1 {
 		t.Fatalf("%d windows, want 1 — short and empty lines are skipped, not fatal", len(got))
 	}
@@ -43,7 +49,7 @@ func TestParseWindowOptionsSurvivesPipeInFreeText(t *testing.T) {
 	// @window_task is free text captured from a user prompt, so it can contain
 	// anything. With a "|" delimiter this shifted GitRoot into garbage and
 	// silently dropped the real value.
-	out := "houston\x1f1\x1fmain\x1f\x1f\x1f\x1f\x1f\x1f\x1frun x | grep fail\x1f/home/n/git/houston\x1f\n"
+	out := "houston\x1f1\x1fmain\x1f\x1f\x1f\x1f\x1f\x1f\x1frun x | grep fail\x1f/home/n/git/houston\x1f\x1fhouston\x1f0\n"
 
 	got := ParseWindowOptions(out)
 	if len(got) != 1 {
@@ -58,8 +64,8 @@ func TestParseWindowOptionsSurvivesPipeInFreeText(t *testing.T) {
 }
 
 func TestParsePaneOptions(t *testing.T) {
-	out := "%307\x1fhouston:1\x1fprocessing 1788848628 \x1fand add a ci task\n" +
-		"%283\x1fdispatcher:1\x1f\x1f\n"
+	out := "%307\x1fhouston:1\x1fprocessing 1788848628 \x1fand add a ci task\x1fnode\x1f0\x1f1\n" +
+		"%283\x1fdispatcher:1\x1f\x1f\x1fbash\x1f1\x1f0\n"
 
 	got := ParsePaneOptions(out)
 	if len(got) != 2 {
@@ -71,7 +77,13 @@ func TestParsePaneOptions(t *testing.T) {
 	if got[0].ClaudeTask != "and add a ci task" {
 		t.Errorf("task = %q", got[0].ClaudeTask)
 	}
+	if got[0].Command != "node" || got[0].Index != 0 || !got[0].Active {
+		t.Errorf("got command=%q index=%d active=%v, want node/0/true", got[0].Command, got[0].Index, got[0].Active)
+	}
 	if got[1].ClaudeStatus != "" {
 		t.Errorf("a pane with no claude status should be empty, got %q", got[1].ClaudeStatus)
+	}
+	if got[1].Command != "bash" || got[1].Index != 1 || got[1].Active {
+		t.Errorf("got command=%q index=%d active=%v, want bash/1/false", got[1].Command, got[1].Index, got[1].Active)
 	}
 }

--- a/ui/src/api/workspace.ts
+++ b/ui/src/api/workspace.ts
@@ -1,12 +1,9 @@
-// Mirror of server/workspace.go's Workspace contract (I2).
-export interface WorkspacePane {
-  id: string
-  index: number
-  active: boolean
-  command: string
-  agent: boolean
-  run_id?: string
-}
+// Mirror of server/workspace.go's Workspace contract (I2). A discriminated
+// union on `agent` so the type system enforces what the Go server
+// guarantees: an agent pane always carries a run_id.
+export type WorkspacePane =
+  | { id: string; index: number; active: boolean; command: string; agent: true; run_id: string }
+  | { id: string; index: number; active: boolean; command: string; agent: false; run_id?: undefined }
 
 export interface WorkspaceWindow {
   index: number

--- a/ui/src/api/workspace.ts
+++ b/ui/src/api/workspace.ts
@@ -1,6 +1,6 @@
-// Mirror of server/workspace.go's Workspace contract (I2). A discriminated
-// union on `agent` so the type system enforces what the Go server
-// guarantees: an agent pane always carries a run_id.
+// Mirror of server/workspace.go's Workspace contract. A discriminated union
+// on `agent` so the type system enforces what the Go server guarantees: an
+// agent pane always carries a run_id.
 export type WorkspacePane =
   | { id: string; index: number; active: boolean; command: string; agent: true; run_id: string }
   | { id: string; index: number; active: boolean; command: string; agent: false; run_id?: undefined }

--- a/ui/src/api/workspace.ts
+++ b/ui/src/api/workspace.ts
@@ -1,0 +1,40 @@
+// Mirror of server/workspace.go's Workspace contract (I2).
+export interface WorkspacePane {
+  id: string
+  index: number
+  active: boolean
+  command: string
+  agent: boolean
+  run_id?: string
+}
+
+export interface WorkspaceWindow {
+  index: number
+  name: string
+  active: boolean
+  branch?: string
+  task?: string
+  crew_codename?: string
+  panes: WorkspacePane[]
+}
+
+export interface WorkspaceSession {
+  name: string
+  window_count: number
+  main_checkout?: WorkspaceWindow[]
+  worktrees?: WorkspaceWindow[]
+  other?: WorkspaceWindow[]
+}
+
+export interface Workspace {
+  host: string
+  sessions: WorkspaceSession[]
+}
+
+export async function fetchWorkspace(): Promise<Workspace> {
+  const res = await fetch('/api/workspace')
+  if (!res.ok) {
+    throw new Error(`fetchWorkspace: ${res.status} ${await res.text()}`)
+  }
+  return (await res.json()) as Workspace
+}

--- a/ui/src/fleet/Shell.tsx
+++ b/ui/src/fleet/Shell.tsx
@@ -4,14 +4,14 @@ import { needsYou } from './staleness'
 import { useNow } from './useNow'
 import { FleetView } from './FleetView'
 import { CrewsView } from './CrewsView'
+import { WorkspaceView } from './WorkspaceView'
 import { RunDetail } from './RunDetail'
 import '../theme/mocha.css'
 import './fleet.css'
 
 type Tab = 'fleet' | 'crews' | 'workspace' | 'dispatch'
 
-const PLACEHOLDER: Record<Exclude<Tab, 'fleet' | 'crews'>, string> = {
-  workspace: 'Workspace arrives next — the tmux tree across every host, including panes that are not agents.',
+const PLACEHOLDER: Record<'dispatch', string> = {
   dispatch: 'Dispatch arrives with the dispatcher milestone — pick a repo, task, tier and engine, and start work from your phone.',
 }
 
@@ -60,7 +60,8 @@ export function Shell() {
             onOpen={(r) => { window.location.hash = `#/fleet/${r.id}/activity` }}
           />
         </div>
-        {tab !== 'fleet' && tab !== 'crews' && <div className="shell-placeholder">{PLACEHOLDER[tab]}</div>}
+        {tab === 'dispatch' && <div className="shell-placeholder">{PLACEHOLDER.dispatch}</div>}
+        {tab === 'workspace' && <WorkspaceView onOpen={(id) => { window.location.hash = `#/fleet/${id}/activity` }} />}
         {/* A stacked overlay, not a `hidden`-swapped replacement of `.fleet` —
             `hidden` maps to display:none, which would collapse `.fleet`'s own
             scroll container and lose its scrollTop on return. */}

--- a/ui/src/fleet/WorkspaceView.test.tsx
+++ b/ui/src/fleet/WorkspaceView.test.tsx
@@ -1,0 +1,139 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { WorkspaceView } from './WorkspaceView'
+import type { Workspace } from '../api/workspace'
+
+let mockReturn: { workspace: Workspace | null; error: string | null; loading: boolean } = {
+  workspace: null,
+  error: null,
+  loading: true,
+}
+vi.mock('./useWorkspace', () => ({
+  useWorkspace: () => mockReturn,
+}))
+
+function fixture(): Workspace {
+  return {
+    host: '',
+    sessions: [
+      {
+        name: 'sess-a',
+        window_count: 2,
+        main_checkout: [
+          {
+            index: 0,
+            name: 'main',
+            active: true,
+            branch: 'feat/38-workspace-tab',
+            crew_codename: 'firefly',
+            panes: [
+              { id: 'pane-1', index: 0, active: true, command: 'claude', agent: true, run_id: 'pane-1' },
+            ],
+          },
+        ],
+        worktrees: [
+          {
+            index: 1,
+            name: 'shell',
+            active: false,
+            panes: [
+              { id: 'pane-2', index: 0, active: false, command: 'zsh', agent: false },
+              { id: 'pane-3', index: 1, active: true, command: 'vim', agent: false },
+            ],
+          },
+        ],
+      },
+      {
+        name: 'sess-b',
+        window_count: 1,
+        other: [
+          {
+            index: 0,
+            name: 'scratch',
+            active: false,
+            panes: [
+              { id: 'pane-4', index: 0, active: false, command: 'htop', agent: false },
+            ],
+          },
+        ],
+      },
+    ],
+  }
+}
+
+afterEach(cleanup)
+
+describe('WorkspaceView states', () => {
+  it('shows a loading state while the first fetch is in flight', () => {
+    mockReturn = { workspace: null, error: null, loading: true }
+    const { container } = render(<WorkspaceView />)
+    expect(container.textContent).toMatch(/loading/i)
+  })
+
+  it('shows an error state when the first fetch fails and there is no prior workspace', () => {
+    mockReturn = { workspace: null, error: 'fetchWorkspace: 500', loading: false }
+    const { container } = render(<WorkspaceView />)
+    expect(container.textContent).toContain('fetchWorkspace: 500')
+  })
+
+  it('renders the stale tree instead of the error state when an error arrives alongside a prior workspace', () => {
+    mockReturn = { workspace: fixture(), error: 'fetchWorkspace: 500', loading: false }
+    const { container } = render(<WorkspaceView />)
+    expect(container.querySelectorAll('.fleet-group').length).toBe(2)
+    expect(container.textContent).not.toContain('fetchWorkspace: 500')
+  })
+
+  it('shows an empty state when there are no sessions', () => {
+    mockReturn = { workspace: { host: '', sessions: [] }, error: null, loading: false }
+    const { container } = render(<WorkspaceView />)
+    expect(container.textContent).toMatch(/no tmux sessions/i)
+  })
+})
+
+describe('WorkspaceView buckets', () => {
+  it('renders Main checkout and Worktrees buckets for sess-a, with no Other bucket', () => {
+    mockReturn = { workspace: fixture(), error: null, loading: false }
+    const { container } = render(<WorkspaceView />)
+
+    const headers = Array.from(container.querySelectorAll('.fleet-group')).map((h) => h.textContent)
+    expect(headers).toEqual(['sess-a2', 'sess-b1'])
+
+    const sections = container.querySelectorAll('section')
+    const sessA = sections[0]
+    const buckets = Array.from(sessA.querySelectorAll('.ws-bucket')).map((b) => b.textContent)
+    expect(buckets).toEqual(['Main checkout', 'Worktrees (1)'])
+
+    expect(container.querySelectorAll('.run-chip.codename').length).toBe(1)
+    expect(container.querySelector('.run-chip.codename')?.textContent).toBe('firefly')
+  })
+
+  it('renders an Other bucket for a session whose only window has no repo identity', () => {
+    mockReturn = { workspace: fixture(), error: null, loading: false }
+    const { container } = render(<WorkspaceView />)
+
+    const sections = container.querySelectorAll('section')
+    const sessB = sections[1]
+    const buckets = Array.from(sessB.querySelectorAll('.ws-bucket')).map((b) => b.textContent)
+    expect(buckets).toEqual(['Other'])
+  })
+
+  it('calls onOpen with exactly the agent pane\'s run id when clicked, and never for a non-agent pane', () => {
+    mockReturn = { workspace: fixture(), error: null, loading: false }
+    const onOpen = vi.fn()
+    const { container } = render(<WorkspaceView onOpen={onOpen} />)
+
+    const panes = container.querySelectorAll('.ws-pane')
+    expect(panes.length).toBe(4)
+
+    const agentPane = container.querySelector('.ws-pane.agent')!
+    fireEvent.click(agentPane)
+    expect(onOpen).toHaveBeenCalledTimes(1)
+    expect(onOpen).toHaveBeenCalledWith('pane-1')
+
+    const plainPanes = Array.from(panes).filter((p) => !p.classList.contains('agent'))
+    expect(plainPanes.length).toBe(3)
+    for (const p of plainPanes) fireEvent.click(p)
+
+    expect(onOpen).toHaveBeenCalledTimes(1)
+  })
+})

--- a/ui/src/fleet/WorkspaceView.tsx
+++ b/ui/src/fleet/WorkspaceView.tsx
@@ -24,7 +24,7 @@ function renderWindows(windows: WorkspaceWindow[], onOpen?: (runId: string) => v
             key={pane.id}
             type="button"
             className="ws-pane agent"
-            onClick={() => onOpen?.(pane.run_id!)}
+            onClick={() => onOpen?.(pane.run_id)}
           >
             {pane.active && <span className="ws-pane-dot" />}
             <span>{pane.command}</span>

--- a/ui/src/fleet/WorkspaceView.tsx
+++ b/ui/src/fleet/WorkspaceView.tsx
@@ -1,0 +1,85 @@
+// Correlation already happened server-side (C2/C3) — the tree the API
+// returns already carries run ids on the panes that have them, so unlike
+// FleetView/CrewsView this view never consumes useRuns(); see
+// docs/superpowers/plans/2026-09-10-workspace-tab.md, C5.
+import { useWorkspace } from './useWorkspace'
+import type { WorkspaceWindow } from '../api/workspace'
+import './fleet.css'
+
+interface WorkspaceViewProps {
+  onOpen?: (runId: string) => void
+}
+
+function renderWindows(windows: WorkspaceWindow[], onOpen?: (runId: string) => void) {
+  return windows.map((win) => (
+    <div key={win.index}>
+      <div className="ws-window">
+        <span>{win.index}: {win.name}</span>
+        {win.branch && <span className="run-chip">{win.branch}</span>}
+        {win.crew_codename && <span className="run-chip codename">{win.crew_codename}</span>}
+      </div>
+      {win.panes.map((pane) =>
+        pane.agent ? (
+          <button
+            key={pane.id}
+            type="button"
+            className="ws-pane agent"
+            onClick={() => onOpen?.(pane.run_id!)}
+          >
+            {pane.active && <span className="ws-pane-dot" />}
+            <span>{pane.command}</span>
+          </button>
+        ) : (
+          <div key={pane.id} className="ws-pane">
+            {pane.active && <span className="ws-pane-dot" />}
+            <span>{pane.command}</span>
+          </div>
+        ),
+      )}
+    </div>
+  ))
+}
+
+function renderBucket(label: string, windows: WorkspaceWindow[] | undefined, onOpen?: (runId: string) => void) {
+  if (!windows || windows.length === 0) return null
+  return (
+    <div key={label}>
+      <div className="ws-bucket">{label}</div>
+      {renderWindows(windows, onOpen)}
+    </div>
+  )
+}
+
+export function WorkspaceView({ onOpen }: WorkspaceViewProps) {
+  const { workspace, error, loading } = useWorkspace()
+
+  return (
+    <div className="workspace mocha">
+      <header className="fleet-nav">
+        <h1>Workspace</h1>
+      </header>
+
+      {loading && <div className="fleet-empty">Loading workspace…</div>}
+
+      {!loading && error && !workspace && (
+        <div className="fleet-empty">{error}</div>
+      )}
+
+      {!loading && workspace && workspace.sessions.length === 0 && (
+        <div className="fleet-empty">No tmux sessions found.</div>
+      )}
+
+      {workspace?.sessions.map((session) => (
+        <section key={session.name}>
+          <div className="fleet-group">
+            <span>{session.name}</span>
+            <span>{session.window_count}</span>
+          </div>
+          {renderBucket('Main checkout', session.main_checkout, onOpen)}
+          {renderBucket(`Worktrees (${session.worktrees?.length ?? 0})`, session.worktrees, onOpen)}
+          {renderBucket('Other', session.other, onOpen)}
+        </section>
+      ))}
+    </div>
+  )
+}

--- a/ui/src/fleet/WorkspaceView.tsx
+++ b/ui/src/fleet/WorkspaceView.tsx
@@ -1,7 +1,5 @@
-// Correlation already happened server-side (C2/C3) — the tree the API
-// returns already carries run ids on the panes that have them, so unlike
-// FleetView/CrewsView this view never consumes useRuns(); see
-// docs/superpowers/plans/2026-09-10-workspace-tab.md, C5.
+// The tree already carries run ids on the panes that have them, so unlike
+// FleetView/CrewsView this view never consumes useRuns().
 import { useWorkspace } from './useWorkspace'
 import type { WorkspaceWindow } from '../api/workspace'
 import './fleet.css'

--- a/ui/src/fleet/fleet.css
+++ b/ui/src/fleet/fleet.css
@@ -277,3 +277,43 @@
   outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
+
+.workspace {
+  position: absolute;
+  inset: 0;
+  overflow-y: auto;
+  background: var(--bg);
+  color: var(--text-dim);
+  font-family: var(--font-ui);
+  font-size: 14px;
+  -webkit-tap-highlight-color: transparent;
+  padding-left: env(safe-area-inset-left);
+  padding-right: env(safe-area-inset-right);
+}
+
+.ws-bucket {
+  padding: 8px 14px 4px; font-size: 11px; font-weight: 600;
+  color: var(--text-faint); text-transform: uppercase; letter-spacing: 0.03em;
+}
+
+.ws-window {
+  display: flex; align-items: center; gap: 6px;
+  margin: 4px 10px 2px; padding: 6px 10px; border-radius: 8px;
+  background: var(--bg-raised); font-size: 12.5px; font-weight: 600; color: var(--text);
+}
+
+.ws-pane {
+  display: flex; align-items: center; gap: 8px;
+  width: calc(100% - 20px); margin: 0 10px 2px 16px; padding: 6px 10px;
+  border-radius: 8px; border: 0; background: none; text-align: left;
+  font: inherit; font-size: 12.5px; color: var(--text-dim);
+  font-family: var(--font-mono);
+}
+.ws-pane.agent { cursor: pointer; }
+.ws-pane.agent:active { background: var(--fill); transform: scale(0.995); }
+.ws-pane-dot { width: 6px; height: 6px; border-radius: 50%; flex: none; background: var(--state-running); }
+
+.ws-pane.agent:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}

--- a/ui/src/fleet/useWorkspace.test.tsx
+++ b/ui/src/fleet/useWorkspace.test.tsx
@@ -94,4 +94,17 @@ describe('useWorkspace lifecycle', () => {
     expect(result.current.workspace).toEqual(workspace('first'))
     expect(result.current.error).toBe('network down')
   })
+
+  it('a rejected first fetch sets error, leaves workspace null, and stops loading', async () => {
+    fetchWorkspaceMock.mockRejectedValueOnce(new Error('network down'))
+    const { result } = renderHook(useWorkspaceProbe)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    expect(result.current.workspace).toBeNull()
+    expect(result.current.error).toBe('network down')
+    expect(result.current.loading).toBe(false)
+  })
 })

--- a/ui/src/fleet/useWorkspace.test.tsx
+++ b/ui/src/fleet/useWorkspace.test.tsx
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { useWorkspace } from './useWorkspace'
+import type { Workspace } from '../api/workspace'
+
+const fetchWorkspaceMock = vi.fn<() => Promise<Workspace>>()
+vi.mock('../api/workspace', () => ({
+  fetchWorkspace: () => fetchWorkspaceMock(),
+}))
+
+function workspace(host = 'local'): Workspace {
+  return { host, sessions: [] }
+}
+
+// Named (not anonymous) so eslint-plugin-react-hooks recognises this as a
+// custom hook rather than an arbitrary function calling a hook.
+function useWorkspaceProbe() {
+  return useWorkspace()
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+  fetchWorkspaceMock.mockReset()
+})
+
+describe('useWorkspace lifecycle', () => {
+  it('fetches once on mount and populates state', async () => {
+    fetchWorkspaceMock.mockResolvedValue(workspace())
+    const { result } = renderHook(useWorkspaceProbe)
+
+    // Flush the microtask queue from the synchronous mount-time fetch,
+    // without advancing the clock far enough to fire the poll interval.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    expect(fetchWorkspaceMock).toHaveBeenCalledTimes(1)
+    expect(result.current.workspace).toEqual(workspace())
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('polls again after the interval elapses', async () => {
+    fetchWorkspaceMock.mockResolvedValue(workspace())
+    renderHook(useWorkspaceProbe)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+    expect(fetchWorkspaceMock).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000)
+    })
+    expect(fetchWorkspaceMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('stops polling after unmount', async () => {
+    fetchWorkspaceMock.mockResolvedValue(workspace())
+    const { unmount } = renderHook(useWorkspaceProbe)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+    expect(fetchWorkspaceMock).toHaveBeenCalledTimes(1)
+
+    unmount()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(9000)
+    })
+    expect(fetchWorkspaceMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('a rejected poll sets error and keeps the prior workspace value', async () => {
+    fetchWorkspaceMock.mockResolvedValueOnce(workspace('first'))
+    const { result } = renderHook(useWorkspaceProbe)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+    expect(result.current.workspace).toEqual(workspace('first'))
+    expect(result.current.error).toBeNull()
+
+    fetchWorkspaceMock.mockRejectedValueOnce(new Error('network down'))
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000)
+    })
+
+    expect(result.current.workspace).toEqual(workspace('first'))
+    expect(result.current.error).toBe('network down')
+  })
+})

--- a/ui/src/fleet/useWorkspace.ts
+++ b/ui/src/fleet/useWorkspace.ts
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react'
+import { fetchWorkspace } from '../api/workspace'
+import type { Workspace } from '../api/workspace'
+
+const POLL_INTERVAL_MS = 3000
+
+/**
+ * Polls /api/workspace on a fixed interval. A failed poll sets `error` but
+ * keeps the last-known `workspace` rather than blanking the view.
+ */
+export function useWorkspace() {
+  const [workspace, setWorkspace] = useState<Workspace | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+
+    const poll = () => {
+      fetchWorkspace()
+        .then((w) => {
+          if (cancelled) return
+          setWorkspace(w)
+          setError(null)
+          setLoading(false)
+        })
+        .catch((e: unknown) => {
+          if (cancelled) return
+          setError(e instanceof Error ? e.message : String(e))
+          setLoading(false)
+        })
+    }
+
+    poll()
+    const id = setInterval(poll, POLL_INTERVAL_MS)
+
+    return () => {
+      cancelled = true
+      clearInterval(id)
+    }
+  }, [])
+
+  return { workspace, error, loading }
+}


### PR DESCRIPTION
## Summary

Fills the Workspace placeholder in the mobile shell (plan B of three from `docs/superpowers/2026-09-08-state-of-play.md`, issue #38).

A new `GET /api/workspace` endpoint returns every tmux session/window/pane on this host, including panes that carry no agent. Each session groups its windows into **Main checkout**, **Worktrees (N)**, and **Other** (no `@git_root`), derived from real repo identity via `git rev-parse --path-format=absolute --git-common-dir` — not the session name, which is not a reliable proxy for the repo (a session can span several different git roots). Agent panes correlate to their existing `/api/runs` entry by the shared tmux-pane-id join key, so tapping one routes to the existing run detail view instead of building a second terminal.

## Mid-execute design change

The plan originally scoped a flat session→window→pane mirror. Partway through execution the dispatcher relayed an explicit, decided (not suggested) human steer: group by repo identity instead, because a flat mirror leaves long sessions long (one session on this machine spans 5 different git roots) and a crew-based grouping would strand most panes (most runs on this machine carry a codename but an empty crew-bus id). The plan document (`docs/superpowers/plans/2026-09-10-workspace-tab.md`) was revised in place to capture the new design and rationale before re-executing the affected components; its "Revised again mid-execute" note has the full detail.

## Security

`GET /api/workspace` is registered on the same `apiMux` every other `/api/*` route uses, so it inherits the token/origin/Host gates unchanged (`TestWorkspaceRouteIsBehindTheAuthGate` proves 401 unauthenticated; verified live below too). The one new subprocess call (`git -C <root> rev-parse ...` in `server/workspace_repo.go`) takes `root` only from tmux's `@git_root` user-option — written by lazytmux, never by this HTTP surface — and uses `exec.CommandContext` with an argv slice, so there is no path from a request into that command regardless of the string's contents. An independent security review confirmed both claims by reading the code rather than accepting them, and found no CRITICAL/HIGH issues.

## Review gate

Standard-tier internal review (this repo has no automated PR-review bot, so the gate ran at full strength): Go, TypeScript, and security reviewers in parallel, fresh context, diff-only.

- **Security**: approve, no blocking findings.
- **Go**: blocked on one HIGH — `repoClassifier.classify` silently and *permanently* cached a transient git failure as "not main checkout," with no log trail. Fixed: it now logs a warning and only caches a successful classification, so a transient failure is retried on the next request instead of wedging a root into the wrong bucket forever. Also added the missing `slog.Error` calls before the handler's 502s, matching this repo's existing convention.
- **TypeScript**: warning — `WorkspacePane` typed `agent`/`run_id` as independent optionals, so a `pane.run_id!` non-null assertion had no type-level backing even though the server guarantees `agent ⇒ run_id`. Fixed: `WorkspacePane` is now a discriminated union on `agent`, and the assertion is gone. Also closed a test-coverage gap: `useWorkspace`'s own first-fetch-fails path was previously only exercised indirectly through a different file's mocked hook.

### Review notes (accepted, not fixed)

Two TypeScript findings were judged out of scope rather than fixed, both tied to federation, which the task explicitly says not to build:

- The poll hook has no protection against an out-of-order response overwriting fresher state with a stale one. Currently inert (single local endpoint, sub-second responses); would matter once a `/api/workspace` response can aggregate multiple hosts.
- `WorkspaceView` keys sessions by `session.name`, which assumes uniqueness — true today since every pane is local, but would need namespacing by host once federation lands.

## Verified

Full gate: `go build`/`vet`/`test` across the whole module, `gofmt -l` clean, `npx tsc -b`/`eslint`/`vitest run` clean (91 tests), `npm run build` + grepped the **built** bundle for real `.workspace`/`.ws-bucket`/`.ws-window`/`.ws-pane` CSS declarations and the `/api/workspace` string in the built JS — a passing build alone doesn't prove that here, per this repo's own retro about the Mocha token file that shipped unimported behind an all-green pipeline.

Live, against this machine's real tmux (not a browser — see below): built the binary, ran it on a scratch port and state dir, and hit `/api/workspace` with the issued token.

- The `dispatcher` session — the exact example the human's directive named — came back `window_count: 5, main: 1, worktrees: 4`.
- The `reftest` session's empty-`@git_root` window came back under `other`, reachable rather than dropped — the other case the directive explicitly named.
- All 19 agent panes in the live tree carried a `run_id` that resolves to a real `/api/runs` entry; the 3 plain panes carried neither `agent: true` nor a `run_id`.
- Unauthenticated request → 401; wrong `Host` header → 421.

**No browser was available to look at the rendered tree.** Both a Playwright and a Firefox-devtools MCP navigation attempt failed on a missing `$DISPLAY`/X server in this environment (confirmed by trying, not assumed) — consistent with the state-of-play doc's standing note that this box has no display. Types, lint, the full test suite, the production build, and the bundle-content grep above are all green, and the data-level behavior is verified live end-to-end through curl, but the actual rendering is unverified, exactly the caveat #8's own retro called out. If this is worth confirming before merge, it needs a run on a machine with a display.

## Plan

`docs/superpowers/plans/2026-09-10-workspace-tab.md` — accepted by `plan-critic` after one revision (fixed an unreachable `Color` field, an `Agent`/`RunID` derivation ambiguity, and an unused prop), then revised again in place mid-execute for the repo-roll-up steer above.

Closes #38

https://claude.ai/code/session_01MAc8UfuZUia3HXmBUsTgQs